### PR TITLE
fix: WaitForURL use default configurations if not provided

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -138,14 +138,13 @@ func (f *frameImpl) WaitForLoadState(given ...string) {
 }
 
 func (f *frameImpl) WaitForURL(url string, options ...FrameWaitForURLOptions) error {
+	navigationOptions := PageWaitForNavigationOptions{URL: url}
 	if len(options) > 0 {
-		if _, err := f.WaitForNavigation(PageWaitForNavigationOptions{
-			URL:       url,
-			Timeout:   options[0].Timeout,
-			WaitUntil: options[0].WaitUntil,
-		}); err != nil {
-			return err
-		}
+		navigationOptions.Timeout = options[0].Timeout
+		navigationOptions.WaitUntil = options[0].WaitUntil
+	}
+	if _, err := f.WaitForNavigation(navigationOptions); err != nil {
+		return err
 	}
 	return nil
 }

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -1,10 +1,10 @@
 package playwright_test
 
 import (
-	"testing"
-
 	"github.com/playwright-community/playwright-go"
 	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
 )
 
 func TestFrameWaitForNavigationShouldWork(t *testing.T) {
@@ -19,6 +19,23 @@ func TestFrameWaitForNavigationShouldWork(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, response.Ok())
 	require.Contains(t, response.URL(), "grid.html")
+}
+
+func TestFrameWaitForURLShouldWork(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+
+	require.NoError(t, page.SetContent(`<a href="grid.html">foobar</a>`))
+	go func() {
+		time.Sleep(2 * time.Second)
+		require.NoError(t, page.Click("a"))
+	}()
+
+	err = page.MainFrame().WaitForURL(server.PREFIX + "/grid.html")
+	require.NoError(t, err)
+	require.Equal(t, server.PREFIX+"/grid.html", page.URL())
 }
 
 func TestFrameWaitForNavigationAnchorLinks(t *testing.T) {


### PR DESCRIPTION
fixes: #285 

`PageWaitForNavigationOptions` is constructed only with URL and if the options are provided then those are explicitly set in the instance otherwise `WaitForNavigation` will use the default options