### PR TITLE
feat: add web first assertions (#271)

### DIFF
--- a/assertions.go
+++ b/assertions.go
@@ -1,0 +1,111 @@
+package playwright
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type playwrightAssertionsImpl struct {
+}
+
+func NewPlaywrightAssertions() PlaywrightAssertions {
+	return &playwrightAssertionsImpl{}
+}
+
+func (pa *playwrightAssertionsImpl) ExpectLocator(locator Locator) LocatorAssertions {
+	return newLocatorAssertions(locator, false)
+}
+
+func (pa *playwrightAssertionsImpl) ExpectPage(page Page) PageAssertions {
+	return newPageAssertions(page, false)
+}
+
+type expectedTextValue struct {
+	Str                 *string `json:"string"`
+	RegexSource         *string `json:"regexSource"`
+	RegexFlags          *string `json:"regexFlags"`
+	MatchSubstring      *bool   `json:"matchSubstring"`
+	NormalizeWhiteSpace *bool   `json:"normalizeWhiteSpace"`
+}
+
+type frameExpectOptions struct {
+	ExpressionArg  interface{}         `json:"expressionArg"`
+	ExpectedText   []expectedTextValue `json:"expectedText"`
+	ExpectedNumber *int                `json:"expectedNumber"`
+	ExpectedValue  interface{}         `json:"expectedValue"`
+	UseInnerText   *bool               `json:"useInnerText"`
+	IsNot          bool                `json:"isNot"`
+	Timeout        *float64            `json:"timeout"`
+}
+
+type frameExpectResult struct {
+	Matches  bool        `json:"matches"`
+	Received interface{} `json:"received"`
+	Log      []string    `json:"log"`
+}
+
+type assertionsBase struct {
+	actualLocator Locator
+	isNot         bool
+}
+
+func (b *assertionsBase) expectImpl(
+	expression string,
+	options frameExpectOptions,
+	expected interface{},
+	message string,
+) error {
+	options.IsNot = b.isNot
+	if options.Timeout == nil {
+		options.Timeout = Float(5000)
+	}
+	if options.IsNot {
+		message = strings.ReplaceAll(message, "expected to", "expected not to")
+	}
+	result, err := b.actualLocator.(*locatorImpl).expect(expression, options)
+	if err != nil {
+		return err
+	}
+
+	if result.Matches == b.isNot {
+		actual := result.Received
+		log := strings.Join(result.Log, "\n")
+		if log != "" {
+			log = "\nCall log:\n" + log
+		}
+		if expected != nil {
+			return fmt.Errorf("%s '%v'\nActual value: %v %s", message, expected, actual, log)
+		}
+		return fmt.Errorf("%s\nActual value: %v %s", message, actual, log)
+	}
+
+	return nil
+}
+
+func (b *assertionsBase) toExpectedTextValues(
+	items []interface{},
+	matchSubstring bool,
+	normalizeWhiteSpace bool,
+) []expectedTextValue {
+	var out []expectedTextValue
+	for _, item := range items {
+		switch item := item.(type) {
+		case string:
+			out = append(out, expectedTextValue{
+				Str:                 String(item),
+				MatchSubstring:      Bool(matchSubstring),
+				NormalizeWhiteSpace: Bool(normalizeWhiteSpace),
+			})
+		case *regexp.Regexp:
+			pattern, flags := splitRegexpString(item)
+			out = append(out, expectedTextValue{
+				RegexSource:         String(pattern),
+				RegexFlags:          String(flags),
+				MatchSubstring:      Bool(matchSubstring),
+				NormalizeWhiteSpace: Bool(normalizeWhiteSpace),
+			})
+		}
+	}
+	return out
+}

--- a/generated-interfaces.go
+++ b/generated-interfaces.go
@@ -1156,6 +1156,86 @@ type Locator interface {
 	WaitFor(options ...PageWaitForSelectorOptions) error
 }
 
+// The `LocatorAssertions` class provides assertion methods that can be used to make assertions about the `Locator` state
+// in the tests. A new instance of `LocatorAssertions` is created by calling
+// PlaywrightAssertions.expectLocator():
+type LocatorAssertions interface {
+	// Ensures the `Locator` points to a checked input.
+	ToBeChecked(options ...LocatorAssertionsToBeCheckedOptions) error
+	// Ensures the `Locator` points to a disabled element.
+	ToBeDisabled(options ...LocatorAssertionsToBeDisabledOptions) error
+	// Ensures the `Locator` points to an editable element.
+	ToBeEditable(options ...LocatorAssertionsToBeEditableOptions) error
+	// Ensures the `Locator` points to an empty editable element or to a DOM node that has no text.
+	ToBeEmpty(options ...LocatorAssertionsToBeEmptyOptions) error
+	// Ensures the `Locator` points to an enabled element.
+	ToBeEnabled(options ...LocatorAssertionsToBeEnabledOptions) error
+	// Ensures the `Locator` points to a focused DOM node.
+	ToBeFocused(options ...LocatorAssertionsToBeFocusedOptions) error
+	// Ensures the `Locator` points to a hidden DOM node, which is the opposite of [visible](./actionability.md#visible).
+	ToBeHidden(options ...LocatorAssertionsToBeHiddenOptions) error
+	// Ensures the `Locator` points to a [visible](./actionability.md#visible) DOM node.
+	ToBeVisible(options ...LocatorAssertionsToBeVisibleOptions) error
+	// Ensures the `Locator` points to an element that contains the given text. You can use regular expressions for the value
+	// as well.
+	// Note that if array is passed as an expected value, entire lists of elements can be asserted:
+	ToContainText(expected interface{}, options ...LocatorAssertionsToContainTextOptions) error
+	// Ensures the `Locator` points to an element with given attribute.
+	ToHaveAttribute(name string, value interface{}, options ...LocatorAssertionsToHaveAttributeOptions) error
+	// Ensures the `Locator` points to an element with given CSS class.
+	// Note that if array is passed as an expected value, entire lists of elements can be asserted:
+	ToHaveClass(expected interface{}, options ...LocatorAssertionsToHaveClassOptions) error
+	// Ensures the `Locator` resolves to an exact number of DOM nodes.
+	ToHaveCount(count int, options ...LocatorAssertionsToHaveCountOptions) error
+	// Ensures the `Locator` resolves to an element with the given computed CSS style.
+	ToHaveCSS(name string, value interface{}, options ...LocatorAssertionsToHaveCSSOptions) error
+	// Ensures the `Locator` points to an element with the given DOM Node ID.
+	ToHaveId(id interface{}, options ...LocatorAssertionsToHaveIdOptions) error
+	// Ensures the `Locator` points to an element with given JavaScript property. Note that this property can be of a primitive
+	// type as well as a plain serializable JavaScript object.
+	ToHaveJSProperty(name string, value interface{}, options ...LocatorAssertionsToHaveJSPropertyOptions) error
+	// Ensures the `Locator` points to an element with the given text. You can use regular expressions for the value as well.
+	// Note that if array is passed as an expected value, entire lists of elements can be asserted:
+	ToHaveText(expected interface{}, options ...LocatorAssertionsToHaveTextOptions) error
+	// Ensures the `Locator` points to an element with the given input value. You can use regular expressions for the value as
+	// well.
+	ToHaveValue(value interface{}, options ...LocatorAssertionsToHaveValueOptions) error
+	// The opposite of LocatorAssertions.toBeChecked().
+	NotToBeChecked(options ...LocatorAssertionsToBeCheckedOptions) error
+	// The opposite of LocatorAssertions.toBeDisabled().
+	NotToBeDisabled(options ...LocatorAssertionsToBeDisabledOptions) error
+	// The opposite of LocatorAssertions.toBeEditable().
+	NotToBeEditable(options ...LocatorAssertionsToBeEditableOptions) error
+	// The opposite of LocatorAssertions.toBeEmpty().
+	NotToBeEmpty(options ...LocatorAssertionsToBeEmptyOptions) error
+	// The opposite of LocatorAssertions.toBeEnabled().
+	NotToBeEnabled(options ...LocatorAssertionsToBeEnabledOptions) error
+	// The opposite of LocatorAssertions.toBeFocused().
+	NotToBeFocused(options ...LocatorAssertionsToBeFocusedOptions) error
+	// The opposite of LocatorAssertions.toBeHidden().
+	NotToBeHidden(options ...LocatorAssertionsToBeHiddenOptions) error
+	// The opposite of LocatorAssertions.toBeVisible().
+	NotToBeVisible(options ...LocatorAssertionsToBeVisibleOptions) error
+	// The opposite of LocatorAssertions.toContainText().
+	NotToContainText(expected interface{}, options ...LocatorAssertionsToContainTextOptions) error
+	// The opposite of LocatorAssertions.toHaveAttribute().
+	NotToHaveAttribute(name string, value interface{}, options ...LocatorAssertionsToHaveAttributeOptions) error
+	// The opposite of LocatorAssertions.toHaveClass().
+	NotToHaveClass(expected interface{}, options ...LocatorAssertionsToHaveClassOptions) error
+	// The opposite of LocatorAssertions.toHaveCount().
+	NotToHaveCount(count int, options ...LocatorAssertionsToHaveCountOptions) error
+	// The opposite of LocatorAssertions.toHaveCSS().
+	NotToHaveCSS(name string, value interface{}, options ...LocatorAssertionsToHaveCSSOptions) error
+	// The opposite of LocatorAssertions.toHaveId().
+	NotToHaveId(id interface{}, options ...LocatorAssertionsToHaveIdOptions) error
+	// The opposite of LocatorAssertions.toHaveJSProperty().
+	NotToHaveJSProperty(name string, value interface{}, options ...LocatorAssertionsToHaveJSPropertyOptions) error
+	// The opposite of LocatorAssertions.toHaveText().
+	NotToHaveText(expected interface{}, options ...LocatorAssertionsToHaveTextOptions) error
+	// The opposite of LocatorAssertions.toHaveValue().
+	NotToHaveValue(value interface{}, options ...LocatorAssertionsToHaveValueOptions) error
+}
+
 // The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.
 // Every `page` object has its own Mouse, accessible with [`property: Page.mouse`].
 type Mouse interface {
@@ -1650,6 +1730,33 @@ type Page interface {
 	// Waits for the main frame to navigate to the given URL.
 	// Shortcut for main frame's Frame.waitForURL().
 	WaitForURL(url string, options ...FrameWaitForURLOptions) error
+}
+
+// The `PageAssertions` class provides assertion methods that can be used to make assertions about the `Page` state in the
+// tests. A new instance of `PageAssertions` is created by calling PlaywrightAssertions.expectPage():
+type PageAssertions interface {
+	// Ensures the page has the given title.
+	ToHaveTitle(titleOrRegExp interface{}, options ...PageAssertionsToHaveTitleOptions) error
+	// Ensures the page is navigated to the given URL.
+	ToHaveURL(urlOrRegExp interface{}, options ...PageAssertionsToHaveURLOptions) error
+	// The opposite of PageAssertions.toHaveTitle().
+	NotToHaveTitle(titleOrRegExp interface{}, options ...PageAssertionsToHaveTitleOptions) error
+	// The opposite of PageAssertions.toHaveURL().
+	NotToHaveURL(urlOrRegExp interface{}, options ...PageAssertionsToHaveURLOptions) error
+}
+
+// Playwright gives you Web-First Assertions with convenience methods for creating assertions that will wait and retry
+// until the expected condition is met.
+// Consider the following example:
+// Playwright will be re-testing the node with the selector `.status` until fetched Node has the `"Submitted"` text. It
+// will be re-fetching the node and checking it over and over, until the condition is met or until the timeout is reached.
+// You can pass this timeout as an option.
+// By default, the timeout for assertions is set to 5 seconds.
+type PlaywrightAssertions interface {
+	// Creates a `LocatorAssertions` object for the given `Locator`.
+	ExpectLocator(locator Locator) LocatorAssertions
+	// Creates a `PageAssertions` object for the given `Page`.
+	ExpectPage(page Page) PageAssertions
 }
 
 // Whenever the page sends a request for a network resource the following sequence of events are emitted by `Page`:

--- a/generated-structs.go
+++ b/generated-structs.go
@@ -1972,16 +1972,78 @@ type LocatorWaitForOptions struct {
 }
 type LocatorAssertionsToBeCheckedOptions struct {
 	Checked *bool `json:"checked"`
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToBeDisabledOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToBeEditableOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToBeEmptyOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToBeEnabledOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToBeFocusedOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToBeHiddenOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToBeVisibleOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
 }
 type LocatorAssertionsToContainTextOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
 	// Whether to use `element.innerText` instead of `element.textContent` when retrieving
 	// DOM node text.
 	UseInnerText *bool `json:"useInnerText"`
 }
+type LocatorAssertionsToHaveAttributeOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToHaveClassOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToHaveCountOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToHaveCSSOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToHaveIdOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToHaveJSPropertyOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
 type LocatorAssertionsToHaveTextOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
 	// Whether to use `element.innerText` instead of `element.textContent` when retrieving
 	// DOM node text.
 	UseInnerText *bool `json:"useInnerText"`
+}
+type LocatorAssertionsToHaveValueOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
 }
 type MouseClickOptions struct {
 	// Defaults to `left`.
@@ -2788,6 +2850,14 @@ type PageWaitForURLOptions struct {
 	// `'commit'` - consider operation to be finished when network response is received
 	// and the document started loading.
 	WaitUntil *WaitUntilState `json:"waitUntil"`
+}
+type PageAssertionsToHaveTitleOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type PageAssertionsToHaveURLOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
 }
 
 // Result of calling <see cref="Request.HeadersArray" />.

