### PR TITLE
chore: update scripts and contributing guide, resolve #299

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,12 +16,20 @@ BROWSER=chromium HEADLESS=1 go test -v --race ./...
 
 ### Roll
 
-1. Find out to which upstream version you want to roll, you need to find out the upstream commit SHA.
-1. `bash scripts/apply-patch.sh`
+1. Find out to which upstream version you want to roll, and change the value of `playwrightCliVersion` in the **run.go** to the new version.
+1. Apply patch `bash scripts/apply-patch.sh`
+1. Fix merge conflicts if any, otherwise ignore this step. Once you are happy you can commit the changes `cd playwright; git commit -am "apply patch" && cd ..`
+1. Regenerate a new patch `bash scripts/update-patch.sh`
+1. Generate go code `go generate ./...`
+
+To adapt to the new version of Playwright's protocol and feature updates, you may need to modify the patch. Refer to the following steps:
+
+1. Apply patch `bash scripts/apply-patch.sh`
 1. `cd playwright`
-1. `reset HEAD~1` this reverts the custom patches
-1. `git stash`
-1. checkout new new sha `git checkout <sha>`
-1. apply the patch again `git stash pop` (and fix merge conflicts)
-1. once you are happy you can commit the changes `git commit -am "apply patch"`
-1. regenerate a new patch `bash scripts/update-patch.sh`
+1. Revert the patch`git reset HEAD~1`
+1. Modify the files under `docs/src/api`, etc. as needed. Available references:
+    - Protocol `packages/protocol/src/protocol.yml`, prior to v1.27.0 are available in `packages/playwright-core/src/protocol/protocol.yml`
+    - [Playwright python](https://github.com/microsoft/playwright-python)
+1. Commit the changes `git commit -am "apply patch"`
+1. Regenerate a new patch `bash scripts/update-patch.sh`
+1. Generate go code `go generate ./...`. If you updated `scripts/data/interfaces.json`, do this step again.

--- a/scripts/apply-patch.sh
+++ b/scripts/apply-patch.sh
@@ -8,13 +8,14 @@ SCRIPTS_DIR="$(dirname "$0")"
 echo "Applying patches..."
 
 pushd "$SCRIPTS_DIR/.."
+PW_VERSION="$(grep -oE "playwrightCliVersion.+\"[0-9\.]+" ./run.go | sed 's/playwrightCliVersion = "/v/g')"
 git submodule update --init
 pushd playwright
 
 git checkout HEAD --detach
 
 if git show-ref -q --heads "$BRANCH_NAME_BUILD"; then
-  git checkout main
+  git checkout "$PW_VERSION"
   git branch -D "$BRANCH_NAME_BUILD"
 fi
 

--- a/scripts/update-patch.sh
+++ b/scripts/update-patch.sh
@@ -9,7 +9,7 @@ pushd "$SCRIPTS_DIR/../playwright"
 SCRIPTS_DIR="$(dirname "$0")"
 echo "Creating patch..."
 git add .
-git diff --full-index playwright-build^1..playwright-build > ../patches/main.patch
+git diff playwright-build^1..playwright-build > ../patches/main.patch
 git reset --hard playwright-build^1
 cd ..
 


### PR DESCRIPTION
I'm trying to [roll](https://github.com/canstand/playwright-go/tree/try-roll) playwright-go to support the new version. The steps in this commit have been verified, for both macOS and WSL.