### PR TITLE
fix: update the command in contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,5 +11,5 @@ For every Pull Request on GitHub and on the main branch the coverage data will g
 You can use the `BROWSER` environment variable to use a different browser than Chromium for the tests and use the `HEADLESS` environment variable which is useful for debugging.
 
 ```
-BROWSER=chromium HEADLESS=1 go test -v --race
+BROWSER=chromium HEADLESS=1 go test -v --race ./...
 ```


### PR DESCRIPTION
Update the test command used in contributing guide to run all the tests on local before creating a PR

the existing commands do not run all the test and only run a subset of it in the main package whereas the test in `tests` folders are not executed