### PR TITLE
example: fix examples/scraping

### DIFF
--- a/examples/scraping/main.go
+++ b/examples/scraping/main.go
@@ -31,7 +31,7 @@ func main() {
 		log.Fatalf("could not get entries: %v", err)
 	}
 	for i, entry := range entries {
-		titleElement, err := entry.QuerySelector("td.title > a")
+		titleElement, err := entry.QuerySelector("td.title > span > a")
 		if err != nil {
 			log.Fatalf("could not get title element: %v", err)
 		}


### PR DESCRIPTION
In the process of creating this PR (https://github.com/playwright-community/playwright-go/pull/303), I discovered an error while running the code in `examples/scraping`.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x158 pc=0x104f3632c]
```

It seems the `titleElement` was not being retrieved, so i have fixed the code.