--- a/helpers.go
+++ b/helpers.go
@@ -1,6 +1,7 @@
 package playwright
 
 import (
+	"fmt"
 	"reflect"
 	"regexp"
 	"strings"
@@ -413,4 +414,17 @@ func serializeMapToNameAndValue(headers map[string]string) []map[string]string {
 		})
 	}
 	return serialized
+}
+
+func splitRegexpString(reg *regexp.Regexp) (pattern, flags string) {
+	matches := regexp.MustCompile(`\(\?([imsU]+)\)(.+)`).FindStringSubmatch(reg.String())
+	if len(matches) == 3 {
+		return matches[2], matches[1]
+	}
+	return reg.String(), ""
+}
+
+func convertRegexp(reg *regexp.Regexp) string {
+	pattern, flags := splitRegexpString(reg)
+	return fmt.Sprintf("'%s', '%s'", pattern, flags)
 }

--- a/locator_assertions.go
+++ b/locator_assertions.go
@@ -1,0 +1,413 @@
+package playwright
+
+import (
+	"reflect"
+	"regexp"
+)
+
+type locatorAssertionsImpl struct {
+	assertionsBase
+}
+
+func newLocatorAssertions(locator Locator, isNot bool) LocatorAssertions {
+	return &locatorAssertionsImpl{
+		assertionsBase: assertionsBase{
+			actualLocator: locator,
+			isNot:         isNot,
+		},
+	}
+}
+
+func (la *locatorAssertionsImpl) ToBeChecked(options ...LocatorAssertionsToBeCheckedOptions) error {
+	var expression = "to.be.checked"
+	var timeout *float64
+	if len(options) == 1 {
+		if options[0].Checked != nil && !*options[0].Checked {
+			expression = "to.be.unchecked"
+		}
+		timeout = options[0].Timeout
+	}
+	return la.expectImpl(
+		expression,
+		frameExpectOptions{Timeout: timeout},
+		nil,
+		"Locator expected to be checked",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToBeDisabled(options ...LocatorAssertionsToBeDisabledOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	return la.expectImpl(
+		"to.be.disabled",
+		frameExpectOptions{Timeout: timeout},
+		nil,
+		"Locator expected to be disabled",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToBeEditable(options ...LocatorAssertionsToBeEditableOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	return la.expectImpl(
+		"to.be.editable",
+		frameExpectOptions{Timeout: timeout},
+		nil,
+		"Locator expected to be editable",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToBeEmpty(options ...LocatorAssertionsToBeEmptyOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	return la.expectImpl(
+		"to.be.empty",
+		frameExpectOptions{Timeout: timeout},
+		nil,
+		"Locator expected to be empty",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToBeEnabled(options ...LocatorAssertionsToBeEnabledOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	return la.expectImpl(
+		"to.be.enabled",
+		frameExpectOptions{Timeout: timeout},
+		nil,
+		"Locator expected to be enabled",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToBeFocused(options ...LocatorAssertionsToBeFocusedOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	return la.expectImpl(
+		"to.be.focused",
+		frameExpectOptions{Timeout: timeout},
+		nil,
+		"Locator expected to be focused",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToBeHidden(options ...LocatorAssertionsToBeHiddenOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	return la.expectImpl(
+		"to.be.hidden",
+		frameExpectOptions{Timeout: timeout},
+		nil,
+		"Locator expected to be hidden",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToBeVisible(options ...LocatorAssertionsToBeVisibleOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	return la.expectImpl(
+		"to.be.visible",
+		frameExpectOptions{Timeout: timeout},
+		nil,
+		"Locator expected to be visible",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToContainText(expected interface{}, options ...LocatorAssertionsToContainTextOptions) error {
+	var (
+		timeout      *float64
+		useInnerText *bool
+	)
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+		useInnerText = options[0].UseInnerText
+	}
+
+	switch expected.(type) {
+	case []string, []*regexp.Regexp:
+		expectedText := la.toExpectedTextValues(la.convertToInterfaceList(expected), true, true)
+		return la.expectImpl(
+			"to.contain.text.array",
+			frameExpectOptions{
+				ExpectedText: expectedText,
+				UseInnerText: useInnerText,
+				Timeout:      timeout,
+			},
+			expected,
+			"Locator expected to contain text",
+		)
+	default:
+		expectedText := la.toExpectedTextValues([]interface{}{expected}, true, true)
+		return la.expectImpl(
+			"to.have.text",
+			frameExpectOptions{
+				ExpectedText: expectedText,
+				UseInnerText: useInnerText,
+				Timeout:      timeout,
+			},
+			expected,
+			"Locator expected to contain text",
+		)
+	}
+}
+
+func (la *locatorAssertionsImpl) ToHaveAttribute(name string, value interface{}, options ...LocatorAssertionsToHaveAttributeOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	expectedText := la.toExpectedTextValues([]interface{}{value}, false, false)
+	return la.expectImpl(
+		"to.have.attribute",
+		frameExpectOptions{
+			ExpressionArg: name,
+			ExpectedText:  expectedText,
+			Timeout:       timeout,
+		},
+		value,
+		"Locator expected to have attribute",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToHaveClass(expected interface{}, options ...LocatorAssertionsToHaveClassOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	switch expected.(type) {
+	case []string, []*regexp.Regexp:
+		expectedText := la.toExpectedTextValues(la.convertToInterfaceList(expected), false, false)
+		return la.expectImpl(
+			"to.have.class.array",
+			frameExpectOptions{
+				ExpectedText: expectedText,
+				Timeout:      timeout,
+			},
+			expected,
+			"Locator expected to have class",
+		)
+	default:
+		expectedText := la.toExpectedTextValues([]interface{}{expected}, false, false)
+		return la.expectImpl(
+			"to.have.class",
+			frameExpectOptions{
+				ExpectedText: expectedText,
+				Timeout:      timeout,
+			},
+			expected,
+			"Locator expected to have class",
+		)
+	}
+}
+
+func (la *locatorAssertionsImpl) ToHaveCount(count int, options ...LocatorAssertionsToHaveCountOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	return la.expectImpl(
+		"to.have.count",
+		frameExpectOptions{ExpectedNumber: &count, Timeout: timeout},
+		count,
+		"Locator expected to have count",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToHaveCSS(name string, value interface{}, options ...LocatorAssertionsToHaveCSSOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	expectedText := la.toExpectedTextValues([]interface{}{value}, false, false)
+	return la.expectImpl(
+		"to.have.css",
+		frameExpectOptions{
+			ExpressionArg: name,
+			ExpectedText:  expectedText,
+			Timeout:       timeout,
+		},
+		value,
+		"Locator expected to have CSS",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToHaveId(id interface{}, options ...LocatorAssertionsToHaveIdOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	expectedText := la.toExpectedTextValues([]interface{}{id}, false, false)
+	return la.expectImpl(
+		"to.have.id",
+		frameExpectOptions{ExpectedText: expectedText, Timeout: timeout},
+		id,
+		"Locator expected to have ID",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToHaveJSProperty(name string, value interface{}, options ...LocatorAssertionsToHaveJSPropertyOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	return la.expectImpl(
+		"to.have.property",
+		frameExpectOptions{
+			ExpressionArg: name,
+			ExpectedValue: value,
+			Timeout:       timeout,
+		},
+		value,
+		"Locator expected to have JS Property",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToHaveText(expected interface{}, options ...LocatorAssertionsToHaveTextOptions) error {
+	var (
+		timeout      *float64
+		useInnerText *bool
+	)
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+		useInnerText = options[0].UseInnerText
+	}
+
+	switch expected.(type) {
+	case []string, []*regexp.Regexp:
+		expectedText := la.toExpectedTextValues(la.convertToInterfaceList(expected), false, true)
+		return la.expectImpl(
+			"to.have.text.array",
+			frameExpectOptions{
+				ExpectedText: expectedText,
+				UseInnerText: useInnerText,
+				Timeout:      timeout,
+			},
+			expected,
+			"Locator expected to have text",
+		)
+	default:
+		expectedText := la.toExpectedTextValues([]interface{}{expected}, false, true)
+		return la.expectImpl(
+			"to.have.text",
+			frameExpectOptions{
+				ExpectedText: expectedText,
+				UseInnerText: useInnerText,
+				Timeout:      timeout,
+			},
+			expected,
+			"Locator expected to have text",
+		)
+	}
+}
+
+func (la *locatorAssertionsImpl) ToHaveValue(value interface{}, options ...LocatorAssertionsToHaveValueOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	expectedText := la.toExpectedTextValues([]interface{}{value}, false, false)
+	return la.expectImpl(
+		"to.have.value",
+		frameExpectOptions{ExpectedText: expectedText, Timeout: timeout},
+		value,
+		"Locator expected to have Value",
+	)
+}
+
+func (la *locatorAssertionsImpl) NotToBeChecked(options ...LocatorAssertionsToBeCheckedOptions) error {
+	return la.not().ToBeChecked(options...)
+}
+
+func (la *locatorAssertionsImpl) NotToBeDisabled(options ...LocatorAssertionsToBeDisabledOptions) error {
+	return la.not().ToBeDisabled(options...)
+}
+
+func (la *locatorAssertionsImpl) NotToBeEditable(options ...LocatorAssertionsToBeEditableOptions) error {
+	return la.not().ToBeEditable(options...)
+}
+
+func (la *locatorAssertionsImpl) NotToBeEmpty(options ...LocatorAssertionsToBeEmptyOptions) error {
+	return la.not().ToBeEmpty(options...)
+}
+
+func (la *locatorAssertionsImpl) NotToBeEnabled(options ...LocatorAssertionsToBeEnabledOptions) error {
+	return la.not().ToBeEnabled(options...)
+}
+
+func (la *locatorAssertionsImpl) NotToBeFocused(options ...LocatorAssertionsToBeFocusedOptions) error {
+	return la.not().ToBeFocused(options...)
+}
+
+func (la *locatorAssertionsImpl) NotToBeHidden(options ...LocatorAssertionsToBeHiddenOptions) error {
+	return la.not().ToBeHidden(options...)
+}
+
+func (la *locatorAssertionsImpl) NotToBeVisible(options ...LocatorAssertionsToBeVisibleOptions) error {
+	return la.not().ToBeVisible(options...)
+}
+
+func (la *locatorAssertionsImpl) NotToContainText(expected interface{}, options ...LocatorAssertionsToContainTextOptions) error {
+	return la.not().ToContainText(expected, options...)
+}
+
+func (la *locatorAssertionsImpl) NotToHaveAttribute(name string, value interface{}, options ...LocatorAssertionsToHaveAttributeOptions) error {
+	return la.not().ToHaveAttribute(name, value, options...)
+}
+
+func (la *locatorAssertionsImpl) NotToHaveClass(expected interface{}, options ...LocatorAssertionsToHaveClassOptions) error {
+	return la.not().ToHaveClass(expected, options...)
+}
+
+func (la *locatorAssertionsImpl) NotToHaveCount(count int, options ...LocatorAssertionsToHaveCountOptions) error {
+	return la.not().ToHaveCount(count, options...)
+}
+
+func (la *locatorAssertionsImpl) NotToHaveCSS(name string, value interface{}, options ...LocatorAssertionsToHaveCSSOptions) error {
+	return la.not().ToHaveCSS(name, value, options...)
+}
+
+func (la *locatorAssertionsImpl) NotToHaveId(id interface{}, options ...LocatorAssertionsToHaveIdOptions) error {
+	return la.not().ToHaveId(id, options...)
+}
+
+func (la *locatorAssertionsImpl) NotToHaveJSProperty(name string, value interface{}, options ...LocatorAssertionsToHaveJSPropertyOptions) error {
+	return la.not().ToHaveJSProperty(name, value, options...)
+}
+
+func (la *locatorAssertionsImpl) NotToHaveText(expected interface{}, options ...LocatorAssertionsToHaveTextOptions) error {
+	return la.not().ToHaveText(expected, options...)
+}
+
+func (la *locatorAssertionsImpl) NotToHaveValue(value interface{}, options ...LocatorAssertionsToHaveValueOptions) error {
+	return la.not().ToHaveValue(value, options...)
+}
+
+func (la *locatorAssertionsImpl) not() LocatorAssertions {
+	return newLocatorAssertions(la.actualLocator, true)
+}
+
+func (la *locatorAssertionsImpl) convertToInterfaceList(v interface{}) []interface{} {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Slice {
+		return []interface{}{v}
+	}
+
+	list := make([]interface{}, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		list[i] = rv.Index(i).Interface()
+	}
+	return list
+}

--- a/page_assertions.go
+++ b/page_assertions.go
@@ -1,0 +1,70 @@
+package playwright
+
+import (
+	"net/url"
+	"path"
+)
+
+type pageAssertionsImpl struct {
+	assertionsBase
+	actualPage Page
+}
+
+func newPageAssertions(page Page, isNot bool) PageAssertions {
+	locator, _ := page.Locator(":root")
+	return &pageAssertionsImpl{
+		assertionsBase: assertionsBase{
+			actualLocator: locator,
+			isNot:         isNot,
+		},
+		actualPage: page,
+	}
+}
+
+func (pa *pageAssertionsImpl) ToHaveTitle(titleOrRegExp interface{}, options ...PageAssertionsToHaveTitleOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	expectedValues := pa.toExpectedTextValues([]interface{}{titleOrRegExp}, false, true)
+	return pa.expectImpl(
+		"to.have.title",
+		frameExpectOptions{ExpectedText: expectedValues, Timeout: timeout},
+		titleOrRegExp,
+		"Page title expected to be",
+	)
+}
+
+func (pa *pageAssertionsImpl) ToHaveURL(urlOrRegExp interface{}, options ...PageAssertionsToHaveURLOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+
+	baseURL := pa.actualPage.Context().(*browserContextImpl).options.BaseURL
+	if urlPath, ok := urlOrRegExp.(string); ok && baseURL != nil {
+		u, _ := url.Parse(*baseURL)
+		u.Path = path.Join(u.Path, urlPath)
+		urlOrRegExp = u.String()
+	}
+
+	expectedValues := pa.toExpectedTextValues([]interface{}{urlOrRegExp}, false, false)
+	return pa.expectImpl(
+		"to.have.url",
+		frameExpectOptions{ExpectedText: expectedValues, Timeout: timeout},
+		urlOrRegExp,
+		"Page URL expected to be",
+	)
+}
+
+func (pa *pageAssertionsImpl) NotToHaveTitle(titleOrRegExp interface{}, options ...PageAssertionsToHaveTitleOptions) error {
+	return pa.not().ToHaveTitle(titleOrRegExp, options...)
+}
+
+func (pa *pageAssertionsImpl) NotToHaveURL(urlOrRegExp interface{}, options ...PageAssertionsToHaveURLOptions) error {
+	return pa.not().ToHaveURL(urlOrRegExp, options...)
+}
+
+func (pa *pageAssertionsImpl) not() PageAssertions {
+	return newPageAssertions(pa.actualPage, true)
+}

--- a/patches/main.patch
+++ b/patches/main.patch
@@ -302,6 +302,15 @@ index f214cf943ae2c95c9377a093f0132e237b9bea2e..bb8269a16898d456ffd3601264469a5b
  - `recordVideo` <[Object]>
    - `dir` <[path]> Path to the directory to put videos into.
    - `size` <[Object]> Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport`
+@@ -710,7 +710,7 @@ using the [`method: AndroidDevice.setDefaultTimeout`] method.
+ Time to retry the assertion for. Defaults to `timeout` in `TestConfig.expect`.
+ 
+ ## csharp-java-python-assertions-timeout
+-* langs: java, python, csharp
++* langs: java, python, csharp, go
+ - `timeout` <[float]>
+ 
+ Time to retry the assertion for.
 @@ -831,7 +831,7 @@ Firefox user preferences. Learn more about the Firefox user preferences at
  [`about:config`](https://support.mozilla.org/en-US/kb/about-config-editor-firefox).
  

--- a/scripts/data/interfaces.json
+++ b/scripts/data/interfaces.json
@@ -931,6 +931,144 @@
 			"error"
 		]
 	},
+	"LocatorAssertions": {
+		"ToBeChecked": [
+			"options ...LocatorAssertionsToBeCheckedOptions",
+			"error"
+		],
+		"ToBeDisabled": [
+			"options ...LocatorAssertionsToBeDisabledOptions",
+			"error"
+		],
+		"ToBeEditable": [
+			"options ...LocatorAssertionsToBeEditableOptions",
+			"error"
+		],
+		"ToBeEmpty": [
+			"options ...LocatorAssertionsToBeEmptyOptions",
+			"error"
+		],
+		"ToBeEnabled": [
+			"options ...LocatorAssertionsToBeEnabledOptions",
+			"error"
+		],
+		"ToBeFocused": [
+			"options ...LocatorAssertionsToBeFocusedOptions",
+			"error"
+		],
+		"ToBeHidden": [
+			"options ...LocatorAssertionsToBeHiddenOptions",
+			"error"
+		],
+		"ToBeVisible": [
+			"options ...LocatorAssertionsToBeVisibleOptions",
+			"error"
+		],
+		"ToContainText": [
+			"expected interface{}, options ...LocatorAssertionsToContainTextOptions",
+			"error"
+		],
+		"ToHaveAttribute": [
+			"name string, value interface{}, options ...LocatorAssertionsToHaveAttributeOptions",
+			"error"
+		],
+		"ToHaveClass": [
+			"expected interface{}, options ...LocatorAssertionsToHaveClassOptions",
+			"error"
+		],
+		"ToHaveCount": [
+			"count int, options ...LocatorAssertionsToHaveCountOptions",
+			"error"
+		],
+		"ToHaveCSS": [
+			"name string, value interface{}, options ...LocatorAssertionsToHaveCSSOptions",
+			"error"
+		],
+		"ToHaveId": [
+			"id interface{}, options ...LocatorAssertionsToHaveIdOptions",
+			"error"
+		],
+		"ToHaveJSProperty": [
+			"name string, value interface{}, options ...LocatorAssertionsToHaveJSPropertyOptions",
+			"error"
+		],
+		"ToHaveText": [
+			"expected interface{}, options ...LocatorAssertionsToHaveTextOptions",
+			"error"
+		],
+		"ToHaveValue": [
+			"value interface{}, options ...LocatorAssertionsToHaveValueOptions",
+			"error"
+		],
+		"NotToBeChecked": [
+			"options ...LocatorAssertionsToBeCheckedOptions",
+			"error"
+		],
+		"NotToBeDisabled": [
+			"options ...LocatorAssertionsToBeDisabledOptions",
+			"error"
+		],
+		"NotToBeEditable": [
+			"options ...LocatorAssertionsToBeEditableOptions",
+			"error"
+		],
+		"NotToBeEmpty": [
+			"options ...LocatorAssertionsToBeEmptyOptions",
+			"error"
+		],
+		"NotToBeEnabled": [
+			"options ...LocatorAssertionsToBeEnabledOptions",
+			"error"
+		],
+		"NotToBeFocused": [
+			"options ...LocatorAssertionsToBeFocusedOptions",
+			"error"
+		],
+		"NotToBeHidden": [
+			"options ...LocatorAssertionsToBeHiddenOptions",
+			"error"
+		],
+		"NotToBeVisible": [
+			"options ...LocatorAssertionsToBeVisibleOptions",
+			"error"
+		],
+		"NotToContainText": [
+			"expected interface{}, options ...LocatorAssertionsToContainTextOptions",
+			"error"
+		],
+		"NotToHaveAttribute": [
+			"name string, value interface{}, options ...LocatorAssertionsToHaveAttributeOptions",
+			"error"
+		],
+		"NotToHaveClass": [
+			"expected interface{}, options ...LocatorAssertionsToHaveClassOptions",
+			"error"
+		],
+		"NotToHaveCount": [
+			"count int, options ...LocatorAssertionsToHaveCountOptions",
+			"error"
+		],
+		"NotToHaveCSS": [
+			"name string, value interface{}, options ...LocatorAssertionsToHaveCSSOptions",
+			"error"
+		],
+		"NotToHaveId": [
+			"id interface{}, options ...LocatorAssertionsToHaveIdOptions",
+			"error"
+		],
+		"NotToHaveJSProperty": [
+			"name string, value interface{}, options ...LocatorAssertionsToHaveJSPropertyOptions",
+			"error"
+		],
+		"NotToHaveText": [
+			"expected interface{}, options ...LocatorAssertionsToHaveTextOptions",
+			"error"
+		],
+		"NotToHaveValue": [
+			"value interface{}, options ...LocatorAssertionsToHaveValueOptions",
+			"error"
+		]
+	},
 	"Mouse": {
 		"Click": [
 			"x, y float64, options ...MouseClickOptions",
@@ -1316,6 +1454,34 @@
 		"WaitForURL": [
 			"url string, options ...FrameWaitForURLOptions",
 			"error"
+		]
+	},
+	"PageAssertions": {
+		"ToHaveTitle": [
+			"titleOrRegExp interface{}, options ...PageAssertionsToHaveTitleOptions",
+			"error"
+		],
+		"ToHaveURL": [
+			"urlOrRegExp interface{}, options ...PageAssertionsToHaveURLOptions",
+			"error"
+		],
+		"NotToHaveTitle": [
+			"titleOrRegExp interface{}, options ...PageAssertionsToHaveTitleOptions",
+			"error"
+		],
+		"NotToHaveURL": [
+			"urlOrRegExp interface{}, options ...PageAssertionsToHaveURLOptions",
+			"error"
+		]
+	},
+	"PlaywrightAssertions": {
+		"ExpectLocator": [
+			"locator Locator",
+			"LocatorAssertions"
+		],
+		"ExpectPage": [
+			"page Page",
+			"PageAssertions"
 		]
 	},
 	"Request": {

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -23,6 +23,7 @@ var pw *playwright.Playwright
 var browser playwright.Browser
 var context playwright.BrowserContext
 var page playwright.Page
+var assertions playwright.PlaywrightAssertions
 var isChromium bool
 var isFirefox bool
 var isWebKit bool
@@ -63,6 +64,7 @@ func BeforeAll() {
 	if err != nil {
 		log.Fatalf("could not launch: %v", err)
 	}
+	assertions = playwright.NewPlaywrightAssertions()
 	isChromium = browserName == "chromium" || browserName == ""
 	isFirefox = browserName == "firefox"
 	isWebKit = browserName == "webkit"

--- a/tests/locator_assertions_test.go
+++ b/tests/locator_assertions_test.go
@@ -1,0 +1,410 @@
+package playwright_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocatorAssertionsToBeChecked(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<input id='checkbox1' type='checkbox' checked>
+	<input id='checkbox2' type='checkbox'>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("#checkbox1")
+	require.NoError(t, err)
+	require.NoError(t, assertions.ExpectLocator(locator).ToBeChecked())
+	require.Error(t, assertions.ExpectLocator(locator).NotToBeChecked())
+
+	locator, err = page.Locator("#checkbox2")
+	require.NoError(t, err)
+	require.Error(t, assertions.ExpectLocator(locator).ToBeChecked())
+	require.NoError(t, assertions.ExpectLocator(locator).NotToBeChecked())
+}
+
+func TestLocatorAssertionsToBeDisabled(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<button disabled>button1</button>
+	<button>button2</button>
+	<div>div</div>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator(":text(\"button1\")")
+	require.NoError(t, err)
+	require.NoError(t, assertions.ExpectLocator(locator).ToBeDisabled())
+	require.Error(t, assertions.ExpectLocator(locator).NotToBeDisabled())
+
+	locator, err = page.Locator(":text(\"button2\")")
+	require.NoError(t, err)
+	require.Error(t, assertions.ExpectLocator(locator).ToBeDisabled())
+	require.NoError(t, assertions.ExpectLocator(locator).NotToBeDisabled())
+
+	locator, err = page.Locator("div")
+	require.NoError(t, err)
+	require.Error(t, assertions.ExpectLocator(locator).ToBeDisabled())
+	require.NoError(t, assertions.ExpectLocator(locator).NotToBeDisabled())
+}
+
+func TestLocatorAssertionsToBeEditable(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<input id=input1>
+	<input id=input2 disabled>
+	<textarea></textarea>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("#input1")
+	require.NoError(t, err)
+	require.NoError(t, assertions.ExpectLocator(locator).ToBeEditable())
+	require.Error(t, assertions.ExpectLocator(locator).NotToBeEditable())
+
+	locator, err = page.Locator("#input2")
+	require.NoError(t, err)
+	require.Error(t, assertions.ExpectLocator(locator).ToBeEditable())
+	require.NoError(t, assertions.ExpectLocator(locator).NotToBeEditable())
+
+	locator, err = page.Locator("textarea")
+	require.NoError(t, err)
+	require.NoError(t, assertions.ExpectLocator(locator).ToBeEditable())
+	require.Error(t, assertions.ExpectLocator(locator).NotToBeEditable())
+}
+
+func TestLocatorAssertionsToBeEmpty(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<textarea id="textarea1"></textarea>
+	<textarea id="textarea2">test</textarea>
+	<div id="div1"></div>
+	<div id="div2">test</div>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("#textarea1")
+	require.NoError(t, err)
+	require.NoError(t, assertions.ExpectLocator(locator).ToBeEmpty())
+	require.Error(t, assertions.ExpectLocator(locator).NotToBeEmpty())
+
+	locator, err = page.Locator("#textarea2")
+	require.NoError(t, err)
+	require.Error(t, assertions.ExpectLocator(locator).ToBeEmpty())
+	require.NoError(t, assertions.ExpectLocator(locator).NotToBeEmpty())
+
+	locator, err = page.Locator("#div1")
+	require.NoError(t, err)
+	require.NoError(t, assertions.ExpectLocator(locator).ToBeEmpty())
+	require.Error(t, assertions.ExpectLocator(locator).NotToBeEmpty())
+
+	locator, err = page.Locator("#div2")
+	require.NoError(t, err)
+	require.Error(t, assertions.ExpectLocator(locator).ToBeEmpty())
+	require.NoError(t, assertions.ExpectLocator(locator).NotToBeEmpty())
+}
+
+func TestLocatorAssertionsToBeEnabled(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<button>button1</button>
+	<button disabled>button2</button>
+	<div>div</div>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator(`:text("button1")`)
+	require.NoError(t, err)
+	require.NoError(t, assertions.ExpectLocator(locator).ToBeEnabled())
+	require.Error(t, assertions.ExpectLocator(locator).NotToBeEnabled())
+
+	locator, err = page.Locator(`:text("button2")`)
+	require.NoError(t, err)
+	require.Error(t, assertions.ExpectLocator(locator).ToBeEnabled())
+	require.NoError(t, assertions.ExpectLocator(locator).NotToBeEnabled())
+
+	locator, err = page.Locator("div")
+	require.NoError(t, err)
+	require.NoError(t, assertions.ExpectLocator(locator).ToBeEnabled())
+	require.Error(t, assertions.ExpectLocator(locator).NotToBeEnabled())
+}
+
+func TestLocatorAssertionsToBeFocused(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<input id=input1>
+	<input id=input2>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("#input1")
+	require.NoError(t, err)
+	require.NoError(t, locator.Focus())
+	require.NoError(t, assertions.ExpectLocator(locator).ToBeFocused())
+	require.Error(t, assertions.ExpectLocator(locator).NotToBeFocused())
+
+	locator, err = page.Locator("#input2")
+	require.NoError(t, err)
+	require.Error(t, assertions.ExpectLocator(locator).ToBeFocused())
+	require.NoError(t, assertions.ExpectLocator(locator).NotToBeFocused())
+}
+
+func TestLocatorAssertionsToBeHidden(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<details>
+		<summary>click to open</summary>
+		<ul>
+			<li>hidden item 1</li>
+			<li>hidden item 2</li>
+			<li>hidden item 3</li>
+		</ul>
+	</details>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("summary")
+	require.NoError(t, err)
+	require.Error(t, assertions.ExpectLocator(locator).ToBeHidden())
+	require.NoError(t, assertions.ExpectLocator(locator).NotToBeHidden())
+
+	locator, err = page.Locator("ul")
+	require.NoError(t, err)
+	require.NoError(t, assertions.ExpectLocator(locator).ToBeHidden())
+	require.Error(t, assertions.ExpectLocator(locator).NotToBeHidden())
+}
+
+func TestLocatorAssertionsToBeVisible(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<details>
+		<summary>click to open</summary>
+		<ul>
+			<li>hidden item 1</li>
+			<li>hidden item 2</li>
+			<li>hidden item 3</li>
+		</ul>
+	</details>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("summary")
+	require.NoError(t, err)
+	require.NoError(t, assertions.ExpectLocator(locator).ToBeVisible())
+	require.Error(t, assertions.ExpectLocator(locator).NotToBeVisible())
+
+	locator, err = page.Locator("ul")
+	require.NoError(t, err)
+	require.Error(t, assertions.ExpectLocator(locator).ToBeVisible())
+	require.NoError(t, assertions.ExpectLocator(locator).NotToBeVisible())
+}
+
+func TestLocatorAssertionsToContainText(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`<div>test1</div>`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("div")
+	require.NoError(t, err)
+
+	require.NoError(t, assertions.ExpectLocator(locator).ToContainText("test"))
+	require.NoError(t, assertions.ExpectLocator(locator).ToContainText([]string{"test"}))
+	require.NoError(t, assertions.ExpectLocator(locator).ToContainText(regexp.MustCompile(`test\d+`)))
+	require.NoError(t, assertions.ExpectLocator(locator).ToContainText([]*regexp.Regexp{regexp.MustCompile("test")}))
+	require.Error(t, assertions.ExpectLocator(locator).ToContainText("invalid"))
+	require.Error(t, assertions.ExpectLocator(locator).NotToContainText("test"))
+}
+
+func TestLocatorAssertionsToHaveAttribute(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<input id="input1" type="text">
+	<input id="input2" type="number">
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("#input1")
+	require.NoError(t, err)
+	require.NoError(t, assertions.ExpectLocator(locator).ToHaveAttribute("type", "text"))
+	require.NoError(t, assertions.ExpectLocator(locator).ToHaveAttribute("type", regexp.MustCompile("text")))
+	require.Error(t, assertions.ExpectLocator(locator).NotToHaveAttribute("type", "text"))
+	require.Error(t, assertions.ExpectLocator(locator).NotToHaveAttribute("type", regexp.MustCompile("text")))
+
+	locator, err = page.Locator("#input2")
+	require.NoError(t, err)
+	require.Error(t, assertions.ExpectLocator(locator).ToHaveAttribute("type", "text"))
+	require.Error(t, assertions.ExpectLocator(locator).ToHaveAttribute("type", regexp.MustCompile("text")))
+	require.NoError(t, assertions.ExpectLocator(locator).NotToHaveAttribute("type", "text"))
+	require.NoError(t, assertions.ExpectLocator(locator).NotToHaveAttribute("type", regexp.MustCompile("text")))
+}
+
+func TestLocatorAssertionsToHaveClass(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<div class="test1">test1</div>
+	<div class="test2">test2</div>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator(".test1")
+	require.NoError(t, err)
+	require.NoError(t, assertions.ExpectLocator(locator).ToHaveClass("test1"))
+	require.NoError(t, assertions.ExpectLocator(locator).ToHaveClass([]string{"test1"}))
+	require.NoError(t, assertions.ExpectLocator(locator).ToHaveClass(regexp.MustCompile("test.{1}")))
+	require.NoError(t, assertions.ExpectLocator(locator).ToHaveClass([]*regexp.Regexp{regexp.MustCompile(`test\d+`)}))
+	require.Error(t, assertions.ExpectLocator(locator).NotToHaveClass("test1"))
+
+	locator, err = page.Locator(".test2")
+	require.NoError(t, err)
+	require.Error(t, assertions.ExpectLocator(locator).ToHaveClass("test1"))
+	require.Error(t, assertions.ExpectLocator(locator).ToHaveClass([]string{"test1"}))
+	require.Error(t, assertions.ExpectLocator(locator).ToHaveClass(regexp.MustCompile(`test\d{2}`)))
+	require.Error(t, assertions.ExpectLocator(locator).ToHaveClass([]*regexp.Regexp{regexp.MustCompile(`test123`)}))
+	require.NoError(t, assertions.ExpectLocator(locator).NotToHaveClass("test1"))
+}
+
+func TestLocatorAssertionsToHaveCount(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<button>button1</button>
+	<button disabled>button2</button>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("button")
+	require.NoError(t, err)
+	require.NoError(t, assertions.ExpectLocator(locator).ToHaveCount(2))
+	require.Error(t, assertions.ExpectLocator(locator).NotToHaveCount(2))
+}
+
+func TestLocatorAssertionsToHaveCSS(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<button id="button1" style="display: flex">button1</button>
+	<button id="button2">button2</button>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("#button1")
+	require.NoError(t, err)
+	require.NoError(t, assertions.ExpectLocator(locator).ToHaveCSS("display", "flex"))
+	require.Error(t, assertions.ExpectLocator(locator).NotToHaveCSS("display", "flex"))
+
+	locator, err = page.Locator("#button2")
+	require.NoError(t, err)
+	require.Error(t, assertions.ExpectLocator(locator).ToHaveCSS("display", "flex"))
+	require.NoError(t, assertions.ExpectLocator(locator).NotToHaveCSS("display", "flex"))
+}
+
+func TestLocatorAssertionsToHaveId(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<button id="button1">button1</button>
+	<div>div</div>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("button")
+	require.NoError(t, err)
+	require.NoError(t, assertions.ExpectLocator(locator).ToHaveId("button1"))
+	require.Error(t, assertions.ExpectLocator(locator).NotToHaveId("button1"))
+
+	locator, err = page.Locator("div")
+	require.NoError(t, err)
+	require.Error(t, assertions.ExpectLocator(locator).ToHaveId("button1"))
+	require.NoError(t, assertions.ExpectLocator(locator).NotToHaveId("button1"))
+}
+
+func TestLocatorAssertionsToHaveJSProperty(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	require.NoError(t, page.SetContent("<div></div>"))
+	_, err = page.EvalOnSelector("div", "e => e.foo = true")
+	require.NoError(t, err)
+
+	locator, err := page.Locator("div")
+	require.NoError(t, err)
+	require.NoError(t, assertions.ExpectLocator(locator).ToHaveJSProperty("foo", true))
+	require.Error(t, assertions.ExpectLocator(locator).NotToHaveJSProperty("foo", true))
+}
+
+func TestLocatorAssertionsToHaveText(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`<div>test</div>`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("div")
+	require.NoError(t, err)
+	require.NoError(t, assertions.ExpectLocator(locator).ToHaveText("test"))
+	require.NoError(t, assertions.ExpectLocator(locator).ToHaveText([]string{"test"}))
+	require.NoError(t, assertions.ExpectLocator(locator).ToHaveText(regexp.MustCompile("test.*")))
+	require.NoError(t, assertions.ExpectLocator(locator).ToHaveText([]*regexp.Regexp{regexp.MustCompile("test.*")}))
+	require.Error(t, assertions.ExpectLocator(locator).ToHaveText("invalid"))
+	require.Error(t, assertions.ExpectLocator(locator).NotToHaveText("test"))
+}
+
+func TestLocatorAssertionsToHaveValue(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`<input type="text" value="test">`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("input")
+	require.NoError(t, err)
+	require.NoError(t, assertions.ExpectLocator(locator).ToHaveValue("test"))
+	require.NoError(t, assertions.ExpectLocator(locator).ToHaveValue(regexp.MustCompile("te.*")))
+	require.Error(t, assertions.ExpectLocator(locator).ToHaveValue("invalid"))
+	require.Error(t, assertions.ExpectLocator(locator).NotToHaveValue("test"))
+}

--- a/tests/page_assertions_test.go
+++ b/tests/page_assertions_test.go
@@ -1,0 +1,31 @@
+package playwright_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPageAssertionsToHaveTitle(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	require.NoError(t, page.SetContent(`<head><title>TEST</title></head>`))
+
+	require.NoError(t, assertions.ExpectPage(page).ToHaveTitle("TEST"))
+	require.NoError(t, assertions.ExpectPage(page).ToHaveTitle(regexp.MustCompile("(?i)test")))
+	require.NoError(t, assertions.ExpectPage(page).NotToHaveTitle("NOT TEST"))
+}
+
+func TestPageAssertionsToHaveURL(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+
+	require.NoError(t, assertions.ExpectPage(page).ToHaveURL(server.EMPTY_PAGE))
+	require.NoError(t, assertions.ExpectPage(page).ToHaveURL(regexp.MustCompile(`.*\.html`)))
+	require.NoError(t, assertions.ExpectPage(page).NotToHaveURL("https://playwright.dev"))
+}


### PR DESCRIPTION
This is an implementation for web first assertions (#271).

An example of usage is bellow, 

```go
assertions := playwright.NewPlaywrightAssertions()

err := assertions.ExpectLocator(locator).ToHaveText("example")
if err != nil {
    // handle error
}
```

The current implementation still works, but I think there are some areas for improvements.
Belows are some of my considerations.

- PlaywrightAssertions interface is possibly unneeded.
It may be simpler to call Expect function directory instead of through PlaywrightAssertions interface.
```go
// example

err := playwright.ExpectLocator(locator).ToHaveText("example")
```

- I'm not sure it's more useful to be integrated with *testing.T.
Current implementation returns error to handle it by ourselves.
```go
// example

assertions := playwright.NewPlaywrightAssertions(t) // `t` is `*testing.T`
// no return value, error is reported in `ToHaveText` method
assertions.ExpectLocator(locator).ToHaveText("example")
```

There may be other improvements other than the above, so please let me know if anyone has some good ideas!