### PR TITLE
chore: add support for noViewport

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -21,7 +21,7 @@ func (b *browserImpl) IsConnected() bool {
 }
 
 func (b *browserImpl) NewContext(options ...BrowserNewContextOptions) (BrowserContext, error) {
-	overrides := map[string]interface{}{"sdkLanguage": "javascript"}
+	overrides := map[string]interface{}{}
 	if len(options) == 1 {
 		if options[0].ExtraHttpHeaders != nil {
 			overrides["extraHTTPHeaders"] = serializeMapToNameAndValue(options[0].ExtraHttpHeaders)
@@ -39,6 +39,10 @@ func (b *browserImpl) NewContext(options ...BrowserNewContextOptions) (BrowserCo
 			}
 			options[0].StorageState = storageState
 			options[0].StorageStatePath = nil
+		}
+		if options[0].NoViewport != nil && *options[0].NoViewport {
+			overrides["noDefaultViewport"] = true
+			options[0].NoViewport = nil
 		}
 	}
 	channel, err := b.channel.Send("newContext", overrides, options)
@@ -71,9 +75,7 @@ func (b *browserImpl) NewPage(options ...BrowserNewContextOptions) (Page, error)
 }
 
 func (b *browserImpl) NewBrowserCDPSession() (CDPSession, error) {
-	channel, err := b.channel.Send("newBrowserCDPSession", map[string]interface{}{
-		"sdkLanguage": "javascript",
-	})
+	channel, err := b.channel.Send("newBrowserCDPSession")
 	if err != nil {
 		return nil, fmt.Errorf("could not send message: %w", err)
 	}

--- a/browser_context.go
+++ b/browser_context.go
@@ -53,8 +53,7 @@ func (b *browserContextImpl) Tracing() Tracing {
 
 func (b *browserContextImpl) NewCDPSession(page Page) (CDPSession, error) {
 	channel, err := b.channel.Send("newCDPSession", map[string]interface{}{
-		"sdkLanguage": "javascript",
-		"page":        page.(*pageImpl).channel,
+		"page": page.(*pageImpl).channel,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not send message: %w", err)

--- a/browser_type.go
+++ b/browser_type.go
@@ -32,7 +32,6 @@ func (b *browserTypeImpl) Launch(options ...BrowserTypeLaunchOptions) (Browser, 
 func (b *browserTypeImpl) LaunchPersistentContext(userDataDir string, options ...BrowserTypeLaunchPersistentContextOptions) (BrowserContext, error) {
 	overrides := map[string]interface{}{
 		"userDataDir": userDataDir,
-		"sdkLanguage": "javascript",
 	}
 	if len(options) == 1 {
 		if options[0].ExtraHttpHeaders != nil {
@@ -41,6 +40,10 @@ func (b *browserTypeImpl) LaunchPersistentContext(userDataDir string, options ..
 		if options[0].Env != nil {
 			overrides["env"] = serializeMapToNameAndValue(options[0].Env)
 			options[0].Env = nil
+		}
+		if options[0].NoViewport != nil && *options[0].NoViewport {
+			overrides["noDefaultViewport"] = true
+			options[0].NoViewport = nil
 		}
 	}
 	channel, err := b.channel.Send("launchPersistentContext", overrides, options)
@@ -88,7 +91,6 @@ func (b *browserTypeImpl) Connect(url string, options ...BrowserTypeConnectOptio
 func (b *browserTypeImpl) ConnectOverCDP(endpointURL string, options ...BrowserTypeConnectOverCDPOptions) (Browser, error) {
 	overrides := map[string]interface{}{
 		"endpointURL": endpointURL,
-		"sdkLanguage": "javascript",
 	}
 	response, err := b.channel.SendReturnAsDict("connectOverCDP", overrides, options)
 	if err != nil {

--- a/generated-structs.go
+++ b/generated-structs.go
@@ -44,6 +44,8 @@ type BrowserNewContextOptions struct {
 	// value, `Accept-Language` request header value as well as number and date formatting
 	// rules.
 	Locale *string `json:"locale"`
+	// Does not enforce fixed viewport, allows resizing window in the headed mode.
+	NoViewport *bool `json:"noViewport"`
 	// Whether to emulate network being offline. Defaults to `false`.
 	Offline *bool `json:"offline"`
 	// A list of permissions to grant to all pages in this context. See BrowserContext.GrantPermissions()
@@ -183,6 +185,8 @@ type BrowserNewPageOptions struct {
 	// value, `Accept-Language` request header value as well as number and date formatting
 	// rules.
 	Locale *string `json:"locale"`
+	// Does not enforce fixed viewport, allows resizing window in the headed mode.
+	NoViewport *bool `json:"noViewport"`
 	// Whether to emulate network being offline. Defaults to `false`.
 	Offline *bool `json:"offline"`
 	// A list of permissions to grant to all pages in this context. See BrowserContext.GrantPermissions()
@@ -467,6 +471,8 @@ type BrowserTypeLaunchPersistentContextOptions struct {
 	// value, `Accept-Language` request header value as well as number and date formatting
 	// rules.
 	Locale *string `json:"locale"`
+	// Does not enforce fixed viewport, allows resizing window in the headed mode.
+	NoViewport *bool `json:"noViewport"`
 	// Whether to emulate network being offline. Defaults to `false`.
 	Offline *bool `json:"offline"`
 	// A list of permissions to grant to all pages in this context. See BrowserContext.GrantPermissions()

--- a/patches/main.patch
+++ b/patches/main.patch
@@ -200,7 +200,7 @@ index 61dd9e3ad4e9b83a8132bc61c026d2c18b35d979..fc440fe38af9dfbd4f6d3c7ef6518906
  * langs: csharp, java
  - `body` <[string]>
 diff --git a/docs/src/api/params.md b/docs/src/api/params.md
-index f214cf943ae2c95c9377a093f0132e237b9bea2e..a9b810fba267f6c99d70e24f8b08ecac07ed6396 100644
+index f214cf943ae2c95c9377a093f0132e237b9bea2e..a2459b14d9d520616ef81d093b4591bfba61a77e 100644
 --- a/docs/src/api/params.md
 +++ b/docs/src/api/params.md
 @@ -146,8 +146,8 @@ Defaults to `'visible'`. Can be either:
@@ -250,6 +250,15 @@ index f214cf943ae2c95c9377a093f0132e237b9bea2e..a9b810fba267f6c99d70e24f8b08ecac
  - `viewport` <[null]|[Object]>
    - `width` <[int]> page width in pixels.
    - `height` <[int]> page height in pixels.
+@@ -415,7 +415,7 @@ Function to be evaluated in the worker context.
+ Sets a consistent viewport for each page. Defaults to an 1280x720 viewport. `no_viewport` disables the fixed viewport.
+ 
+ ## python-context-option-no-viewport
+-* langs: python
++* langs: python, go
+ - `noViewport` <[boolean]>
+ 
+ Does not enforce fixed viewport, allows resizing window in the headed mode.
 @@ -557,7 +557,7 @@ call [`method: BrowserContext.close`] for the HAR to be saved.
  Optional setting to control whether to omit request content from the HAR. Defaults to `false`.
  


### PR DESCRIPTION
This patch should allow something like that:

```go
	browser, err := pw.Chromium.Launch(playwright.BrowserTypeLaunchOptions{Headless: playwright.Bool(false), Args: []string{"--start-maximized"}})
	if err != nil {
		log.Fatalf("could not launch browser: %v", err)
	}
	page, err := browser.NewPage(playwright.BrowserNewContextOptions{NoViewport: playwright.Bool(true)})
	if err != nil {
		log.Fatalf("could not create page: %v", err)
	}
	if _, err = page.Goto("https://news.ycombinator.com"); err != nil {
		log.Fatalf("could not goto: %v", err)
	}
```

Fixes https://github.com/playwright-community/playwright-go/issues/245
