### PR TITLE
Add multiple missing features

### DIFF
--- a/apiresponse_assertions.go
+++ b/apiresponse_assertions.go
@@ -1,0 +1,79 @@
+package playwright
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type apiResponseAssertionsImpl struct {
+	actual APIResponse
+	isNot  bool
+}
+
+func newAPIResponseAssertions(actual APIResponse, isNot bool) *apiResponseAssertionsImpl {
+	return &apiResponseAssertionsImpl{
+		actual: actual,
+		isNot:  isNot,
+	}
+}
+
+func (ar *apiResponseAssertionsImpl) Not() APIResponseAssertions {
+	return newAPIResponseAssertions(ar.actual, true)
+}
+
+func (ar *apiResponseAssertionsImpl) ToBeOK() error {
+	if ar.isNot != ar.actual.Ok() {
+		return nil
+	}
+	message := fmt.Sprintf(`Response status expected to be within [200..299] range, was %v`, ar.actual.Status())
+	if ar.isNot {
+		message = strings.ReplaceAll(message, "expected to", "expected not to")
+	}
+	logList, err := ar.actual.(*apiResponseImpl).fetchLog()
+	if err != nil {
+		return err
+	}
+	log := strings.Join(logList, "\n")
+	if log != "" {
+		message += "\nCall log:\n" + log
+	}
+
+	isTextEncoding := false
+	contentType, ok := ar.actual.Headers()["content-type"]
+	if ok {
+		isTextEncoding = isTexualMimeType(contentType)
+	}
+	if isTextEncoding {
+		text, err := ar.actual.Text()
+		if err == nil {
+			message += fmt.Sprintf(`\n Response Text:\n %s`, subString(text, 0, 1000))
+		}
+	}
+	return errors.New(message)
+}
+
+func (ar *apiResponseAssertionsImpl) NotToBeOK() error {
+	return ar.Not().ToBeOK()
+}
+
+func isTexualMimeType(mimeType string) bool {
+	re := regexp.MustCompile(`^(text\/.*?|application\/(json|(x-)?javascript|xml.*?|ecmascript|graphql|x-www-form-urlencoded)|image\/svg(\+xml)?|application\/.*?(\+json|\+xml))(;\s*charset=.*)?$`)
+	return re.MatchString(mimeType)
+}
+
+func subString(s string, start, length int) string {
+	if start < 0 {
+		start = 0
+	}
+	if length < 0 {
+		length = 0
+	}
+	rs := []rune(s)
+	end := start + length
+	if end > len(rs) {
+		end = len(rs)
+	}
+	return string(rs[start:end])
+}

--- a/assertions.go
+++ b/assertions.go
@@ -1,0 +1,138 @@
+package playwright
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+)
+
+type playwrightAssertionsImpl struct {
+	defaultTimeout *float64
+}
+
+func NewPlaywrightAssertions(timeout ...float64) PlaywrightAssertions {
+	if len(timeout) > 0 {
+		return &playwrightAssertionsImpl{Float(timeout[0])}
+	}
+	return &playwrightAssertionsImpl{Float(5000)}
+}
+
+func (pa *playwrightAssertionsImpl) APIResponse(response APIResponse) APIResponseAssertions {
+	return newAPIResponseAssertions(response, false)
+}
+
+func (pa *playwrightAssertionsImpl) Locator(locator Locator) LocatorAssertions {
+	return newLocatorAssertions(locator, false, pa.defaultTimeout)
+}
+
+func (pa *playwrightAssertionsImpl) Page(page Page) PageAssertions {
+	return newPageAssertions(page, false, pa.defaultTimeout)
+}
+
+type expectedTextValue struct {
+	Str                 *string `json:"string"`
+	RegexSource         *string `json:"regexSource"`
+	RegexFlags          *string `json:"regexFlags"`
+	MatchSubstring      *bool   `json:"matchSubstring"`
+	IgnoreCase          *bool   `json:"ignoreCase"`
+	NormalizeWhiteSpace *bool   `json:"normalizeWhiteSpace"`
+}
+
+type frameExpectOptions struct {
+	ExpressionArg  interface{}         `json:"expressionArg"`
+	ExpectedText   []expectedTextValue `json:"expectedText"`
+	ExpectedNumber *int                `json:"expectedNumber"`
+	ExpectedValue  interface{}         `json:"expectedValue"`
+	UseInnerText   *bool               `json:"useInnerText"`
+	IsNot          bool                `json:"isNot"`
+	Timeout        *float64            `json:"timeout"`
+}
+
+type frameExpectResult struct {
+	Matches  bool        `json:"matches"`
+	Received interface{} `json:"received"`
+	Log      []string    `json:"log"`
+}
+
+type assertionsBase struct {
+	actualLocator  Locator
+	isNot          bool
+	defaultTimeout *float64
+}
+
+func (b *assertionsBase) expect(
+	expression string,
+	options frameExpectOptions,
+	expected interface{},
+	message string,
+) error {
+	options.IsNot = b.isNot
+	if options.Timeout == nil {
+		options.Timeout = b.defaultTimeout
+	}
+	if options.IsNot {
+		message = strings.ReplaceAll(message, "expected to", "expected not to")
+	}
+	result, err := b.actualLocator.(*locatorImpl).expect(expression, options)
+	if err != nil {
+		return err
+	}
+
+	if result.Matches == b.isNot {
+		actual := result.Received
+		log := strings.Join(result.Log, "\n")
+		if log != "" {
+			log = "\nCall log:\n" + log
+		}
+		if expected != nil {
+			return fmt.Errorf("%s '%v'\nActual value: %v %s", message, expected, actual, log)
+		}
+		return fmt.Errorf("%s\nActual value: %v %s", message, actual, log)
+	}
+
+	return nil
+}
+
+func toExpectedTextValues(
+	items []interface{},
+	matchSubstring bool,
+	normalizeWhiteSpace bool,
+	ignoreCase *bool,
+) []expectedTextValue {
+	var out []expectedTextValue
+	for _, item := range items {
+		switch item := item.(type) {
+		case string:
+			out = append(out, expectedTextValue{
+				Str:                 String(item),
+				MatchSubstring:      Bool(matchSubstring),
+				NormalizeWhiteSpace: Bool(normalizeWhiteSpace),
+				IgnoreCase:          ignoreCase,
+			})
+		case *regexp.Regexp:
+			pattern, flags := convertRegexp(item)
+			out = append(out, expectedTextValue{
+				RegexSource:         String(pattern),
+				RegexFlags:          String(flags),
+				MatchSubstring:      Bool(matchSubstring),
+				NormalizeWhiteSpace: Bool(normalizeWhiteSpace),
+				IgnoreCase:          ignoreCase,
+			})
+		}
+	}
+	return out
+}
+
+func convertToInterfaceList(v interface{}) []interface{} {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Slice {
+		return []interface{}{v}
+	}
+
+	list := make([]interface{}, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		list[i] = rv.Index(i).Interface()
+	}
+	return list
+}

--- a/browser_context.go
+++ b/browser_context.go
@@ -266,6 +266,23 @@ func (b *browserContextImpl) ExpectEvent(event string, cb func() error, options 
 	return b.waiterForEvent(event, options...).Expect(cb)
 }
 
+func (b *browserContextImpl) ExpectPage(cb func() error, options ...BrowserContextExpectPageOptions) (Page, error) {
+	var w *waiter
+	if len(options) == 1 {
+		w = b.waiterForEvent("page", BrowserContextWaitForEventOptions{
+			Predicate: options[0].Predicate,
+			Timeout:   options[0].Timeout,
+		})
+	} else {
+		w = b.waiterForEvent("page")
+	}
+	ret, err := w.Expect(cb)
+	if err != nil {
+		return nil, err
+	}
+	return ret.(Page), nil
+}
+
 func (b *browserContextImpl) Close() error {
 	if b.isClosedOrClosing {
 		return nil

--- a/browser_context.go
+++ b/browser_context.go
@@ -263,7 +263,7 @@ func (b *browserContextImpl) waiterForEvent(event string, options ...BrowserCont
 }
 
 func (b *browserContextImpl) ExpectEvent(event string, cb func() error, options ...BrowserContextWaitForEventOptions) (interface{}, error) {
-	return b.waiterForEvent(event, options...).Expect(cb)
+	return b.waiterForEvent(event, options...).RunAndWait(cb)
 }
 
 func (b *browserContextImpl) ExpectPage(cb func() error, options ...BrowserContextExpectPageOptions) (Page, error) {
@@ -276,7 +276,7 @@ func (b *browserContextImpl) ExpectPage(cb func() error, options ...BrowserConte
 	} else {
 		w = b.waiterForEvent("page")
 	}
-	ret, err := w.Expect(cb)
+	ret, err := w.RunAndWait(cb)
 	if err != nil {
 		return nil, err
 	}

--- a/browser_context.go
+++ b/browser_context.go
@@ -18,7 +18,7 @@ type browserContextImpl struct {
 	routes            []*routeHandlerEntry
 	ownedPage         Page
 	browser           *browserImpl
-	serviceWorkers    []*workerImpl
+	serviceWorkers    []Worker
 	backgroundPages   []Page
 	bindings          map[string]BindingCallFunction
 	tracing           *tracingImpl
@@ -521,6 +521,12 @@ func (b *browserContextImpl) BackgroundPages() []Page {
 	b.Lock()
 	defer b.Unlock()
 	return b.backgroundPages
+}
+
+func (b *browserContextImpl) ServiceWorkers() []Worker {
+	b.Lock()
+	defer b.Unlock()
+	return b.serviceWorkers
 }
 
 func newBrowserContext(parent *channelOwner, objectType string, guid string, initializer map[string]interface{}) *browserContextImpl {

--- a/browser_context.go
+++ b/browser_context.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 )
 
 type browserContextImpl struct {
@@ -21,6 +22,10 @@ type browserContextImpl struct {
 	backgroundPages   []Page
 	bindings          map[string]BindingCallFunction
 	tracing           *tracingImpl
+	request           *apiRequestContextImpl
+	harRecorders      map[string]harRecordingMetadata
+	closed            chan struct{}
+	browserType       *browserTypeImpl
 }
 
 func (b *browserContextImpl) SetDefaultNavigationTimeout(timeout float64) {
@@ -217,6 +222,28 @@ func (b *browserContextImpl) Unroute(url interface{}, handlers ...routeHandler) 
 	return nil
 }
 
+func (b *browserContextImpl) Request() APIRequestContext {
+	return b.request
+}
+
+func (b *browserContextImpl) RouteFromHAR(har string, options ...BrowserContextRouteFromHAROptions) error {
+	opt := BrowserContextRouteFromHAROptions{}
+	if len(options) == 1 {
+		opt = options[0]
+	}
+	if opt.Update != nil && *opt.Update {
+		return b.recordIntoHar(har, browserContextRecordIntoHarOptions{
+			URL: opt.URL,
+		})
+	}
+	notFound := opt.NotFound
+	if notFound == nil {
+		notFound = HarNotFoundAbort
+	}
+	router := newHarRouter(b.connection.localUtils, har, *notFound, opt.URL)
+	return router.addContextRoute(b)
+}
+
 func (b *browserContextImpl) WaitForEvent(event string, options ...BrowserContextWaitForEventOptions) (interface{}, error) {
 	return b.waiterForEvent(event, options...).Wait()
 }
@@ -246,15 +273,31 @@ func (b *browserContextImpl) Close() error {
 	b.Lock()
 	b.isClosedOrClosing = true
 	b.Unlock()
-
-	if b.options != nil && b.options.RecordHarPath != nil {
-		response, err := b.channel.Send("harExport")
+	for harId, harMetaData := range b.harRecorders {
+		overrides := map[string]interface{}{}
+		if harId != "" {
+			overrides["harId"] = harId
+		}
+		response, err := b.channel.Send("harExport", overrides)
 		if err != nil {
 			return err
 		}
 		artifact := fromChannel(response).(*artifactImpl)
-		if err := artifact.SaveAs(*b.options.RecordHarPath); err != nil {
-			return err
+		// Server side will compress artifact if content is attach or if file is .zip.
+		needCompressed := strings.HasSuffix(strings.ToLower(harMetaData.Path), ".zip")
+		if !needCompressed && harMetaData.Content == HarContentPolicyAttach {
+			tmpPath := harMetaData.Path + ".tmp"
+			if err := artifact.SaveAs(tmpPath); err != nil {
+				return err
+			}
+			err = b.connection.localUtils.HarUnzip(tmpPath, harMetaData.Path)
+			if err != nil {
+				return err
+			}
+		} else {
+			if err := artifact.SaveAs(harMetaData.Path); err != nil {
+				return err
+			}
 		}
 		if err := artifact.Delete(); err != nil {
 			return err
@@ -262,7 +305,41 @@ func (b *browserContextImpl) Close() error {
 	}
 
 	_, err := b.channel.Send("close")
+	<-b.closed
 	return err
+}
+
+type browserContextRecordIntoHarOptions struct {
+	Page Page
+	URL  interface{}
+	// UpdateContent *HarContentPolicy
+	// UpdateMode    *HarMode
+}
+
+func (b *browserContextImpl) recordIntoHar(har string, options ...browserContextRecordIntoHarOptions) error {
+	overrides := map[string]interface{}{}
+	harOptions := recordHarInputOptions{
+		Path: har,
+	}
+	content := HarContentPolicyAttach
+	harOptions.Content = content
+	harOptions.Mode = HarModeMinimal
+	if len(options) == 1 {
+		harOptions.URL = options[0].URL
+		overrides["options"] = prepareRecordHarOptions(harOptions)
+		if options[0].Page != nil {
+			overrides["page"] = options[0].Page.(*pageImpl).channel
+		}
+	}
+	harId, err := b.channel.Send("harStart", overrides)
+	if err != nil {
+		return err
+	}
+	b.harRecorders[harId.(string)] = harRecordingMetadata{
+		Path:    har,
+		Content: content,
+	}
+	return nil
 }
 
 type StorageState struct {
@@ -322,7 +399,9 @@ func (b *browserContextImpl) onBinding(binding *bindingCallImpl) {
 }
 
 func (b *browserContextImpl) onClose() {
+	b.Lock()
 	b.isClosedOrClosing = true
+	b.Unlock()
 	if b.browser != nil {
 		contexts := make([]BrowserContext, 0)
 		b.browser.Lock()
@@ -334,7 +413,7 @@ func (b *browserContextImpl) onClose() {
 		b.browser.contexts = contexts
 		b.browser.Unlock()
 	}
-	b.Emit("close")
+	b.Emit("close", b)
 }
 
 func (b *browserContextImpl) onPage(page *pageImpl) {
@@ -351,14 +430,34 @@ func (b *browserContextImpl) onPage(page *pageImpl) {
 
 func (b *browserContextImpl) onRoute(route *routeImpl) {
 	go func() {
+		b.Lock()
+		defer b.Unlock()
+		routes := make([]*routeHandlerEntry, len(b.routes))
+		copy(routes, b.routes)
+
+		defer func() {
+			if len(b.routes) == 0 {
+				_, _ = b.channel.Send("setNetworkInterceptionEnabled", map[string]interface{}{
+					"enabled": false,
+				})
+			}
+		}()
+
 		url := route.Request().URL()
-		for _, handlerEntry := range b.routes {
-			if handlerEntry.matcher.Matches(url) {
-				handlerEntry.handler(route)
+		for i, handlerEntry := range routes {
+			if !handlerEntry.Matches(url) {
+				continue
+			}
+			if handlerEntry.WillExceed() {
+				b.routes = append(b.routes[:i], b.routes[i+1:]...)
+			}
+			handled := handlerEntry.Handle(route)
+			yes := <-handled
+			if yes {
 				return
 			}
 		}
-		if err := route.Continue(); err != nil {
+		if err := route.internalContinue(true); err != nil {
 			log.Printf("could not continue request: %v", err)
 		}
 	}()
@@ -385,6 +484,22 @@ func (b *browserContextImpl) OnBackgroundPage(ev map[string]interface{}) {
 	b.Emit("backgroundpage", p)
 }
 
+func (b *browserContextImpl) onServiceWorker(worker *workerImpl) {
+	worker.context = b
+	b.serviceWorkers = append(b.serviceWorkers, worker)
+	b.Emit("serviceworker", worker)
+}
+
+func (b *browserContextImpl) setBrowserType(bt *browserTypeImpl) {
+	b.browserType = bt
+	if b.options != nil && b.options.RecordHarPath != nil {
+		b.harRecorders[""] = harRecordingMetadata{
+			Path:    *b.options.RecordHarPath,
+			Content: b.options.RecordHarContent,
+		}
+	}
+}
+
 func (b *browserContextImpl) BackgroundPages() []Page {
 	b.Lock()
 	defer b.Unlock()
@@ -397,11 +512,26 @@ func newBrowserContext(parent *channelOwner, objectType string, guid string, ini
 		pages:           make([]Page, 0),
 		routes:          make([]*routeHandlerEntry, 0),
 		bindings:        make(map[string]BindingCallFunction),
+		harRecorders:    make(map[string]harRecordingMetadata),
+		closed:          make(chan struct{}, 1),
 	}
 	bt.createChannelOwner(bt, parent, objectType, guid, initializer)
 	bt.tracing = fromChannel(initializer["tracing"]).(*tracingImpl)
+	bt.request = fromChannel(initializer["requestContext"]).(*apiRequestContextImpl)
 	bt.channel.On("bindingCall", func(params map[string]interface{}) {
 		bt.onBinding(fromChannel(params["binding"]).(*bindingCallImpl))
+	})
+
+	bt.channel.On("close", bt.onClose)
+	bt.channel.On("page", func(payload map[string]interface{}) {
+		bt.onPage(fromChannel(payload["page"]).(*pageImpl))
+	})
+	bt.channel.On("route", func(params map[string]interface{}) {
+		bt.onRoute(fromChannel(params["route"]).(*routeImpl))
+	})
+	bt.channel.On("backgroundPage", bt.OnBackgroundPage)
+	bt.channel.On("serviceWorker", func(params map[string]interface{}) {
+		bt.onServiceWorker(fromChannel(params["worker"]).(*workerImpl))
 	})
 	bt.channel.On("request", func(ev map[string]interface{}) {
 		request := fromChannel(ev["request"]).(*requestImpl)
@@ -446,14 +576,9 @@ func newBrowserContext(parent *channelOwner, objectType string, guid string, ini
 			page.(*pageImpl).Emit("response", response)
 		}
 	})
-	bt.channel.On("close", bt.onClose)
-	bt.channel.On("page", func(payload map[string]interface{}) {
-		bt.onPage(fromChannel(payload["page"]).(*pageImpl))
+	bt.Once("close", func() {
+		bt.closed <- struct{}{}
 	})
-	bt.channel.On("route", func(params map[string]interface{}) {
-		bt.onRoute(fromChannel(params["route"]).(*routeImpl))
-	})
-	bt.channel.On("backgroundPage", bt.OnBackgroundPage)
 	bt.setEventSubscriptionMapping(map[string]string{
 		"request":         "request",
 		"response":        "response",

--- a/browser_type.go
+++ b/browser_type.go
@@ -6,6 +6,7 @@ import (
 
 type browserTypeImpl struct {
 	channelOwner
+	playwright *Playwright
 }
 
 func (b *browserTypeImpl) Name() string {
@@ -111,6 +112,7 @@ func (b *browserTypeImpl) Connect(url string, options ...BrowserTypeConnectOptio
 	}
 	jsonPipe.On("message", connection.Dispatch)
 	playwright := connection.Start()
+	playwright.setSelectors(b.playwright.Selectors)
 	browser = fromChannel(playwright.initializer["preLaunchedBrowser"]).(*browserImpl)
 	browser.shouldCloseConnectionOnClose = true
 	browser.setBrowserType(b)

--- a/browser_type.go
+++ b/browser_type.go
@@ -26,16 +26,24 @@ func (b *browserTypeImpl) Launch(options ...BrowserTypeLaunchOptions) (Browser, 
 	if err != nil {
 		return nil, fmt.Errorf("could not send message: %w", err)
 	}
-	return fromChannel(channel).(*browserImpl), nil
+	browser := fromChannel(channel).(*browserImpl)
+	browser.setBrowserType(b)
+	return browser, nil
 }
 
 func (b *browserTypeImpl) LaunchPersistentContext(userDataDir string, options ...BrowserTypeLaunchPersistentContextOptions) (BrowserContext, error) {
 	overrides := map[string]interface{}{
 		"userDataDir": userDataDir,
 	}
+	option := &BrowserNewContextOptions{}
 	if len(options) == 1 {
+		err := assignStructFields(option, options[0], true)
+		if err != nil {
+			return nil, fmt.Errorf("can not convert options: %w", err)
+		}
 		if options[0].ExtraHttpHeaders != nil {
 			overrides["extraHTTPHeaders"] = serializeMapToNameAndValue(options[0].ExtraHttpHeaders)
+			options[0].ExtraHttpHeaders = nil
 		}
 		if options[0].Env != nil {
 			overrides["env"] = serializeMapToNameAndValue(options[0].Env)
@@ -46,21 +54,28 @@ func (b *browserTypeImpl) LaunchPersistentContext(userDataDir string, options ..
 			options[0].NoViewport = nil
 		}
 		if options[0].RecordHarPath != nil {
-			recordHar := map[string]interface{}{}
-			recordHar["path"] = *options[0].RecordHarPath
-			if options[0].RecordHarOmitContent != nil {
-				recordHar["omitContent"] = true
-			}
-			overrides["recordHar"] = recordHar
-		} else if options[0].RecordHarOmitContent != nil {
-			return nil, fmt.Errorf("recordHarOmitContent is set but recordHarPath is nil")
+			overrides["recordHar"] = prepareRecordHarOptions(recordHarInputOptions{
+				Path:        *options[0].RecordHarPath,
+				URL:         options[0].RecordHarUrlFilter,
+				Mode:        options[0].RecordHarMode,
+				Content:     options[0].RecordHarContent,
+				OmitContent: options[0].RecordHarOmitContent,
+			})
+			options[0].RecordHarPath = nil
+			options[0].RecordHarUrlFilter = nil
+			options[0].RecordHarMode = nil
+			options[0].RecordHarContent = nil
+			options[0].RecordHarOmitContent = nil
 		}
 	}
 	channel, err := b.channel.Send("launchPersistentContext", overrides, options)
 	if err != nil {
 		return nil, fmt.Errorf("could not send message: %w", err)
 	}
-	return fromChannel(channel).(*browserContextImpl), nil
+	context := fromChannel(channel).(*browserContextImpl)
+	context.options = option
+	context.setBrowserType(b)
+	return context, nil
 }
 func (b *browserTypeImpl) Connect(url string, options ...BrowserTypeConnectOptions) (Browser, error) {
 	overrides := map[string]interface{}{
@@ -98,6 +113,7 @@ func (b *browserTypeImpl) Connect(url string, options ...BrowserTypeConnectOptio
 	playwright := connection.Start()
 	browser = fromChannel(playwright.initializer["preLaunchedBrowser"]).(*browserImpl)
 	browser.shouldCloseConnectionOnClose = true
+	browser.setBrowserType(b)
 	return browser, nil
 }
 func (b *browserTypeImpl) ConnectOverCDP(endpointURL string, options ...BrowserTypeConnectOverCDPOptions) (Browser, error) {
@@ -114,6 +130,7 @@ func (b *browserTypeImpl) ConnectOverCDP(endpointURL string, options ...BrowserT
 		browser.contexts = append(browser.contexts, context)
 		context.browser = browser
 	}
+	browser.setBrowserType(b)
 	return browser, nil
 }
 

--- a/connection.go
+++ b/connection.go
@@ -22,6 +22,7 @@ type connection struct {
 	lastIDLock                  sync.Mutex
 	rootObject                  *rootChannelOwner
 	callbacks                   sync.Map
+	afterClose                  func()
 	onClose                     func() error
 	onmessage                   func(map[string]interface{}) error
 	isRemote                    bool
@@ -51,6 +52,9 @@ func (c *connection) Stop() error {
 }
 
 func (c *connection) cleanup() {
+	if c.afterClose != nil {
+		c.afterClose()
+	}
 	c.callbacks.Range(func(key, value any) bool {
 		select {
 		case value.(chan callback) <- callback{

--- a/element_handle.go
+++ b/element_handle.go
@@ -131,20 +131,12 @@ func (e *elementHandleImpl) QuerySelectorAll(selector string) ([]ElementHandle, 
 
 func (e *elementHandleImpl) EvalOnSelector(selector string, expression string, options ...interface{}) (interface{}, error) {
 	var arg interface{}
-	forceExpression := false
-	if !isFunctionBody(expression) {
-		forceExpression = true
-	}
 	if len(options) == 1 {
 		arg = options[0]
-	} else if len(options) == 2 {
-		arg = options[0]
-		forceExpression = options[1].(bool)
 	}
 	result, err := e.channel.Send("evalOnSelector", map[string]interface{}{
 		"selector":   selector,
 		"expression": expression,
-		"isFunction": !forceExpression,
 		"arg":        serializeArgument(arg),
 	})
 	if err != nil {
@@ -155,20 +147,12 @@ func (e *elementHandleImpl) EvalOnSelector(selector string, expression string, o
 
 func (e *elementHandleImpl) EvalOnSelectorAll(selector string, expression string, options ...interface{}) (interface{}, error) {
 	var arg interface{}
-	forceExpression := false
-	if !isFunctionBody(expression) {
-		forceExpression = true
-	}
 	if len(options) == 1 {
 		arg = options[0]
-	} else if len(options) == 2 {
-		arg = options[0]
-		forceExpression = options[1].(bool)
 	}
 	result, err := e.channel.Send("evalOnSelectorAll", map[string]interface{}{
 		"selector":   selector,
 		"expression": expression,
-		"isFunction": !forceExpression,
 		"arg":        serializeArgument(arg),
 	})
 	if err != nil {

--- a/fetch.go
+++ b/fetch.go
@@ -359,6 +359,20 @@ func (r *apiResponseImpl) fetchUid() string {
 	return r.initializer["fetchUid"].(string)
 }
 
+func (r *apiResponseImpl) fetchLog() ([]string, error) {
+	ret, err := r.request.channel.Send("fetchLog", map[string]interface{}{
+		"fetchUid": r.fetchUid(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]string, len(ret.([]interface{})))
+	for i, v := range ret.([]interface{}) {
+		result[i] = v.(string)
+	}
+	return result, nil
+}
+
 func newAPIResponse(context *apiRequestContextImpl, initializer map[string]interface{}) *apiResponseImpl {
 	return &apiResponseImpl{
 		request:     context,

--- a/fetch.go
+++ b/fetch.go
@@ -229,7 +229,7 @@ func (r *apiRequestContextImpl) Patch(url string, options ...APIRequestContextPa
 
 func (r *apiRequestContextImpl) Put(url string, options ...APIRequestContextPutOptions) (APIResponse, error) {
 	opts := APIRequestContextFetchOptions{
-		Method: String("GET"),
+		Method: String("PUT"),
 	}
 	if len(options) == 1 {
 		err := assignStructFields(&opts, options[0], false)
@@ -243,7 +243,7 @@ func (r *apiRequestContextImpl) Put(url string, options ...APIRequestContextPutO
 
 func (r *apiRequestContextImpl) Post(url string, options ...APIRequestContextPostOptions) (APIResponse, error) {
 	opts := APIRequestContextFetchOptions{
-		Method: String("GET"),
+		Method: String("POST"),
 	}
 	if len(options) == 1 {
 		err := assignStructFields(&opts, options[0], false)

--- a/frame.go
+++ b/frame.go
@@ -720,6 +720,64 @@ func (f *frameImpl) Locator(selector string, options ...FrameLocatorOptions) (Lo
 	return newLocator(f, selector, option)
 }
 
+func (f *frameImpl) GetByAltText(text interface{}, options ...LocatorGetByAltTextOptions) (Locator, error) {
+	exact := false
+	if len(options) == 1 {
+		if *options[0].Exact {
+			exact = true
+		}
+	}
+	return f.Locator(getByAltTextSelector(text, exact))
+}
+
+func (f *frameImpl) GetByLabel(text interface{}, options ...LocatorGetByLabelOptions) (Locator, error) {
+	exact := false
+	if len(options) == 1 {
+		if *options[0].Exact {
+			exact = true
+		}
+	}
+	return f.Locator(getByLabelSelector(text, exact))
+}
+
+func (f *frameImpl) GetByPlaceholder(text interface{}, options ...LocatorGetByPlaceholderOptions) (Locator, error) {
+	exact := false
+	if len(options) == 1 {
+		if *options[0].Exact {
+			exact = true
+		}
+	}
+	return f.Locator(getByPlaceholderSelector(text, exact))
+}
+
+func (f *frameImpl) GetByRole(role AriaRole, options ...LocatorGetByRoleOptions) (Locator, error) {
+	return f.Locator(getByRoleSelector(role, options...))
+}
+
+func (f *frameImpl) GetByTestId(testId interface{}) (Locator, error) {
+	return f.Locator(getByTestIdSelector(getTestIdAttributeName(), testId))
+}
+
+func (f *frameImpl) GetByText(text interface{}, options ...LocatorGetByTextOptions) (Locator, error) {
+	exact := false
+	if len(options) == 1 {
+		if *options[0].Exact {
+			exact = true
+		}
+	}
+	return f.Locator(getByTextSelector(text, exact))
+}
+
+func (f *frameImpl) GetByTitle(text interface{}, options ...LocatorGetByTitleOptions) (Locator, error) {
+	exact := false
+	if len(options) == 1 {
+		if *options[0].Exact {
+			exact = true
+		}
+	}
+	return f.Locator(getByTitleSelector(text, exact))
+}
+
 func (f *frameImpl) FrameLocator(selector string) FrameLocator {
 	return newFrameLocator(f, selector)
 }

--- a/frame.go
+++ b/frame.go
@@ -304,19 +304,11 @@ func (f *frameImpl) QuerySelectorAll(selector string) ([]ElementHandle, error) {
 
 func (f *frameImpl) Evaluate(expression string, options ...interface{}) (interface{}, error) {
 	var arg interface{}
-	forceExpression := false
-	if !isFunctionBody(expression) {
-		forceExpression = true
-	}
 	if len(options) == 1 {
 		arg = options[0]
-	} else if len(options) == 2 {
-		arg = options[0]
-		forceExpression = options[1].(bool)
 	}
 	result, err := f.channel.Send("evaluateExpression", map[string]interface{}{
 		"expression": expression,
-		"isFunction": !forceExpression,
 		"arg":        serializeArgument(arg),
 	})
 	if err != nil {
@@ -327,20 +319,12 @@ func (f *frameImpl) Evaluate(expression string, options ...interface{}) (interfa
 
 func (f *frameImpl) EvalOnSelector(selector string, expression string, options ...interface{}) (interface{}, error) {
 	var arg interface{}
-	forceExpression := false
-	if !isFunctionBody(expression) {
-		forceExpression = true
-	}
 	if len(options) == 1 {
 		arg = options[0]
-	} else if len(options) == 2 {
-		arg = options[0]
-		forceExpression = options[1].(bool)
 	}
 	result, err := f.channel.Send("evalOnSelector", map[string]interface{}{
 		"selector":   selector,
 		"expression": expression,
-		"isFunction": !forceExpression,
 		"arg":        serializeArgument(arg),
 	})
 	if err != nil {
@@ -351,20 +335,12 @@ func (f *frameImpl) EvalOnSelector(selector string, expression string, options .
 
 func (f *frameImpl) EvalOnSelectorAll(selector string, expression string, options ...interface{}) (interface{}, error) {
 	var arg interface{}
-	forceExpression := false
-	if !isFunctionBody(expression) {
-		forceExpression = true
-	}
 	if len(options) == 1 {
 		arg = options[0]
-	} else if len(options) == 2 {
-		arg = options[0]
-		forceExpression = options[1].(bool)
 	}
 	result, err := f.channel.Send("evalOnSelectorAll", map[string]interface{}{
 		"selector":   selector,
 		"expression": expression,
-		"isFunction": !forceExpression,
 		"arg":        serializeArgument(arg),
 	})
 	if err != nil {
@@ -375,19 +351,11 @@ func (f *frameImpl) EvalOnSelectorAll(selector string, expression string, option
 
 func (f *frameImpl) EvaluateHandle(expression string, options ...interface{}) (JSHandle, error) {
 	var arg interface{}
-	forceExpression := false
-	if !isFunctionBody(expression) {
-		forceExpression = true
-	}
 	if len(options) == 1 {
 		arg = options[0]
-	} else if len(options) == 2 {
-		arg = options[0]
-		forceExpression = options[1].(bool)
 	}
 	result, err := f.channel.Send("evaluateExpressionHandle", map[string]interface{}{
 		"expression": expression,
-		"isFunction": !forceExpression,
 		"arg":        serializeArgument(arg),
 	})
 	if err != nil {
@@ -518,13 +486,8 @@ func (f *frameImpl) WaitForFunction(expression string, arg interface{}, options 
 	if len(options) == 1 {
 		option = options[0]
 	}
-	forceExpression := false
-	if !isFunctionBody(expression) {
-		forceExpression = true
-	}
 	result, err := f.channel.Send("waitForFunction", map[string]interface{}{
 		"expression": expression,
-		"isFunction": !forceExpression,
 		"arg":        serializeArgument(arg),
 		"timeout":    option.Timeout,
 		"polling":    option.Polling,

--- a/frame.go
+++ b/frame.go
@@ -148,7 +148,7 @@ func (f *frameImpl) waitForLoadStateImpl(state string, timeout *float64, cb func
 		_, err := waiter.Wait()
 		return err
 	} else {
-		_, err := waiter.Expect(cb)
+		_, err := waiter.RunAndWait(cb)
 		return err
 	}
 }

--- a/frame_locator.go
+++ b/frame_locator.go
@@ -19,6 +19,64 @@ func (fl *frameLocatorImpl) FrameLocator(selector string) FrameLocator {
 	return newFrameLocator(fl.frame, fl.frameSelector+" >> internal:control=enter-frame >> "+selector)
 }
 
+func (fl *frameLocatorImpl) GetByAltText(text interface{}, options ...LocatorGetByAltTextOptions) (Locator, error) {
+	exact := false
+	if len(options) == 1 {
+		if *options[0].Exact {
+			exact = true
+		}
+	}
+	return fl.Locator(getByAltTextSelector(text, exact))
+}
+
+func (fl *frameLocatorImpl) GetByLabel(text interface{}, options ...LocatorGetByLabelOptions) (Locator, error) {
+	exact := false
+	if len(options) == 1 {
+		if *options[0].Exact {
+			exact = true
+		}
+	}
+	return fl.Locator(getByLabelSelector(text, exact))
+}
+
+func (fl *frameLocatorImpl) GetByPlaceholder(text interface{}, options ...LocatorGetByPlaceholderOptions) (Locator, error) {
+	exact := false
+	if len(options) == 1 {
+		if *options[0].Exact {
+			exact = true
+		}
+	}
+	return fl.Locator(getByPlaceholderSelector(text, exact))
+}
+
+func (fl *frameLocatorImpl) GetByRole(role AriaRole, options ...LocatorGetByRoleOptions) (Locator, error) {
+	return fl.Locator(getByRoleSelector(role, options...))
+}
+
+func (fl *frameLocatorImpl) GetByTestId(testId interface{}) (Locator, error) {
+	return fl.Locator(getByTestIdSelector(getTestIdAttributeName(), testId))
+}
+
+func (fl *frameLocatorImpl) GetByText(text interface{}, options ...LocatorGetByTextOptions) (Locator, error) {
+	exact := false
+	if len(options) == 1 {
+		if *options[0].Exact {
+			exact = true
+		}
+	}
+	return fl.Locator(getByTextSelector(text, exact))
+}
+
+func (fl *frameLocatorImpl) GetByTitle(text interface{}, options ...LocatorGetByTitleOptions) (Locator, error) {
+	exact := false
+	if len(options) == 1 {
+		if *options[0].Exact {
+			exact = true
+		}
+	}
+	return fl.Locator(getByTitleSelector(text, exact))
+}
+
 func (fl *frameLocatorImpl) Last() FrameLocator {
 	return newFrameLocator(fl.frame, fl.frameSelector+" >> nth=-1")
 }

--- a/generated-interfaces.go
+++ b/generated-interfaces.go
@@ -152,6 +152,20 @@ type APIResponse interface {
 	URL() string
 }
 
+// The `APIResponseAssertions` class provides assertion methods that can be used to make assertions about the
+// `APIResponse` in the tests. A new instance of `APIResponseAssertions` is created by calling
+// PlaywrightAssertions.expectAPIResponse():
+type APIResponseAssertions interface {
+	// Makes the assertion check for the opposite condition. For example, this code tests that the response status is not
+	// successful:
+	Not() APIResponseAssertions
+	// Ensures the response status code is within `200..299` range.
+	// **Usage**
+	ToBeOK() error
+	// The opposite of APIResponseAssertions.toBeOK().
+	NotToBeOK() error
+}
+
 type BindingCall interface {
 	Call(f BindingCallFunction)
 }
@@ -1793,6 +1807,156 @@ type Locator interface {
 	WaitFor(options ...PageWaitForSelectorOptions) error
 }
 
+// The `LocatorAssertions` class provides assertion methods that can be used to make assertions about the `Locator`
+// state in the tests. A new instance of `LocatorAssertions` is created by calling
+// PlaywrightAssertions.expectLocator():
+type LocatorAssertions interface {
+	// Makes the assertion check for the opposite condition. For example, this code tests that the Locator doesn't contain
+	// text `"error"`:
+	Not() LocatorAssertions
+	// Ensures the `Locator` points to a checked input.
+	// **Usage**
+	ToBeChecked(options ...LocatorAssertionsToBeCheckedOptions) error
+	// Ensures the `Locator` points to a disabled element. Element is disabled if it has "disabled" attribute or is
+	// disabled via
+	// ['aria-disabled'](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled). Note
+	// that only native control elements such as HTML `button`, `input`, `select`, `textarea`, `option`, `optgroup` can be
+	// disabled by setting "disabled" attribute. "disabled" attribute on other elements is ignored by the browser.
+	// **Usage**
+	ToBeDisabled(options ...LocatorAssertionsToBeDisabledOptions) error
+	// Ensures the `Locator` points to an editable element.
+	// **Usage**
+	ToBeEditable(options ...LocatorAssertionsToBeEditableOptions) error
+	// Ensures the `Locator` points to an empty editable element or to a DOM node that has no text.
+	// **Usage**
+	ToBeEmpty(options ...LocatorAssertionsToBeEmptyOptions) error
+	// Ensures the `Locator` points to an enabled element.
+	// **Usage**
+	ToBeEnabled(options ...LocatorAssertionsToBeEnabledOptions) error
+	// Ensures the `Locator` points to a focused DOM node.
+	// **Usage**
+	ToBeFocused(options ...LocatorAssertionsToBeFocusedOptions) error
+	// Ensures that `Locator` either does not resolve to any DOM node, or resolves to a
+	// [non-visible](../actionability.md#visible) one.
+	// **Usage**
+	ToBeHidden(options ...LocatorAssertionsToBeHiddenOptions) error
+	// Ensures that `Locator` points to an [attached](../actionability.md#attached) and
+	// [visible](../actionability.md#visible) DOM node.
+	// **Usage**
+	ToBeVisible(options ...LocatorAssertionsToBeVisibleOptions) error
+	// Ensures the `Locator` points to an element that contains the given text. You can use regular expressions for the
+	// value as well.
+	// **Usage**
+	// If you pass an array as an expected value, the expectations are:
+	// 1. Locator resolves to a list of elements.
+	// 1. Elements from a **subset** of this list contain text from the expected array, respectively.
+	// 1. The matching subset of elements has the same order as the expected array.
+	// 1. Each text value from the expected array is matched by some element from the list.
+	// For example, consider the following list:
+	// ```html
+	// <ul>
+	// <li>Item Text 1</li>
+	// <li>Item Text 2</li>
+	// <li>Item Text 3</li>
+	// </ul>
+	// ```
+	// Let's see how we can use the assertion:
+	ToContainText(expected interface{}, options ...LocatorAssertionsToContainTextOptions) error
+	// Ensures the `Locator` points to an element with given attribute.
+	// **Usage**
+	ToHaveAttribute(name string, value interface{}, options ...LocatorAssertionsToHaveAttributeOptions) error
+	// Ensures the `Locator` points to an element with given CSS classes. This needs to be a full match or using a relaxed
+	// regular expression.
+	// **Usage**
+	// ```html
+	// <div class='selected row' id='component'></div>
+	// ```
+	// Note that if array is passed as an expected value, entire lists of elements can be asserted:
+	ToHaveClass(expected interface{}, options ...LocatorAssertionsToHaveClassOptions) error
+	// Ensures the `Locator` resolves to an exact number of DOM nodes.
+	// **Usage**
+	ToHaveCount(count int, options ...LocatorAssertionsToHaveCountOptions) error
+	// Ensures the `Locator` resolves to an element with the given computed CSS style.
+	// **Usage**
+	ToHaveCSS(name string, value interface{}, options ...LocatorAssertionsToHaveCSSOptions) error
+	// Ensures the `Locator` points to an element with the given DOM Node ID.
+	// **Usage**
+	ToHaveId(id interface{}, options ...LocatorAssertionsToHaveIdOptions) error
+	// Ensures the `Locator` points to an element with given JavaScript property. Note that this property can be of a
+	// primitive type as well as a plain serializable JavaScript object.
+	// **Usage**
+	ToHaveJSProperty(name string, value interface{}, options ...LocatorAssertionsToHaveJSPropertyOptions) error
+	// Ensures the `Locator` points to an element with the given text. You can use regular expressions for the value as
+	// well.
+	// **Usage**
+	// If you pass an array as an expected value, the expectations are:
+	// 1. Locator resolves to a list of elements.
+	// 1. The number of elements equals the number of expected values in the array.
+	// 1. Elements from the list have text matching expected array values, one by one, in order.
+	// For example, consider the following list:
+	// ```html
+	// <ul>
+	// <li>Text 1</li>
+	// <li>Text 2</li>
+	// <li>Text 3</li>
+	// </ul>
+	// ```
+	// Let's see how we can use the assertion:
+	ToHaveText(expected interface{}, options ...LocatorAssertionsToHaveTextOptions) error
+	// Ensures the `Locator` points to an element with the given input value. You can use regular expressions for the
+	// value as well.
+	// **Usage**
+	ToHaveValue(value interface{}, options ...LocatorAssertionsToHaveValueOptions) error
+	// Ensures the `Locator` points to multi-select/combobox (i.e. a `select` with the `multiple` attribute) and the
+	// specified values are selected.
+	// **Usage**
+	// For example, given the following element:
+	// ```html
+	// <select id="favorite-colors" multiple>
+	// <option value="R">Red</option>
+	// <option value="G">Green</option>
+	// <option value="B">Blue</option>
+	// </select>
+	// ```
+	ToHaveValues(values []interface{}, options ...LocatorAssertionsToHaveValuesOptions) error
+	// The opposite of LocatorAssertions.toBeChecked().
+	NotToBeChecked(options ...LocatorAssertionsToBeCheckedOptions) error
+	// The opposite of LocatorAssertions.toBeDisabled().
+	NotToBeDisabled(options ...LocatorAssertionsToBeDisabledOptions) error
+	// The opposite of LocatorAssertions.toBeEditable().
+	NotToBeEditable(options ...LocatorAssertionsToBeEditableOptions) error
+	// The opposite of LocatorAssertions.toBeEmpty().
+	NotToBeEmpty(options ...LocatorAssertionsToBeEmptyOptions) error
+	// The opposite of LocatorAssertions.toBeEnabled().
+	NotToBeEnabled(options ...LocatorAssertionsToBeEnabledOptions) error
+	// The opposite of LocatorAssertions.toBeFocused().
+	NotToBeFocused(options ...LocatorAssertionsToBeFocusedOptions) error
+	// The opposite of LocatorAssertions.toBeHidden().
+	NotToBeHidden(options ...LocatorAssertionsToBeHiddenOptions) error
+	// The opposite of LocatorAssertions.toBeVisible().
+	NotToBeVisible(options ...LocatorAssertionsToBeVisibleOptions) error
+	// The opposite of LocatorAssertions.toContainText().
+	NotToContainText(expected interface{}, options ...LocatorAssertionsToContainTextOptions) error
+	// The opposite of LocatorAssertions.toHaveAttribute().
+	NotToHaveAttribute(name string, value interface{}, options ...LocatorAssertionsToHaveAttributeOptions) error
+	// The opposite of LocatorAssertions.toHaveClass().
+	NotToHaveClass(expected interface{}, options ...LocatorAssertionsToHaveClassOptions) error
+	// The opposite of LocatorAssertions.toHaveCount().
+	NotToHaveCount(count int, options ...LocatorAssertionsToHaveCountOptions) error
+	// The opposite of LocatorAssertions.toHaveCSS().
+	NotToHaveCSS(name string, value interface{}, options ...LocatorAssertionsToHaveCSSOptions) error
+	// The opposite of LocatorAssertions.toHaveId().
+	NotToHaveId(id interface{}, options ...LocatorAssertionsToHaveIdOptions) error
+	// The opposite of LocatorAssertions.toHaveJSProperty().
+	NotToHaveJSProperty(name string, value interface{}, options ...LocatorAssertionsToHaveJSPropertyOptions) error
+	// The opposite of LocatorAssertions.toHaveText().
+	NotToHaveText(expected interface{}, options ...LocatorAssertionsToHaveTextOptions) error
+	// The opposite of LocatorAssertions.toHaveValue().
+	NotToHaveValue(value interface{}, options ...LocatorAssertionsToHaveValueOptions) error
+	// The opposite of LocatorAssertions.toHaveValues().
+	NotToHaveValues(values []interface{}, options ...LocatorAssertionsToHaveValuesOptions) error
+}
+
 // The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.
 // Every `page` object has its own Mouse, accessible with [`property: Page.mouse`].
 type Mouse interface {
@@ -2240,6 +2404,10 @@ type Page interface {
 	// main resource response. In case of multiple redirects, the navigation will resolve with the response of the last
 	// redirect.
 	Reload(options ...PageReloadOptions) (Response, error)
+	// API testing helper associated with this page. This method returns the same instance as
+	// [`property: BrowserContext.request`] on the page's context. See [`property: BrowserContext.request`] for more
+	// details.
+	Request() APIRequestContext
 	// Routing provides the capability to modify network requests that are made by a page.
 	// Once routing is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or
 	// aborted.
@@ -2420,6 +2588,43 @@ type Page interface {
 	// Waits for the main frame to navigate to the given URL.
 	// **Usage**
 	WaitForURL(url string, options ...FrameWaitForURLOptions) error
+}
+
+// The `PageAssertions` class provides assertion methods that can be used to make assertions about the `Page` state in
+// the tests. A new instance of `PageAssertions` is created by calling PlaywrightAssertions.expectPage():
+type PageAssertions interface {
+	// Makes the assertion check for the opposite condition. For example, this code tests that the page URL doesn't
+	// contain `"error"`:
+	Not() PageAssertions
+	// Ensures the page has the given title.
+	// **Usage**
+	ToHaveTitle(titleOrRegExp interface{}, options ...PageAssertionsToHaveTitleOptions) error
+	// Ensures the page is navigated to the given URL.
+	// **Usage**
+	ToHaveURL(urlOrRegExp interface{}, options ...PageAssertionsToHaveURLOptions) error
+	// The opposite of PageAssertions.toHaveTitle().
+	NotToHaveTitle(titleOrRegExp interface{}, options ...PageAssertionsToHaveTitleOptions) error
+	// The opposite of PageAssertions.toHaveURL().
+	NotToHaveURL(urlOrRegExp interface{}, options ...PageAssertionsToHaveURLOptions) error
+}
+
+// Playwright gives you Web-First Assertions with convenience methods for creating assertions that will wait and retry
+// until the expected condition is met.
+// Consider the following example:
+// Playwright will be re-testing the node with the selector `.status` until fetched Node has the `"Submitted"` text.
+// It will be re-fetching the node and checking it over and over, until the condition is met or until the timeout is
+// reached. You can pass this timeout as an option.
+// By default, the timeout for assertions is set to 5 seconds.
+type PlaywrightAssertions interface {
+	// Creates a `APIResponseAssertions` object for the given `APIResponse`.
+	// **Usage**
+	APIResponse(response APIResponse) APIResponseAssertions
+	// Creates a `LocatorAssertions` object for the given `Locator`.
+	// **Usage**
+	Locator(locator Locator) LocatorAssertions
+	// Creates a `PageAssertions` object for the given `Page`.
+	// **Usage**
+	Page(page Page) PageAssertions
 }
 
 // Whenever the page sends a request for a network resource the following sequence of events are emitted by `Page`:

--- a/generated-interfaces.go
+++ b/generated-interfaces.go
@@ -2,7 +2,7 @@ package playwright
 
 // Exposes API that can be used for the Web API testing. This class is used for creating `APIRequestContext` instance
 // which in turn can be used for sending web requests. An instance of this class can be obtained via
-// [`property: Playwright.request`]. For more information see `APIRequestContext`.
+// Playwright.request(). For more information see `APIRequestContext`.
 type APIRequest interface {
 	EventEmitter
 	// Creates new instances of `APIRequestContext`.
@@ -12,11 +12,11 @@ type APIRequest interface {
 // This API is used for the Web API testing. You can use it to trigger API endpoints, configure micro-services,
 // prepare environment or the service to your e2e test.
 // Each Playwright browser context has associated with it `APIRequestContext` instance which shares cookie storage
-// with the browser context and can be accessed via [`property: BrowserContext.request`] or
-// [`property: Page.request`]. It is also possible to create a new APIRequestContext instance manually by calling
+// with the browser context and can be accessed via BrowserContext.request() or
+// Page.request(). It is also possible to create a new APIRequestContext instance manually by calling
 // APIRequest.newContext().
 // **Cookie management**
-// `APIRequestContext` returned by [`property: BrowserContext.request`] and [`property: Page.request`] shares cookie
+// `APIRequestContext` returned by BrowserContext.request() and Page.request() shares cookie
 // storage with the corresponding `BrowserContext`. Each API request will have `Cookie` header populated with the
 // values from the browser context. If the API response contains `Set-Cookie` header it will automatically update
 // `BrowserContext` cookies and requests made from the page will pick them up. This means that if you log in using
@@ -37,41 +37,10 @@ type APIRequestContext interface {
 	// Sends HTTP(S) request and returns its response. The method will populate request cookies from the context and
 	// update context cookies from the response. The method will automatically follow redirects. JSON objects can be
 	// passed directly to the request.
-	// **Usage**
-	// ```python
-	// data = {
-	// "title": "Book Title",
-	// "body": "John Doe",
-	// }
-	// api_request_context.fetch("https://example.com/api/createBook", method="post", data=data)
-	// ```
-	// The common way to send file(s) in the body of a request is to encode it as form fields with `multipart/form-data`
-	// encoding. You can achieve that with Playwright API like this:
-	// ```python
-	// api_request_context.fetch(
-	// "https://example.com/api/uploadScrip'",
-	// method="post",
-	// multipart={
-	// "fileField": {
-	// "name": "f.js",
-	// "mimeType": "text/javascript",
-	// "buffer": b"console.log(2022);",
-	// },
-	// })
-	// ```
 	Fetch(urlOrRequest interface{}, options ...APIRequestContextFetchOptions) (APIResponse, error)
 	// Sends HTTP(S) [GET](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET) request and returns its
 	// response. The method will populate request cookies from the context and update context cookies from the response.
 	// The method will automatically follow redirects.
-	// **Usage**
-	// Request parameters can be configured with `params` option, they will be serialized into the URL search parameters:
-	// ```python
-	// query_params = {
-	// "isbn": "1234",
-	// "page": "23"
-	// }
-	// api_request_context.get("https://example.com/api/getText", params=query_params)
-	// ```
 	Get(url string, options ...APIRequestContextGetOptions) (APIResponse, error)
 	// Sends HTTP(S) [HEAD](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD) request and returns its
 	// response. The method will populate request cookies from the context and update context cookies from the response.
@@ -80,38 +49,6 @@ type APIRequestContext interface {
 	// Sends HTTP(S) [POST](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST) request and returns its
 	// response. The method will populate request cookies from the context and update context cookies from the response.
 	// The method will automatically follow redirects.
-	// **Usage**
-	// JSON objects can be passed directly to the request:
-	// ```python
-	// data = {
-	// "title": "Book Title",
-	// "body": "John Doe",
-	// }
-	// api_request_context.post("https://example.com/api/createBook", data=data)
-	// ```
-	// To send form data to the server use `form` option. Its value will be encoded into the request body with
-	// `application/x-www-form-urlencoded` encoding (see below how to use `multipart/form-data` form encoding to send
-	// files):
-	// ```python
-	// formData = {
-	// "title": "Book Title",
-	// "body": "John Doe",
-	// }
-	// api_request_context.post("https://example.com/api/findBook", form=formData)
-	// ```
-	// The common way to send file(s) in the body of a request is to upload them as form fields with `multipart/form-data`
-	// encoding. You can achieve that with Playwright API like this:
-	// ```python
-	// api_request_context.post(
-	// "https://example.com/api/uploadScrip'",
-	// multipart={
-	// "fileField": {
-	// "name": "f.js",
-	// "mimeType": "text/javascript",
-	// "buffer": b"console.log(2022);",
-	// },
-	// })
-	// ```
 	Post(url string, options ...APIRequestContextPostOptions) (APIResponse, error)
 	// Sends HTTP(S) [PUT](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT) request and returns its
 	// response. The method will populate request cookies from the context and update context cookies from the response.
@@ -160,7 +97,6 @@ type APIResponseAssertions interface {
 	// successful:
 	Not() APIResponseAssertions
 	// Ensures the response status code is within `200..299` range.
-	// **Usage**
 	ToBeOK() error
 	// The opposite of APIResponseAssertions.toBeOK().
 	NotToBeOK() error
@@ -185,7 +121,6 @@ type Browser interface {
 	// The `Browser` object itself is considered to be disposed and cannot be used anymore.
 	Close() error
 	// Returns an array of all open browser contexts. In a newly created browser, this will return zero browser contexts.
-	// **Usage**
 	Contexts() []BrowserContext
 	// Indicates that the browser is connected.
 	IsConnected() bool
@@ -194,7 +129,6 @@ type Browser interface {
 	// returned context via BrowserContext.close() when your code is done with the `BrowserContext`, and before
 	// calling Browser.close(). This will ensure the `context` is closed gracefully and any artifacts—like HARs
 	// and videos—are fully flushed and saved.
-	// **Usage**
 	NewContext(options ...BrowserNewContextOptions) (BrowserContext, error)
 	// Creates a new page in a new browser context. Closing this page will close the context as well.
 	// This is a convenience API that should only be used for the single-page scenarios and short snippets. Production
@@ -208,9 +142,8 @@ type Browser interface {
 	// [Chromium Tracing](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool) which is a low-level
 	// chromium-specific debugging tool. API to control [Playwright Tracing](../trace-viewer) could be found
 	// [here](./class-tracing).
-	// You can use Browser.startTracing`] and [`method: Browser.stopTracing() to create a trace file that can be
+	// You can use Browser.startTracing() and Browser.stopTracing() to create a trace file that can be
 	// opened in Chrome DevTools performance panel.
-	// **Usage**
 	StartTracing(options ...BrowserStartTracingOptions) error
 	// **NOTE** This API controls
 	// [Chromium Tracing](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool) which is a low-level
@@ -247,7 +180,6 @@ type BrowserContext interface {
 	EventEmitter
 	// Adds cookies into this browser context. All pages within this context will have these cookies installed. Cookies
 	// can be obtained via BrowserContext.cookies().
-	// **Usage**
 	AddCookies(cookies ...OptionalCookie) error
 	// Adds a script which would be evaluated in one of the following scenarios:
 	// - Whenever a page is created in the browser context or is navigated.
@@ -255,17 +187,12 @@ type BrowserContext interface {
 	// evaluated in the context of the newly attached frame.
 	// The script is evaluated after the document was created but before any of its scripts were run. This is useful to
 	// amend the JavaScript environment, e.g. to seed `Math.random`.
-	// **Usage**
-	// An example of overriding `Math.random` before the page loads:
-	// **NOTE** The order of evaluation of multiple scripts installed via BrowserContext.addInitScript() and
-	// Page.addInitScript() is not defined.
 	AddInitScript(script BrowserContextAddInitScriptOptions) error
 	// Returns the browser instance of the context. If it was launched as a persistent context null gets returned.
 	Browser() Browser
 	// Clears context cookies.
 	ClearCookies() error
 	// Clears all permission overrides for the browser context.
-	// **Usage**
 	ClearPermissions() error
 	// Closes the browser context. All the pages that belong to the browser context will be closed.
 	// **NOTE** The default browser context cannot be closed.
@@ -275,7 +202,6 @@ type BrowserContext interface {
 	Cookies(urls ...string) ([]*Cookie, error)
 	// Waits for event to fire and passes its value into the predicate function. Returns when the predicate returns truthy
 	// value. Will throw an error if the context closes before the event is fired. Returns the event data value.
-	// **Usage**
 	ExpectEvent(event string, cb func() error, options ...BrowserContextWaitForEventOptions) (interface{}, error)
 	// Performs action and waits for a new `Page` to be created in the context. If predicate is provided, it passes `Page`
 	// value into the `predicate` function and waits for `predicate(event)` to return a truthy value. Will throw an error
@@ -287,16 +213,11 @@ type BrowserContext interface {
 	// The first argument of the `callback` function contains information about the caller: `{ browserContext:
 	// BrowserContext, page: Page, frame: Frame }`.
 	// See Page.exposeBinding() for page-only version.
-	// **Usage**
-	// An example of exposing page URL to all frames in all pages in the context:
-	// An example of passing an element handle:
 	ExposeBinding(name string, binding BindingCallFunction, handle ...bool) error
 	// The method adds a function called `name` on the `window` object of every frame in every page in the context. When
 	// called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`.
 	// If the `callback` returns a [Promise], it will be awaited.
 	// See Page.exposeFunction() for page-only version.
-	// **Usage**
-	// An example of adding a `sha256` function to all pages in the context:
 	ExposeFunction(name string, binding ExposedFunction) error
 	// Grants specified permissions to the browser context. Only grants corresponding permissions to the given origin if
 	// specified.
@@ -318,11 +239,11 @@ type BrowserContext interface {
 	// - Page.reload()
 	// - Page.setContent()
 	// - Page.waitForNavigation()
-	// **NOTE** Page.setDefaultNavigationTimeout`] and [`method: Page.setDefaultTimeout() take priority over
+	// **NOTE** Page.setDefaultNavigationTimeout() and Page.setDefaultTimeout() take priority over
 	// BrowserContext.setDefaultNavigationTimeout().
 	SetDefaultNavigationTimeout(timeout float64)
 	// This setting will change the default maximum time for all the methods accepting `timeout` option.
-	// **NOTE** Page.setDefaultNavigationTimeout`], [`method: Page.setDefaultTimeout() and
+	// **NOTE** Page.setDefaultNavigationTimeout(), Page.setDefaultTimeout() and
 	// BrowserContext.setDefaultNavigationTimeout() take priority over
 	// BrowserContext.setDefaultTimeout().
 	SetDefaultTimeout(timeout float64)
@@ -333,9 +254,6 @@ type BrowserContext interface {
 	// requests.
 	SetExtraHTTPHeaders(headers map[string]string) error
 	// Sets the context's geolocation. Passing `null` or `undefined` emulates position unavailable.
-	// **Usage**
-	// **NOTE** Consider using BrowserContext.grantPermissions() to grant permissions for the browser context
-	// pages to read its geolocation.
 	SetGeolocation(gelocation *Geolocation) error
 	// API testing helper associated with this context. Requests made with this API will use context cookies.
 	Request() APIRequestContext
@@ -345,15 +263,6 @@ type BrowserContext interface {
 	// **NOTE** BrowserContext.route() will not intercept requests intercepted by Service Worker. See
 	// [this](https://github.com/microsoft/playwright/issues/1090) issue. We recommend disabling Service Workers when
 	// using request interception by setting `Browser.newContext.serviceWorkers` to `'block'`.
-	// **Usage**
-	// An example of a naive handler that aborts all image requests:
-	// or the same snippet using a regex pattern instead:
-	// It is possible to examine the request to decide the route action. For example, mocking all requests that contain
-	// some post data, and leaving all other requests as is:
-	// Page routes (set up with Page.route()) take precedence over browser context routes when request matches
-	// both handlers.
-	// To remove a route with its handler you can use BrowserContext.unroute().
-	// **NOTE** Enabling routing disables http cache.
 	Route(url interface{}, handler routeHandler, times ...int) error
 	SetOffline(offline bool) error
 	// If specified the network requests that are made in the context will be served from the HAR file. Read more about
@@ -367,7 +276,7 @@ type BrowserContext interface {
 	// Removes a route created with BrowserContext.route(). When `handler` is not specified, removes all routes
 	// for the `url`.
 	Unroute(url interface{}, handler ...routeHandler) error
-	// **NOTE** In most cases, you should use BrowserContext.waitForEvent().
+	// **NOTE** In most cases, you should use BrowserContext.ExpectForEvent().
 	// Waits for given `event` to fire. If predicate is provided, it passes event's value into the `predicate` function
 	// and waits for `predicate(event)` to return a truthy value. Will throw an error if the browser context is closed
 	// before the `event` is fired.
@@ -383,14 +292,12 @@ type BrowserContext interface {
 // Start recording a trace before performing actions. At the end, stop tracing and save it to a file.
 type Tracing interface {
 	// Start tracing.
-	// **Usage**
 	Start(options ...TracingStartOptions) error
 	// Stop tracing.
 	Stop(options ...TracingStopOptions) error
 	// Start a new trace chunk. If you'd like to record multiple traces on the same `BrowserContext`, use
-	// Tracing.start`] once, and then create multiple trace chunks with [`method: Tracing.startChunk() and
+	// Tracing.start() once, and then create multiple trace chunks with Tracing.startChunk() and
 	// Tracing.stopChunk().
-	// **Usage**
 	StartChunk(options ...TracingStartChunkOptions) error
 	// Stop the trace chunk. See Tracing.startChunk() for more details about multiple trace chunks.
 	StopChunk(options ...TracingStopChunkOptions) error
@@ -402,22 +309,6 @@ type BrowserType interface {
 	// A path where Playwright expects to find a bundled browser executable.
 	ExecutablePath() string
 	// Returns the browser instance.
-	// **Usage**
-	// You can use `ignoreDefaultArgs` to filter out `--mute-audio` from default arguments:
-	// > **Chromium-only** Playwright can also be used to control the Google Chrome or Microsoft Edge browsers, but it
-	// works best with the version of Chromium it is bundled with. There is no guarantee it will work with any other
-	// version. Use `executablePath` option with extreme caution.
-	// >
-	// > If Google Chrome (rather than Chromium) is preferred, a
-	// [Chrome Canary](https://www.google.com/chrome/browser/canary.html) or
-	// [Dev Channel](https://www.chromium.org/getting-involved/dev-channel) build is suggested.
-	// >
-	// > Stock browsers like Google Chrome and Microsoft Edge are suitable for tests that require proprietary media codecs
-	// for video playback. See
-	// [this article](https://www.howtogeek.com/202825/what%E2%80%99s-the-difference-between-chromium-and-chrome/) for
-	// other differences between Chromium and Chrome.
-	// [This article](https://chromium.googlesource.com/chromium/src/+/lkgr/docs/chromium_browser_vs_google_chrome.md)
-	// describes some differences for Linux users.
 	Launch(options ...BrowserTypeLaunchOptions) (Browser, error)
 	// Returns the persistent browser context instance.
 	// Launches browser that uses persistent storage located at `userDataDir` and returns the only context. Closing this
@@ -432,7 +323,6 @@ type BrowserType interface {
 	// This method attaches Playwright to an existing browser instance using the Chrome DevTools Protocol.
 	// The default browser context is accessible via Browser.contexts().
 	// **NOTE** Connecting over the Chrome DevTools Protocol is only supported for Chromium-based browsers.
-	// **Usage**
 	ConnectOverCDP(endpointURL string, options ...BrowserTypeConnectOverCDPOptions) (Browser, error)
 }
 
@@ -454,7 +344,7 @@ type ConsoleMessage interface {
 // `Dialog` objects are dispatched by page via the [`event: Page.dialog`] event.
 // An example of using `Dialog` class:
 // **NOTE** Dialogs are dismissed automatically, unless there is a [`event: Page.dialog`] listener. When listener is
-// present, it **must** either Dialog.accept`] or [`method: Dialog.dismiss() the dialog - otherwise the page
+// present, it **must** either Dialog.accept() or Dialog.dismiss() the dialog - otherwise the page
 // will [freeze](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking) waiting for the
 // dialog, and actions like click will never finish.
 type Dialog interface {
@@ -506,7 +396,7 @@ type Download interface {
 // **NOTE** The use of ElementHandle is discouraged, use `Locator` objects and web-first assertions instead.
 // ElementHandle prevents DOM element from garbage collection unless the handle is disposed with
 // JSHandle.dispose(). ElementHandles are auto-disposed when their origin frame gets navigated.
-// ElementHandle instances can be used as an argument in Page.evalOnSelector`] and [`method: Page.evaluate()
+// ElementHandle instances can be used as an argument in Page.evalOnSelector() and Page.evaluate()
 // methods.
 // The difference between the `Locator` and ElementHandle is that the ElementHandle points to a particular element,
 // while `Locator` captures the logic of how to retrieve an element.
@@ -526,14 +416,13 @@ type ElementHandle interface {
 	// [Element.getBoundingClientRect](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect).
 	// Assuming the page is static, it is safe to use bounding box coordinates to perform input. For example, the
 	// following snippet should click the center of the element.
-	// **Usage**
 	BoundingBox() (*Rect, error)
 	// This method checks the element by performing the following steps:
 	// 1. Ensure that element is a checkbox or a radio input. If not, this method throws. If the element is already
 	// checked, this method returns immediately.
 	// 1. Wait for [actionability](../actionability.md) checks on the element, unless `force` option is set.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to click in the center of the element.
+	// 1. Use Page.mouse() to click in the center of the element.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// 1. Ensure that the element is now checked. If not, this method throws.
 	// If the element is detached from the DOM at any moment during the action, this method throws.
@@ -546,7 +435,7 @@ type ElementHandle interface {
 	// 1. Wait for [actionability](../actionability.md) checks on the matched element, unless `force` option is set. If
 	// the element is detached during the checks, the whole action is retried.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to click in the center of the element.
+	// 1. Use Page.mouse() to click in the center of the element.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// 1. Ensure that the element is now checked or unchecked. If not, this method throws.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
@@ -555,7 +444,7 @@ type ElementHandle interface {
 	// This method clicks the element by performing the following steps:
 	// 1. Wait for [actionability](../actionability.md) checks on the element, unless `force` option is set.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to click in the center of the element, or the specified `position`.
+	// 1. Use Page.mouse() to click in the center of the element, or the specified `position`.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// If the element is detached from the DOM at any moment during the action, this method throws.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
@@ -566,7 +455,7 @@ type ElementHandle interface {
 	// This method double clicks the element by performing the following steps:
 	// 1. Wait for [actionability](../actionability.md) checks on the element, unless `force` option is set.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to double click in the center of the element, or the specified `position`.
+	// 1. Use Page.mouse() to double click in the center of the element, or the specified `position`.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set. Note that if
 	// the first click of the `dblclick()` triggers a navigation event, this method will throw.
 	// If the element is detached from the DOM at any moment during the action, this method throws.
@@ -577,38 +466,18 @@ type ElementHandle interface {
 	// The snippet below dispatches the `click` event on the element. Regardless of the visibility state of the element,
 	// `click` is dispatched. This is equivalent to calling
 	// [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
-	// **Usage**
-	// Under the hood, it creates an instance of an event based on the given `type`, initializes it with `eventInit`
-	// properties and dispatches it on the element. Events are `composed`, `cancelable` and bubble by default.
-	// Since `eventInit` is event-specific, please refer to the events documentation for the lists of initial properties:
-	// - [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)
-	// - [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)
-	// - [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)
-	// - [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)
-	// - [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)
-	// - [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)
-	// - [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)
-	// You can also specify `JSHandle` as the property value if you want live objects to be passed into the event:
 	DispatchEvent(typ string, initObjects ...interface{}) error
 	// Returns the return value of `expression`.
 	// The method finds an element matching the specified selector in the `ElementHandle`s subtree and passes it as a
 	// first argument to `expression`. If no elements match the selector, the method throws an error.
 	// If `expression` returns a [Promise], then ElementHandle.evalOnSelector() would wait for the promise to
 	// resolve and return its value.
-	// **Usage**
 	EvalOnSelector(selector string, expression string, options ...interface{}) (interface{}, error)
 	// Returns the return value of `expression`.
 	// The method finds all elements matching the specified selector in the `ElementHandle`'s subtree and passes an array
 	// of matched elements as a first argument to `expression`.
 	// If `expression` returns a [Promise], then ElementHandle.evalOnSelectorAll() would wait for the promise to
 	// resolve and return its value.
-	// **Usage**
-	// ```html
-	// <div class="feed">
-	// <div class="tweet">Hello!</div>
-	// <div class="tweet">Hi!</div>
-	// </div>
-	// ```
 	EvalOnSelectorAll(selector string, expression string, options ...interface{}) (interface{}, error)
 	// This method waits for [actionability](../actionability.md) checks, focuses the element, fills it and triggers an
 	// `input` event after filling. Note that you can pass an empty string to clear the input field.
@@ -625,7 +494,7 @@ type ElementHandle interface {
 	// This method hovers over the element by performing the following steps:
 	// 1. Wait for [actionability](../actionability.md) checks on the element, unless `force` option is set.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to hover over the center of the element, or the specified `position`.
+	// 1. Use Page.mouse() to hover over the center of the element, or the specified `position`.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// If the element is detached from the DOM at any moment during the action, this method throws.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
@@ -649,7 +518,7 @@ type ElementHandle interface {
 	IsVisible() (bool, error)
 	// Returns the frame containing the given element.
 	OwnerFrame() (Frame, error)
-	// Focuses the element, and then uses Keyboard.down`] and [`method: Keyboard.up().
+	// Focuses the element, and then uses Keyboard.down() and Keyboard.up().
 	// `key` can specify the intended
 	// [keyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) value or a single character
 	// to generate the text for. A superset of the `key` values can be found
@@ -691,7 +560,6 @@ type ElementHandle interface {
 	// instead.
 	// Returns the array of option values that have been successfully selected.
 	// Triggers a `change` and `input` event once all the provided options have been selected.
-	// **Usage**
 	SelectOption(values SelectOptionValues, options ...ElementHandleSelectOptionOptions) ([]string, error)
 	// This method waits for [actionability](../actionability.md) checks, then focuses the element and selects all its
 	// text content.
@@ -709,7 +577,7 @@ type ElementHandle interface {
 	// This method taps the element by performing the following steps:
 	// 1. Wait for [actionability](../actionability.md) checks on the element, unless `force` option is set.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.touchscreen`] to tap the center of the element, or the specified `position`.
+	// 1. Use Page.touchscreen() to tap the center of the element, or the specified `position`.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// If the element is detached from the DOM at any moment during the action, this method throws.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
@@ -721,15 +589,13 @@ type ElementHandle interface {
 	// Focuses the element, and then sends a `keydown`, `keypress`/`input`, and `keyup` event for each character in the
 	// text.
 	// To press a special key, like `Control` or `ArrowDown`, use ElementHandle.press().
-	// **Usage**
-	// An example of typing into a text field and then submitting the form:
 	Type(value string, options ...ElementHandleTypeOptions) error
 	// This method checks the element by performing the following steps:
 	// 1. Ensure that element is a checkbox or a radio input. If not, this method throws. If the element is already
 	// unchecked, this method returns immediately.
 	// 1. Wait for [actionability](../actionability.md) checks on the element, unless `force` option is set.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to click in the center of the element.
+	// 1. Use Page.mouse() to click in the center of the element.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// 1. Ensure that the element is now unchecked. If not, this method throws.
 	// If the element is detached from the DOM at any moment during the action, this method throws.
@@ -756,8 +622,6 @@ type ElementHandle interface {
 	// or become visible/hidden). If at the moment of calling the method `selector` already satisfies the condition, the
 	// method will return immediately. If the selector doesn't satisfy the condition for the `timeout` milliseconds, the
 	// function will throw.
-	// **Usage**
-	// **NOTE** This method does not work across navigations, use Page.waitForSelector() instead.
 	WaitForSelector(selector string, options ...ElementHandleWaitForSelectorOptions) (ElementHandle, error)
 	// Returns `input.value` for the selected `<input>` or `<textarea>` or `<select>` element.
 	// Throws for non-input elements. However, if the element is inside the `<label>` element that has an associated
@@ -804,7 +668,7 @@ type Frame interface {
 	// 1. Wait for [actionability](../actionability.md) checks on the matched element, unless `force` option is set. If
 	// the element is detached during the checks, the whole action is retried.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to click in the center of the element.
+	// 1. Use Page.mouse() to click in the center of the element.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// 1. Ensure that the element is now checked or unchecked. If not, this method throws.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
@@ -824,7 +688,7 @@ type Frame interface {
 	// 1. Wait for [actionability](../actionability.md) checks on the matched element, unless `force` option is set. If
 	// the element is detached during the checks, the whole action is retried.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to click in the center of the element.
+	// 1. Use Page.mouse() to click in the center of the element.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// 1. Ensure that the element is now checked. If not, this method throws.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
@@ -836,7 +700,7 @@ type Frame interface {
 	// 1. Wait for [actionability](../actionability.md) checks on the matched element, unless `force` option is set. If
 	// the element is detached during the checks, the whole action is retried.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to click in the center of the element, or the specified `position`.
+	// 1. Use Page.mouse() to click in the center of the element, or the specified `position`.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
 	// Passing zero timeout disables this.
@@ -848,7 +712,7 @@ type Frame interface {
 	// 1. Wait for [actionability](../actionability.md) checks on the matched element, unless `force` option is set. If
 	// the element is detached during the checks, the whole action is retried.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to double click in the center of the element, or the specified `position`.
+	// 1. Use Page.mouse() to double click in the center of the element, or the specified `position`.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set. Note that if
 	// the first click of the `dblclick()` triggers a navigation event, this method will throw.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
@@ -858,51 +722,31 @@ type Frame interface {
 	// The snippet below dispatches the `click` event on the element. Regardless of the visibility state of the element,
 	// `click` is dispatched. This is equivalent to calling
 	// [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
-	// **Usage**
-	// Under the hood, it creates an instance of an event based on the given `type`, initializes it with `eventInit`
-	// properties and dispatches it on the element. Events are `composed`, `cancelable` and bubble by default.
-	// Since `eventInit` is event-specific, please refer to the events documentation for the lists of initial properties:
-	// - [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)
-	// - [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)
-	// - [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)
-	// - [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)
-	// - [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)
-	// - [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)
-	// - [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)
-	// You can also specify `JSHandle` as the property value if you want live objects to be passed into the event:
 	DispatchEvent(selector, typ string, eventInit interface{}, options ...PageDispatchEventOptions) error
 	// Returns the return value of `expression`.
-	// If the function passed to the Frame.evaluate`] returns a [Promise], then [`method: Frame.evaluate() would
+	// If the function passed to the Frame.evaluate() returns a [Promise], then Frame.evaluate() would
 	// wait for the promise to resolve and return its value.
 	// If the function passed to the Frame.evaluate() returns a non-[Serializable] value, then
 	// Frame.evaluate() returns `undefined`. Playwright also supports transferring some additional values that
 	// are not serializable by `JSON`: `-0`, `NaN`, `Infinity`, `-Infinity`.
-	// **Usage**
-	// A string can also be passed in instead of a function.
-	// `ElementHandle` instances can be passed as an argument to the Frame.evaluate():
 	Evaluate(expression string, options ...interface{}) (interface{}, error)
 	// Returns the return value of `expression` as a `JSHandle`.
-	// The only difference between Frame.evaluate`] and [`method: Frame.evaluateHandle() is that
+	// The only difference between Frame.evaluate() and Frame.evaluateHandle() is that
 	// Frame.evaluateHandle() returns `JSHandle`.
 	// If the function, passed to the Frame.evaluateHandle(), returns a [Promise], then
 	// Frame.evaluateHandle() would wait for the promise to resolve and return its value.
-	// **Usage**
-	// A string can also be passed in instead of a function.
-	// `JSHandle` instances can be passed as an argument to the Frame.evaluateHandle():
 	EvaluateHandle(expression string, options ...interface{}) (JSHandle, error)
 	// Returns the return value of `expression`.
 	// The method finds an element matching the specified selector within the frame and passes it as a first argument to
 	// `expression`. If no elements match the selector, the method throws an error.
 	// If `expression` returns a [Promise], then Frame.evalOnSelector() would wait for the promise to resolve
 	// and return its value.
-	// **Usage**
 	EvalOnSelector(selector string, expression string, options ...interface{}) (interface{}, error)
 	// Returns the return value of `expression`.
 	// The method finds all elements matching the specified selector within the frame and passes an array of matched
 	// elements as a first argument to `expression`.
 	// If `expression` returns a [Promise], then Frame.evalOnSelectorAll() would wait for the promise to resolve
 	// and return its value.
-	// **Usage**
 	EvalOnSelectorAll(selector string, expression string, options ...interface{}) (interface{}, error)
 	// This method waits for an element matching `selector`, waits for [actionability](../actionability.md) checks,
 	// focuses the element, fills it and triggers an `input` event after filling. Note that you can pass an empty string
@@ -920,95 +764,29 @@ type Frame interface {
 	// This is an inverse of ElementHandle.contentFrame(). Note that returned handle actually belongs to the
 	// parent frame.
 	// This method throws an error if the frame has been detached before `frameElement()` returns.
-	// **Usage**
 	FrameElement() (ElementHandle, error)
 	// When working with iframes, you can create a frame locator that will enter the iframe and allow selecting elements
 	// in that iframe.
-	// **Usage**
-	// Following snippet locates element with text "Submit" in the iframe with id `my-frame`, like `<iframe
-	// id="my-frame">`:
 	FrameLocator(selector string) FrameLocator
 	// Returns element attribute value.
 	GetAttribute(selector string, name string, options ...PageGetAttributeOptions) (string, error)
 	// Allows locating elements by their alt text.
-	// **Usage**
-	// For example, this method will find the image by alt text "Playwright logo":
-	// ```html
-	// <img alt='Playwright logo'>
-	// ```
 	GetByAltText(text interface{}, options ...LocatorGetByAltTextOptions) (Locator, error)
 	// Allows locating input elements by the text of the associated label.
-	// **Usage**
-	// For example, this method will find the input by label text "Password" in the following DOM:
-	// ```html
-	// <label for="password-input">Password:</label>
-	// <input id="password-input">
-	// ```
 	GetByLabel(text interface{}, options ...LocatorGetByLabelOptions) (Locator, error)
 	// Allows locating input elements by the placeholder text.
-	// **Usage**
-	// For example, consider the following DOM structure.
-	// ```html
-	// <input type="email" placeholder="name@example.com" />
-	// ```
-	// You can fill the input after locating it by the placeholder text:
 	GetByPlaceholder(text interface{}, options ...LocatorGetByPlaceholderOptions) (Locator, error)
 	// Allows locating elements by their [ARIA role](https://www.w3.org/TR/wai-aria-1.2/#roles),
 	// [ARIA attributes](https://www.w3.org/TR/wai-aria-1.2/#aria-attributes) and
 	// [accessible name](https://w3c.github.io/accname/#dfn-accessible-name).
-	// **Usage**
-	// Consider the following DOM structure.
-	// ```html
-	// <h3>Sign up</h3>
-	// <label>
-	// <input type="checkbox" /> Subscribe
-	// </label>
-	// <br/>
-	// <button>Submit</button>
-	// ```
-	// You can locate each element by it's implicit role:
-	// **Details**
-	// Role selector **does not replace** accessibility audits and conformance tests, but rather gives early feedback
-	// about the ARIA guidelines.
-	// Many html elements have an implicitly [defined role](https://w3c.github.io/html-aam/#html-element-role-mappings)
-	// that is recognized by the role selector. You can find all the
-	// [supported roles here](https://www.w3.org/TR/wai-aria-1.2/#role_definitions). ARIA guidelines **do not recommend**
-	// duplicating implicit roles and attributes by setting `role` and/or `aria-*` attributes to default values.
 	GetByRole(role AriaRole, options ...LocatorGetByRoleOptions) (Locator, error)
 	// Locate element by the test id.
-	// **Usage**
-	// Consider the following DOM structure.
-	// ```html
-	// <button data-testid="directions">Itinéraire</button>
-	// ```
-	// You can locate the element by it's test id:
-	// **Details**
-	// By default, the `data-testid` attribute is used as a test id. Use Selectors.setTestIdAttribute() to
-	// configure a different test id attribute if necessary.
 	GetByTestId(testId interface{}) (Locator, error)
 	// Allows locating elements that contain given text.
 	// See also Locator.filter() that allows to match by another criteria, like an accessible role, and then
 	// filter by the text content.
-	// **Usage**
-	// Consider the following DOM structure:
-	// ```html
-	// <div>Hello <span>world</span></div>
-	// <div>Hello</div>
-	// ```
-	// You can locate by text substring, exact string, or a regular expression:
-	// **Details**
-	// Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into
-	// one, turns line breaks into spaces and ignores leading and trailing whitespace.
-	// Input elements of the type `button` and `submit` are matched by their `value` instead of the text content. For
-	// example, locating by text `"Log in"` matches `<input type=button value="Log in">`.
 	GetByText(text interface{}, options ...LocatorGetByTextOptions) (Locator, error)
 	// Allows locating elements by their title attribute.
-	// **Usage**
-	// Consider the following DOM structure.
-	// ```html
-	// <span title='Issues count'>25 issues</span>
-	// ```
-	// You can check the issues count after locating it by the title text:
 	GetByTitle(title interface{}, options ...LocatorGetByTitleOptions) (Locator, error)
 	// Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of
 	// the last redirect.
@@ -1031,7 +809,7 @@ type Frame interface {
 	// 1. Wait for [actionability](../actionability.md) checks on the matched element, unless `force` option is set. If
 	// the element is detached during the checks, the whole action is retried.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to hover over the center of the element, or the specified `position`.
+	// 1. Use Page.mouse() to hover over the center of the element, or the specified `position`.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
 	// Passing zero timeout disables this.
@@ -1104,7 +882,6 @@ type Frame interface {
 	// instead.
 	// Returns the array of option values that have been successfully selected.
 	// Triggers a `change` and `input` event once all the provided options have been selected.
-	// **Usage**
 	SelectOption(selector string, values SelectOptionValues, options ...FrameSelectOptionOptions) ([]string, error)
 	// Sets the value of the file input to these file paths or files. If some of the `filePaths` are relative paths, then
 	// they are resolved relative to the current working directory. For empty array, clears the selected files.
@@ -1118,7 +895,7 @@ type Frame interface {
 	// 1. Wait for [actionability](../actionability.md) checks on the matched element, unless `force` option is set. If
 	// the element is detached during the checks, the whole action is retried.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.touchscreen`] to tap the center of the element, or the specified `position`.
+	// 1. Use Page.touchscreen() to tap the center of the element, or the specified `position`.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
 	// Passing zero timeout disables this.
@@ -1131,7 +908,6 @@ type Frame interface {
 	// Sends a `keydown`, `keypress`/`input`, and `keyup` event for each character in the text. `frame.type` can be used
 	// to send fine-grained keyboard events. To fill values in form fields, use Frame.fill().
 	// To press a special key, like `Control` or `ArrowDown`, use Keyboard.press().
-	// **Usage**
 	Type(selector, text string, options ...PageTypeOptions) error
 	// Returns frame's url.
 	URL() string
@@ -1142,7 +918,7 @@ type Frame interface {
 	// 1. Wait for [actionability](../actionability.md) checks on the matched element, unless `force` option is set. If
 	// the element is detached during the checks, the whole action is retried.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to click in the center of the element.
+	// 1. Use Page.mouse() to click in the center of the element.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// 1. Ensure that the element is now unchecked. If not, this method throws.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
@@ -1150,27 +926,17 @@ type Frame interface {
 	Uncheck(selector string, options ...FrameUncheckOptions) error
 	WaitForEvent(event string, options ...PageWaitForEventOptions) (interface{}, error)
 	// Returns when the `expression` returns a truthy value, returns that value.
-	// **Usage**
-	// The Frame.waitForFunction() can be used to observe viewport size change:
-	// To pass an argument to the predicate of `frame.waitForFunction` function:
 	WaitForFunction(expression string, arg interface{}, options ...FrameWaitForFunctionOptions) (JSHandle, error)
 	// Waits for the required load state to be reached.
 	// This returns when the frame reaches a required load state, `load` by default. The navigation must have been
 	// committed when this method is called. If current document has already reached the required state, resolves
 	// immediately.
-	// **Usage**
 	WaitForLoadState(options ...PageWaitForLoadStateOptions) error
 	// Waits for the frame navigation and returns the main resource response. In case of multiple redirects, the
 	// navigation will resolve with the response of the last redirect. In case of navigation to a different anchor or
 	// navigation due to History API usage, the navigation will resolve with `null`.
-	// **Usage**
-	// This method waits for the frame to navigate to a new URL. It is useful for when you run code which will indirectly
-	// cause the frame to navigate. Consider this example:
-	// **NOTE** Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to change the URL
-	// is considered a navigation.
 	WaitForNavigation(options ...PageWaitForNavigationOptions) (Response, error)
 	// Waits for the frame to navigate to the given URL.
-	// **Usage**
 	WaitForURL(url string, options ...FrameWaitForURLOptions) error
 	// Returns when element specified by selector satisfies `state` option. Returns `null` if waiting for `hidden` or
 	// `detached`.
@@ -1179,8 +945,6 @@ type Frame interface {
 	// Wait for the `selector` to satisfy `state` option (either appear/disappear from dom, or become visible/hidden). If
 	// at the moment of calling the method `selector` already satisfies the condition, the method will return immediately.
 	// If the selector doesn't satisfy the condition for the `timeout` milliseconds, the function will throw.
-	// **Usage**
-	// This method works across navigations:
 	WaitForSelector(selector string, options ...PageWaitForSelectorOptions) (ElementHandle, error)
 	// Waits for the given `timeout` in milliseconds.
 	// Note that `frame.waitForTimeout()` should only be used for debugging. Tests using the timer in production are going
@@ -1216,84 +980,22 @@ type FrameLocator interface {
 	// [Learn more about locators](../locators.md).
 	Locator(selector string, options ...LocatorLocatorOptions) (Locator, error)
 	// Allows locating elements by their alt text.
-	// **Usage**
-	// For example, this method will find the image by alt text "Playwright logo":
-	// ```html
-	// <img alt='Playwright logo'>
-	// ```
 	GetByAltText(text interface{}, options ...LocatorGetByAltTextOptions) (Locator, error)
 	// Allows locating input elements by the text of the associated label.
-	// **Usage**
-	// For example, this method will find the input by label text "Password" in the following DOM:
-	// ```html
-	// <label for="password-input">Password:</label>
-	// <input id="password-input">
-	// ```
 	GetByLabel(text interface{}, options ...LocatorGetByLabelOptions) (Locator, error)
 	// Allows locating input elements by the placeholder text.
-	// **Usage**
-	// For example, consider the following DOM structure.
-	// ```html
-	// <input type="email" placeholder="name@example.com" />
-	// ```
-	// You can fill the input after locating it by the placeholder text:
 	GetByPlaceholder(text interface{}, options ...LocatorGetByPlaceholderOptions) (Locator, error)
 	// Allows locating elements by their [ARIA role](https://www.w3.org/TR/wai-aria-1.2/#roles),
 	// [ARIA attributes](https://www.w3.org/TR/wai-aria-1.2/#aria-attributes) and
 	// [accessible name](https://w3c.github.io/accname/#dfn-accessible-name).
-	// **Usage**
-	// Consider the following DOM structure.
-	// ```html
-	// <h3>Sign up</h3>
-	// <label>
-	// <input type="checkbox" /> Subscribe
-	// </label>
-	// <br/>
-	// <button>Submit</button>
-	// ```
-	// You can locate each element by it's implicit role:
-	// **Details**
-	// Role selector **does not replace** accessibility audits and conformance tests, but rather gives early feedback
-	// about the ARIA guidelines.
-	// Many html elements have an implicitly [defined role](https://w3c.github.io/html-aam/#html-element-role-mappings)
-	// that is recognized by the role selector. You can find all the
-	// [supported roles here](https://www.w3.org/TR/wai-aria-1.2/#role_definitions). ARIA guidelines **do not recommend**
-	// duplicating implicit roles and attributes by setting `role` and/or `aria-*` attributes to default values.
 	GetByRole(role AriaRole, options ...LocatorGetByRoleOptions) (Locator, error)
 	// Locate element by the test id.
-	// **Usage**
-	// Consider the following DOM structure.
-	// ```html
-	// <button data-testid="directions">Itinéraire</button>
-	// ```
-	// You can locate the element by it's test id:
-	// **Details**
-	// By default, the `data-testid` attribute is used as a test id. Use Selectors.setTestIdAttribute() to
-	// configure a different test id attribute if necessary.
 	GetByTestId(testId interface{}) (Locator, error)
 	// Allows locating elements that contain given text.
 	// See also Locator.filter() that allows to match by another criteria, like an accessible role, and then
 	// filter by the text content.
-	// **Usage**
-	// Consider the following DOM structure:
-	// ```html
-	// <div>Hello <span>world</span></div>
-	// <div>Hello</div>
-	// ```
-	// You can locate by text substring, exact string, or a regular expression:
-	// **Details**
-	// Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into
-	// one, turns line breaks into spaces and ignores leading and trailing whitespace.
-	// Input elements of the type `button` and `submit` are matched by their `value` instead of the text content. For
-	// example, locating by text `"Log in"` matches `<input type=button value="Log in">`.
 	GetByText(text interface{}, options ...LocatorGetByTextOptions) (Locator, error)
 	// Allows locating elements by their title attribute.
-	// **Usage**
-	// Consider the following DOM structure.
-	// ```html
-	// <span title='Issues count'>25 issues</span>
-	// ```
-	// You can check the issues count after locating it by the title text:
 	GetByTitle(title interface{}, options ...LocatorGetByTitleOptions) (Locator, error)
 	// Returns locator to the n-th matching frame. It's zero based, `nth(0)` selects the first frame.
 	Nth(index int) FrameLocator
@@ -1304,7 +1006,7 @@ type FrameLocator interface {
 // JSHandle prevents the referenced JavaScript object being garbage collected unless the handle is exposed with
 // JSHandle.dispose(). JSHandles are auto-disposed when their origin frame gets navigated or the parent
 // context gets destroyed.
-// JSHandle instances can be used as an argument in Page.evalOnSelector`], [`method: Page.evaluate() and
+// JSHandle instances can be used as an argument in Page.evalOnSelector(), Page.evaluate() and
 // Page.evaluateHandle() methods.
 type JSHandle interface {
 	// Returns either `null` or the object handle itself, if the object handle is an instance of `ElementHandle`.
@@ -1315,7 +1017,6 @@ type JSHandle interface {
 	// This method passes this handle as the first argument to `expression`.
 	// If `expression` returns a [Promise], then `handle.evaluate` would wait for the promise to resolve and return its
 	// value.
-	// **Usage**
 	Evaluate(expression string, options ...interface{}) (interface{}, error)
 	// Returns the return value of `expression` as a `JSHandle`.
 	// This method passes this handle as the first argument to `expression`.
@@ -1326,7 +1027,6 @@ type JSHandle interface {
 	// See Page.evaluateHandle() for more details.
 	EvaluateHandle(expression string, options ...interface{}) (JSHandle, error)
 	// The method returns a map with **own property names** as keys and JSHandle instances for the property values.
-	// **Usage**
 	GetProperties() (map[string]JSHandle, error)
 	// Fetches a single property from the referenced object.
 	GetProperty(name string) (JSHandle, error)
@@ -1339,7 +1039,7 @@ type JSHandle interface {
 
 // Keyboard provides an api for managing a virtual keyboard. The high level api is Keyboard.type(), which
 // takes raw characters and generates proper `keydown`, `keypress`/`input`, and `keyup` events on your page.
-// For finer control, you can use Keyboard.down`], [`method: Keyboard.up(), and
+// For finer control, you can use Keyboard.down(), Keyboard.up(), and
 // Keyboard.insertText() to manually fire events as if they were generated from a real keyboard.
 // An example of holding down `Shift` in order to select and delete some text:
 // An example of pressing uppercase `A`
@@ -1365,9 +1065,6 @@ type Keyboard interface {
 	// **NOTE** Modifier keys DO influence `keyboard.down`. Holding down `Shift` will type the text in upper case.
 	Down(key string) error
 	// Dispatches only `input` event, does not emit the `keydown`, `keyup` or `keypress` events.
-	// **Usage**
-	// **NOTE** Modifier keys DO NOT effect `keyboard.insertText`. Holding down `Shift` will not type the text in upper
-	// case.
 	InsertText(text string) error
 	// `key` can specify the intended
 	// [keyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) value or a single character
@@ -1382,14 +1079,9 @@ type Keyboard interface {
 	// texts.
 	// Shortcuts such as `key: "Control+o"` or `key: "Control+Shift+T"` are supported as well. When specified with the
 	// modifier, modifier is pressed and being held while the subsequent key is being pressed.
-	// **Usage**
-	// Shortcut for Keyboard.down`] and [`method: Keyboard.up().
 	Press(key string, options ...KeyboardPressOptions) error
 	// Sends a `keydown`, `keypress`/`input`, and `keyup` event for each character in the text.
 	// To press a special key, like `Control` or `ArrowDown`, use Keyboard.press().
-	// **Usage**
-	// **NOTE** Modifier keys DO NOT effect `keyboard.type`. Holding down `Shift` will not type the text in upper case.
-	// **NOTE** For characters that are not on a US keyboard, only an `input` event will be sent.
 	Type(text string, options ...KeyboardTypeOptions) error
 	// Dispatches a `keyup` event.
 	Up(key string) error
@@ -1400,13 +1092,10 @@ type Keyboard interface {
 // [Learn more about locators](../locators.md).
 type Locator interface {
 	// When locator points to a list of elements, returns array of locators, pointing to respective elements.
-	// **Usage**
 	All() ([]Locator, error)
 	// Returns an array of `node.innerText` values for all matching nodes.
-	// **Usage**
 	AllInnerTexts() ([]string, error)
 	// Returns an array of `node.textContent` values for all matching nodes.
-	// **Usage**
 	AllTextContents() ([]string, error)
 	// Calls [blur](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/blur) on the element.
 	Blur(options ...LocatorBlurOptions) error
@@ -1421,7 +1110,6 @@ type Locator interface {
 	// [Element.getBoundingClientRect](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect).
 	// Assuming the page is static, it is safe to use bounding box coordinates to perform input. For example, the
 	// following snippet should click the center of the element.
-	// **Usage**
 	BoundingBox(options ...LocatorBoundingBoxOptions) (*Rect, error)
 	// Ensure that checkbox or radio element is checked.
 	// **Details**
@@ -1430,13 +1118,12 @@ type Locator interface {
 	// checked, this method returns immediately.
 	// 1. Wait for [actionability](../actionability.md) checks on the element, unless `force` option is set.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to click in the center of the element.
+	// 1. Use Page.mouse() to click in the center of the element.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// 1. Ensure that the element is now checked. If not, this method throws.
 	// If the element is detached from the DOM at any moment during the action, this method throws.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
 	// Passing zero timeout disables this.
-	// **Usage**
 	Check(options ...FrameCheckOptions) error
 	// Clear the input field.
 	// **Details**
@@ -1446,31 +1133,26 @@ type Locator interface {
 	// error. However, if the element is inside the `<label>` element that has an associated
 	// [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be cleared
 	// instead.
-	// **Usage**
 	Clear(options ...LocatorClearOptions) error
 	// Click an element.
 	// **Details**
 	// This method clicks the element by performing the following steps:
 	// 1. Wait for [actionability](../actionability.md) checks on the element, unless `force` option is set.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to click in the center of the element, or the specified `position`.
+	// 1. Use Page.mouse() to click in the center of the element, or the specified `position`.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// If the element is detached from the DOM at any moment during the action, this method throws.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
 	// Passing zero timeout disables this.
-	// **Usage**
-	// Click a button:
-	// Shift-right-click at a specific position on a canvas:
 	Click(options ...PageClickOptions) error
 	// Returns the number of elements matching the locator.
-	// **Usage**
 	Count() (int, error)
 	// Double-click an element.
 	// **Details**
 	// This method double clicks the element by performing the following steps:
 	// 1. Wait for [actionability](../actionability.md) checks on the element, unless `force` option is set.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to double click in the center of the element, or the specified `position`.
+	// 1. Use Page.mouse() to double click in the center of the element, or the specified `position`.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set. Note that if
 	// the first click of the `dblclick()` triggers a navigation event, this method will throw.
 	// If the element is detached from the DOM at any moment during the action, this method throws.
@@ -1479,28 +1161,11 @@ type Locator interface {
 	// **NOTE** `element.dblclick()` dispatches two `click` events and a single `dblclick` event.
 	Dblclick(options ...FrameDblclickOptions) error
 	// Programmaticaly dispatch an event on the matching element.
-	// **Usage**
-	// **Details**
-	// The snippet above dispatches the `click` event on the element. Regardless of the visibility state of the element,
-	// `click` is dispatched. This is equivalent to calling
-	// [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
-	// Under the hood, it creates an instance of an event based on the given `type`, initializes it with `eventInit`
-	// properties and dispatches it on the element. Events are `composed`, `cancelable` and bubble by default.
-	// Since `eventInit` is event-specific, please refer to the events documentation for the lists of initial properties:
-	// - [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)
-	// - [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)
-	// - [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)
-	// - [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)
-	// - [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)
-	// - [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)
-	// - [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)
-	// You can also specify `JSHandle` as the property value if you want live objects to be passed into the event:
 	DispatchEvent(typ string, eventInit interface{}, options ...PageDispatchEventOptions) error
 	// Drag the source element towards the target element and drop it.
 	// **Details**
 	// This method drags the locator to another target locator or target position. It will first move to the source
 	// element, perform a `mousedown`, then move to the target element or position and perform a `mouseup`.
-	// **Usage**
 	DragTo(target Locator, options ...FrameDragAndDropOptions) error
 	// Resolves given locator to the first matching DOM element. If there are no matching elements, waits for one. If
 	// multiple elements match the locator, throws.
@@ -1513,7 +1178,6 @@ type Locator interface {
 	// second argument.
 	// If `expression` returns a [Promise], this method will wait for the promise to resolve and return its value.
 	// If `expression` throws or rejects, this method throws.
-	// **Usage**
 	Evaluate(expression string, arg interface{}, options ...LocatorEvaluateOptions) (interface{}, error)
 	// Execute JavaScript code in the page, taking all matching elements as an argument.
 	// **Details**
@@ -1521,33 +1185,22 @@ type Locator interface {
 	// `arg` as a second argument.
 	// If `expression` returns a [Promise], this method will wait for the promise to resolve and return its value.
 	// If `expression` throws or rejects, this method throws.
-	// **Usage**
 	EvaluateAll(expression string, options ...interface{}) (interface{}, error)
 	// Execute JavaScript code in the page, taking the matching element as an argument, and return a `JSHandle` with the
 	// result.
 	// **Details**
 	// Returns the return value of `expression` as a`JSHandle`, called with the matching element as a first argument, and
 	// `arg` as a second argument.
-	// The only difference between Locator.evaluate`] and [`method: Locator.evaluateHandle() is that
+	// The only difference between Locator.evaluate() and Locator.evaluateHandle() is that
 	// Locator.evaluateHandle() returns `JSHandle`.
 	// If `expression` returns a [Promise], this method will wait for the promise to resolve and return its value.
 	// If `expression` throws or rejects, this method throws.
 	// See Page.evaluateHandle() for more details.
 	EvaluateHandle(expression string, arg interface{}, options ...LocatorEvaluateHandleOptions) (interface{}, error)
 	// Set a value to the input field.
-	// **Usage**
-	// **Details**
-	// This method waits for [actionability](../actionability.md) checks, focuses the element, fills it and triggers an
-	// `input` event after filling. Note that you can pass an empty string to clear the input field.
-	// If the target element is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an
-	// error. However, if the element is inside the `<label>` element that has an associated
-	// [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be filled
-	// instead.
-	// To send fine-grained keyboard events, use Locator.type().
 	Fill(value string, options ...FrameFillOptions) error
 	// This method narrows existing locator according to the options, for example filters by text. It can be chained to
 	// filter multiple times.
-	// **Usage**
 	Filter(options ...LocatorLocatorOptions) (Locator, error)
 	// Returns locator to the first matching element.
 	First() (Locator, error)
@@ -1555,175 +1208,63 @@ type Locator interface {
 	Focus(options ...FrameFocusOptions) error
 	// When working with iframes, you can create a frame locator that will enter the iframe and allow locating elements in
 	// that iframe:
-	// **Usage**
 	FrameLocator(selector string) FrameLocator
 	// Returns the matching element's attribute value.
 	GetAttribute(name string, options ...PageGetAttributeOptions) (string, error)
 	// Allows locating elements by their alt text.
-	// **Usage**
-	// For example, this method will find the image by alt text "Playwright logo":
-	// ```html
-	// <img alt='Playwright logo'>
-	// ```
 	GetByAltText(text interface{}, options ...LocatorGetByAltTextOptions) (Locator, error)
 	// Allows locating input elements by the text of the associated label.
-	// **Usage**
-	// For example, this method will find the input by label text "Password" in the following DOM:
-	// ```html
-	// <label for="password-input">Password:</label>
-	// <input id="password-input">
-	// ```
 	GetByLabel(text interface{}, options ...LocatorGetByLabelOptions) (Locator, error)
 	// Allows locating input elements by the placeholder text.
-	// **Usage**
-	// For example, consider the following DOM structure.
-	// ```html
-	// <input type="email" placeholder="name@example.com" />
-	// ```
-	// You can fill the input after locating it by the placeholder text:
 	GetByPlaceholder(text interface{}, options ...LocatorGetByPlaceholderOptions) (Locator, error)
 	// Allows locating elements by their [ARIA role](https://www.w3.org/TR/wai-aria-1.2/#roles),
 	// [ARIA attributes](https://www.w3.org/TR/wai-aria-1.2/#aria-attributes) and
 	// [accessible name](https://w3c.github.io/accname/#dfn-accessible-name).
-	// **Usage**
-	// Consider the following DOM structure.
-	// ```html
-	// <h3>Sign up</h3>
-	// <label>
-	// <input type="checkbox" /> Subscribe
-	// </label>
-	// <br/>
-	// <button>Submit</button>
-	// ```
-	// You can locate each element by it's implicit role:
-	// **Details**
-	// Role selector **does not replace** accessibility audits and conformance tests, but rather gives early feedback
-	// about the ARIA guidelines.
-	// Many html elements have an implicitly [defined role](https://w3c.github.io/html-aam/#html-element-role-mappings)
-	// that is recognized by the role selector. You can find all the
-	// [supported roles here](https://www.w3.org/TR/wai-aria-1.2/#role_definitions). ARIA guidelines **do not recommend**
-	// duplicating implicit roles and attributes by setting `role` and/or `aria-*` attributes to default values.
 	GetByRole(role AriaRole, options ...LocatorGetByRoleOptions) (Locator, error)
 	// Locate element by the test id.
-	// **Usage**
-	// Consider the following DOM structure.
-	// ```html
-	// <button data-testid="directions">Itinéraire</button>
-	// ```
-	// You can locate the element by it's test id:
-	// **Details**
-	// By default, the `data-testid` attribute is used as a test id. Use Selectors.setTestIdAttribute() to
-	// configure a different test id attribute if necessary.
 	GetByTestId(testId interface{}) (Locator, error)
 	// Allows locating elements that contain given text.
 	// See also Locator.filter() that allows to match by another criteria, like an accessible role, and then
 	// filter by the text content.
-	// **Usage**
-	// Consider the following DOM structure:
-	// ```html
-	// <div>Hello <span>world</span></div>
-	// <div>Hello</div>
-	// ```
-	// You can locate by text substring, exact string, or a regular expression:
-	// **Details**
-	// Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into
-	// one, turns line breaks into spaces and ignores leading and trailing whitespace.
-	// Input elements of the type `button` and `submit` are matched by their `value` instead of the text content. For
-	// example, locating by text `"Log in"` matches `<input type=button value="Log in">`.
 	GetByText(text interface{}, options ...LocatorGetByTextOptions) (Locator, error)
 	// Allows locating elements by their title attribute.
-	// **Usage**
-	// Consider the following DOM structure.
-	// ```html
-	// <span title='Issues count'>25 issues</span>
-	// ```
-	// You can check the issues count after locating it by the title text:
 	GetByTitle(title interface{}, options ...LocatorGetByTitleOptions) (Locator, error)
 	// Highlight the corresponding element(s) on the screen. Useful for debugging, don't commit the code that uses
 	// Locator.highlight().
 	Highlight() error
 	// Hover over the matching element.
-	// **Usage**
-	// **Details**
-	// This method hovers over the element by performing the following steps:
-	// 1. Wait for [actionability](../actionability.md) checks on the element, unless `force` option is set.
-	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to hover over the center of the element, or the specified `position`.
-	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
-	// If the element is detached from the DOM at any moment during the action, this method throws.
-	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
-	// Passing zero timeout disables this.
 	Hover(options ...PageHoverOptions) error
 	// Returns the [`element.innerHTML`](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML).
 	InnerHTML(options ...PageInnerHTMLOptions) (string, error)
 	// Returns the [`element.innerText`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText).
 	InnerText(options ...PageInnerTextOptions) (string, error)
 	// Returns the value for the matching `<input>` or `<textarea>` or `<select>` element.
-	// **Usage**
-	// **Details**
-	// Throws elements that are not an input, textarea or a select. However, if the element is inside the `<label>`
-	// element that has an associated
-	// [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), returns the value of the
-	// control.
 	InputValue(options ...FrameInputValueOptions) (string, error)
 	// Returns whether the element is checked. Throws if the element is not a checkbox or radio input.
-	// **Usage**
 	IsChecked(options ...FrameIsCheckedOptions) (bool, error)
 	// Returns whether the element is disabled, the opposite of [enabled](../actionability.md#enabled).
-	// **Usage**
 	IsDisabled(options ...FrameIsDisabledOptions) (bool, error)
 	// Returns whether the element is [editable](../actionability.md#editable).
-	// **Usage**
 	IsEditable(options ...FrameIsEditableOptions) (bool, error)
 	// Returns whether the element is [enabled](../actionability.md#enabled).
-	// **Usage**
 	IsEnabled(options ...FrameIsEnabledOptions) (bool, error)
 	// Returns whether the element is hidden, the opposite of [visible](../actionability.md#visible).
-	// **Usage**
 	IsHidden(options ...FrameIsHiddenOptions) (bool, error)
 	// Returns whether the element is [visible](../actionability.md#visible).
-	// **Usage**
 	IsVisible(options ...FrameIsVisibleOptions) (bool, error)
 	// Returns locator to the last matching element.
-	// **Usage**
 	Last() (Locator, error)
 	// The method finds an element matching the specified selector in the locator's subtree. It also accepts filter
 	// options, similar to Locator.filter() method.
 	// [Learn more about locators](../locators.md).
 	Locator(selector string, options ...LocatorLocatorOptions) (Locator, error)
 	// Returns locator to the n-th matching element. It's zero based, `nth(0)` selects the first element.
-	// **Usage**
 	Nth(index int) (Locator, error)
 	// A page this locator belongs to.
 	Page() Page
 	// Focuses the mathing element and presses a combintation of the keys.
-	// **Usage**
-	// **Details**
-	// Focuses the element, and then uses Keyboard.down`] and [`method: Keyboard.up().
-	// `key` can specify the intended
-	// [keyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) value or a single character
-	// to generate the text for. A superset of the `key` values can be found
-	// [here](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values). Examples of the keys are:
-	// `F1` - `F12`, `Digit0`- `Digit9`, `KeyA`- `KeyZ`, `Backquote`, `Minus`, `Equal`, `Backslash`, `Backspace`, `Tab`,
-	// `Delete`, `Escape`, `ArrowDown`, `End`, `Enter`, `Home`, `Insert`, `PageDown`, `PageUp`, `ArrowRight`, `ArrowUp`,
-	// etc.
-	// Following modification shortcuts are also supported: `Shift`, `Control`, `Alt`, `Meta`, `ShiftLeft`.
-	// Holding down `Shift` will type the text that corresponds to the `key` in the upper case.
-	// If `key` is a single character, it is case-sensitive, so the values `a` and `A` will generate different respective
-	// texts.
-	// Shortcuts such as `key: "Control+o"` or `key: "Control+Shift+T"` are supported as well. When specified with the
-	// modifier, modifier is pressed and being held while the subsequent key is being pressed.
 	Press(key string, options ...PagePressOptions) error
 	// Take a screenshot of the element matching the locator.
-	// **Usage**
-	// Disable animations and save screenshot to a file:
-	// **Details**
-	// This method captures a screenshot of the page, clipped to the size and position of a particular element matching
-	// the locator. If the element is covered by other elements, it will not be actually visible on the screenshot. If the
-	// element is a scrollable container, only the currently scrolled content will be visible on the screenshot.
-	// This method waits for the [actionability](../actionability.md) checks, then scrolls element into view before taking
-	// a screenshot. If the element is detached from DOM, the method throws an error.
-	// Returns the buffer with the captured screenshot.
 	Screenshot(options ...LocatorScreenshotOptions) ([]byte, error)
 	// This method waits for [actionability](../actionability.md) checks, then tries to scroll element into view, unless
 	// it is completely visible as defined by
@@ -1739,14 +1280,6 @@ type Locator interface {
 	// instead.
 	// Returns the array of option values that have been successfully selected.
 	// Triggers a `change` and `input` event once all the provided options have been selected.
-	// **Usage**
-	// ```html
-	// <select multiple>
-	// <option value="red">Red</div>
-	// <option value="green">Green</div>
-	// <option value="blue">Blue</div>
-	// </select>
-	// ```
 	SelectOption(values SelectOptionValues, options ...FrameSelectOptionOptions) ([]string, error)
 	// This method waits for [actionability](../actionability.md) checks, then focuses the element and selects all its
 	// text content.
@@ -1755,36 +1288,15 @@ type Locator interface {
 	// the control instead.
 	SelectText(options ...LocatorSelectTextOptions) error
 	// Set the state of a checkbox or a radio element.
-	// **Usage**
-	// **Details**
-	// This method checks or unchecks an element by performing the following steps:
-	// 1. Ensure that matched element is a checkbox or a radio input. If not, this method throws.
-	// 1. If the element already has the right checked state, this method returns immediately.
-	// 1. Wait for [actionability](../actionability.md) checks on the matched element, unless `force` option is set. If
-	// the element is detached during the checks, the whole action is retried.
-	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to click in the center of the element.
-	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
-	// 1. Ensure that the element is now checked or unchecked. If not, this method throws.
-	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
-	// Passing zero timeout disables this.
 	SetChecked(checked bool, options ...FrameSetCheckedOptions) error
 	// Upload file or multiple files into `<input type=file>`.
-	// **Usage**
-	// **Details**
-	// Sets the value of the file input to these file paths or files. If some of the `filePaths` are relative paths, then
-	// they are resolved relative to the current working directory. For empty array, clears the selected files.
-	// This method expects `Locator` to point to an
-	// [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input). However, if the element is inside
-	// the `<label>` element that has an associated
-	// [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), targets the control instead.
 	SetInputFiles(files []InputFile, options ...FrameSetInputFilesOptions) error
 	// Perform a tap gesture on the element matching the locator.
 	// **Details**
 	// This method taps the element by performing the following steps:
 	// 1. Wait for [actionability](../actionability.md) checks on the element, unless `force` option is set.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.touchscreen`] to tap the center of the element, or the specified `position`.
+	// 1. Use Page.touchscreen() to tap the center of the element, or the specified `position`.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// If the element is detached from the DOM at any moment during the action, this method throws.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
@@ -1796,28 +1308,12 @@ type Locator interface {
 	// Focuses the element, and then sends a `keydown`, `keypress`/`input`, and `keyup` event for each character in the
 	// text.
 	// To press a special key, like `Control` or `ArrowDown`, use Locator.press().
-	// **Usage**
-	// An example of typing into a text field and then submitting the form:
 	Type(text string, options ...PageTypeOptions) error
 	// Ensure that checkbox or radio element is unchecked.
-	// **Usage**
-	// **Details**
-	// This method unchecks the element by performing the following steps:
-	// 1. Ensure that element is a checkbox or a radio input. If not, this method throws. If the element is already
-	// unchecked, this method returns immediately.
-	// 1. Wait for [actionability](../actionability.md) checks on the element, unless `force` option is set.
-	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to click in the center of the element.
-	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
-	// 1. Ensure that the element is now unchecked. If not, this method throws.
-	// If the element is detached from the DOM at any moment during the action, this method throws.
-	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
-	// Passing zero timeout disables this.
 	Uncheck(options ...FrameUncheckOptions) error
 	// Returns when element specified by locator satisfies the `state` option.
 	// If target element already satisfies the condition, the method returns immediately. Otherwise, waits for up to
 	// `timeout` milliseconds until the condition is met.
-	// **Usage**
 	WaitFor(options ...PageWaitForSelectorOptions) error
 }
 
@@ -1829,109 +1325,52 @@ type LocatorAssertions interface {
 	// text `"error"`:
 	Not() LocatorAssertions
 	// Ensures the `Locator` points to a checked input.
-	// **Usage**
 	ToBeChecked(options ...LocatorAssertionsToBeCheckedOptions) error
 	// Ensures the `Locator` points to a disabled element. Element is disabled if it has "disabled" attribute or is
 	// disabled via
 	// ['aria-disabled'](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled). Note
 	// that only native control elements such as HTML `button`, `input`, `select`, `textarea`, `option`, `optgroup` can be
 	// disabled by setting "disabled" attribute. "disabled" attribute on other elements is ignored by the browser.
-	// **Usage**
 	ToBeDisabled(options ...LocatorAssertionsToBeDisabledOptions) error
 	// Ensures the `Locator` points to an editable element.
-	// **Usage**
 	ToBeEditable(options ...LocatorAssertionsToBeEditableOptions) error
 	// Ensures the `Locator` points to an empty editable element or to a DOM node that has no text.
-	// **Usage**
 	ToBeEmpty(options ...LocatorAssertionsToBeEmptyOptions) error
 	// Ensures the `Locator` points to an enabled element.
-	// **Usage**
 	ToBeEnabled(options ...LocatorAssertionsToBeEnabledOptions) error
 	// Ensures the `Locator` points to a focused DOM node.
-	// **Usage**
 	ToBeFocused(options ...LocatorAssertionsToBeFocusedOptions) error
 	// Ensures that `Locator` either does not resolve to any DOM node, or resolves to a
 	// [non-visible](../actionability.md#visible) one.
-	// **Usage**
 	ToBeHidden(options ...LocatorAssertionsToBeHiddenOptions) error
 	// Ensures that `Locator` points to an [attached](../actionability.md#attached) and
 	// [visible](../actionability.md#visible) DOM node.
-	// **Usage**
 	ToBeVisible(options ...LocatorAssertionsToBeVisibleOptions) error
 	// Ensures the `Locator` points to an element that contains the given text. You can use regular expressions for the
 	// value as well.
-	// **Usage**
-	// If you pass an array as an expected value, the expectations are:
-	// 1. Locator resolves to a list of elements.
-	// 1. Elements from a **subset** of this list contain text from the expected array, respectively.
-	// 1. The matching subset of elements has the same order as the expected array.
-	// 1. Each text value from the expected array is matched by some element from the list.
-	// For example, consider the following list:
-	// ```html
-	// <ul>
-	// <li>Item Text 1</li>
-	// <li>Item Text 2</li>
-	// <li>Item Text 3</li>
-	// </ul>
-	// ```
-	// Let's see how we can use the assertion:
 	ToContainText(expected interface{}, options ...LocatorAssertionsToContainTextOptions) error
 	// Ensures the `Locator` points to an element with given attribute.
-	// **Usage**
 	ToHaveAttribute(name string, value interface{}, options ...LocatorAssertionsToHaveAttributeOptions) error
 	// Ensures the `Locator` points to an element with given CSS classes. This needs to be a full match or using a relaxed
 	// regular expression.
-	// **Usage**
-	// ```html
-	// <div class='selected row' id='component'></div>
-	// ```
-	// Note that if array is passed as an expected value, entire lists of elements can be asserted:
 	ToHaveClass(expected interface{}, options ...LocatorAssertionsToHaveClassOptions) error
 	// Ensures the `Locator` resolves to an exact number of DOM nodes.
-	// **Usage**
 	ToHaveCount(count int, options ...LocatorAssertionsToHaveCountOptions) error
 	// Ensures the `Locator` resolves to an element with the given computed CSS style.
-	// **Usage**
 	ToHaveCSS(name string, value interface{}, options ...LocatorAssertionsToHaveCSSOptions) error
 	// Ensures the `Locator` points to an element with the given DOM Node ID.
-	// **Usage**
 	ToHaveId(id interface{}, options ...LocatorAssertionsToHaveIdOptions) error
 	// Ensures the `Locator` points to an element with given JavaScript property. Note that this property can be of a
 	// primitive type as well as a plain serializable JavaScript object.
-	// **Usage**
 	ToHaveJSProperty(name string, value interface{}, options ...LocatorAssertionsToHaveJSPropertyOptions) error
 	// Ensures the `Locator` points to an element with the given text. You can use regular expressions for the value as
 	// well.
-	// **Usage**
-	// If you pass an array as an expected value, the expectations are:
-	// 1. Locator resolves to a list of elements.
-	// 1. The number of elements equals the number of expected values in the array.
-	// 1. Elements from the list have text matching expected array values, one by one, in order.
-	// For example, consider the following list:
-	// ```html
-	// <ul>
-	// <li>Text 1</li>
-	// <li>Text 2</li>
-	// <li>Text 3</li>
-	// </ul>
-	// ```
-	// Let's see how we can use the assertion:
 	ToHaveText(expected interface{}, options ...LocatorAssertionsToHaveTextOptions) error
 	// Ensures the `Locator` points to an element with the given input value. You can use regular expressions for the
 	// value as well.
-	// **Usage**
 	ToHaveValue(value interface{}, options ...LocatorAssertionsToHaveValueOptions) error
 	// Ensures the `Locator` points to multi-select/combobox (i.e. a `select` with the `multiple` attribute) and the
 	// specified values are selected.
-	// **Usage**
-	// For example, given the following element:
-	// ```html
-	// <select id="favorite-colors" multiple>
-	// <option value="R">Red</option>
-	// <option value="G">Green</option>
-	// <option value="B">Blue</option>
-	// </select>
-	// ```
 	ToHaveValues(values []interface{}, options ...LocatorAssertionsToHaveValuesOptions) error
 	// The opposite of LocatorAssertions.toBeChecked().
 	NotToBeChecked(options ...LocatorAssertionsToBeCheckedOptions) error
@@ -1972,11 +1411,11 @@ type LocatorAssertions interface {
 }
 
 // The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.
-// Every `page` object has its own Mouse, accessible with [`property: Page.mouse`].
+// Every `page` object has its own Mouse, accessible with Page.mouse().
 type Mouse interface {
-	// Shortcut for Mouse.move`], [`method: Mouse.down`], [`method: Mouse.up().
+	// Shortcut for Mouse.move(), Mouse.down(), Mouse.up().
 	Click(x, y float64, options ...MouseClickOptions) error
-	// Shortcut for Mouse.move`], [`method: Mouse.down`], [`method: Mouse.up`], [`method: Mouse.down() and
+	// Shortcut for Mouse.move(), Mouse.down(), Mouse.up(), Mouse.down() and
 	// Mouse.up().
 	Dblclick(x, y float64, options ...MouseDblclickOptions) error
 	// Dispatches a `mousedown` event.
@@ -2009,7 +1448,7 @@ type Page interface {
 	// 1. Wait for [actionability](../actionability.md) checks on the matched element, unless `force` option is set. If
 	// the element is detached during the checks, the whole action is retried.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to click in the center of the element.
+	// 1. Use Page.mouse() to click in the center of the element.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// 1. Ensure that the element is now checked or unchecked. If not, this method throws.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
@@ -2024,10 +1463,6 @@ type Page interface {
 	// newly attached frame.
 	// The script is evaluated after the document was created but before any of its scripts were run. This is useful to
 	// amend the JavaScript environment, e.g. to seed `Math.random`.
-	// **Usage**
-	// An example of overriding `Math.random` before the page loads:
-	// **NOTE** The order of evaluation of multiple scripts installed via BrowserContext.addInitScript() and
-	// Page.addInitScript() is not defined.
 	AddInitScript(script PageAddInitScriptOptions) error
 	// Adds a `<script>` tag into the page with the desired url or content. Returns the added tag when the script's onload
 	// fires or when the script content was injected into frame.
@@ -2044,7 +1479,7 @@ type Page interface {
 	// 1. Wait for [actionability](../actionability.md) checks on the matched element, unless `force` option is set. If
 	// the element is detached during the checks, the whole action is retried.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to click in the center of the element.
+	// 1. Use Page.mouse() to click in the center of the element.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// 1. Ensure that the element is now checked. If not, this method throws.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
@@ -2055,7 +1490,7 @@ type Page interface {
 	// 1. Wait for [actionability](../actionability.md) checks on the matched element, unless `force` option is set. If
 	// the element is detached during the checks, the whole action is retried.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to click in the center of the element, or the specified `position`.
+	// 1. Use Page.mouse() to click in the center of the element, or the specified `position`.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
 	// Passing zero timeout disables this.
@@ -2075,7 +1510,7 @@ type Page interface {
 	// 1. Wait for [actionability](../actionability.md) checks on the matched element, unless `force` option is set. If
 	// the element is detached during the checks, the whole action is retried.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to double click in the center of the element, or the specified `position`.
+	// 1. Use Page.mouse() to double click in the center of the element, or the specified `position`.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set. Note that if
 	// the first click of the `dblclick()` triggers a navigation event, this method will throw.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
@@ -2085,18 +1520,6 @@ type Page interface {
 	// The snippet below dispatches the `click` event on the element. Regardless of the visibility state of the element,
 	// `click` is dispatched. This is equivalent to calling
 	// [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
-	// **Usage**
-	// Under the hood, it creates an instance of an event based on the given `type`, initializes it with `eventInit`
-	// properties and dispatches it on the element. Events are `composed`, `cancelable` and bubble by default.
-	// Since `eventInit` is event-specific, please refer to the events documentation for the lists of initial properties:
-	// - [DragEvent](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent/DragEvent)
-	// - [FocusEvent](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent)
-	// - [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent)
-	// - [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent)
-	// - [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/PointerEvent)
-	// - [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)
-	// - [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)
-	// You can also specify `JSHandle` as the property value if you want live objects to be passed into the event:
 	DispatchEvent(selector string, typ string, options ...PageDispatchEventOptions) error
 	// The method adds a function called `name` on the `window` object of every frame in this page. When called, the
 	// function executes `callback` and returns a [Promise] which resolves to the return value of `callback`. If the
@@ -2105,53 +1528,38 @@ type Page interface {
 	// BrowserContext, page: Page, frame: Frame }`.
 	// See BrowserContext.exposeBinding() for the context-wide version.
 	// **NOTE** Functions installed via Page.exposeBinding() survive navigations.
-	// **Usage**
-	// An example of exposing page URL to all frames in a page:
-	// An example of passing an element handle:
 	ExposeBinding(name string, binding BindingCallFunction, handle ...bool) error
 	// The method adds a function called `name` on the `window` object of every frame in the page. When called, the
 	// function executes `callback` and returns a [Promise] which resolves to the return value of `callback`.
 	// If the `callback` returns a [Promise], it will be awaited.
 	// See BrowserContext.exposeFunction() for context-wide exposed function.
 	// **NOTE** Functions installed via Page.exposeFunction() survive navigations.
-	// **Usage**
-	// An example of adding a `sha256` function to the page:
 	ExposeFunction(name string, binding ExposedFunction) error
 	// This method changes the `CSS media type` through the `media` argument, and/or the `'prefers-colors-scheme'` media
 	// feature, using the `colorScheme` argument.
-	// **Usage**
 	EmulateMedia(options ...PageEmulateMediaOptions) error
 	// Returns the value of the `expression` invocation.
-	// If the function passed to the Page.evaluate`] returns a [Promise], then [`method: Page.evaluate() would
+	// If the function passed to the Page.evaluate() returns a [Promise], then Page.evaluate() would
 	// wait for the promise to resolve and return its value.
 	// If the function passed to the Page.evaluate() returns a non-[Serializable] value, then
 	// Page.evaluate() resolves to `undefined`. Playwright also supports transferring some additional values
 	// that are not serializable by `JSON`: `-0`, `NaN`, `Infinity`, `-Infinity`.
-	// **Usage**
-	// Passing argument to `expression`:
-	// A string can also be passed in instead of a function:
-	// `ElementHandle` instances can be passed as an argument to the Page.evaluate():
 	Evaluate(expression string, options ...interface{}) (interface{}, error)
 	// Returns the value of the `expression` invocation as a `JSHandle`.
-	// The only difference between Page.evaluate`] and [`method: Page.evaluateHandle() is that
+	// The only difference between Page.evaluate() and Page.evaluateHandle() is that
 	// Page.evaluateHandle() returns `JSHandle`.
 	// If the function passed to the Page.evaluateHandle() returns a [Promise], then
 	// Page.evaluateHandle() would wait for the promise to resolve and return its value.
-	// **Usage**
-	// A string can also be passed in instead of a function:
-	// `JSHandle` instances can be passed as an argument to the Page.evaluateHandle():
 	EvaluateHandle(expression string, options ...interface{}) (JSHandle, error)
 	// The method finds an element matching the specified selector within the page and passes it as a first argument to
 	// `expression`. If no elements match the selector, the method throws an error. Returns the value of `expression`.
 	// If `expression` returns a [Promise], then Page.evalOnSelector() would wait for the promise to resolve and
 	// return its value.
-	// **Usage**
 	EvalOnSelector(selector string, expression string, options ...interface{}) (interface{}, error)
 	// The method finds all elements matching the specified selector within the page and passes an array of matched
 	// elements as a first argument to `expression`. Returns the result of `expression` invocation.
 	// If `expression` returns a [Promise], then Page.evalOnSelectorAll() would wait for the promise to resolve
 	// and return its value.
-	// **Usage**
 	EvalOnSelectorAll(selector string, expression string, options ...interface{}) (interface{}, error)
 	// Performs action and waits for a `ConsoleMessage` to be logged by in the page. If predicate is provided, it passes
 	// `ConsoleMessage` value into the `predicate` function and waits for `predicate(message)` to return a truthy value.
@@ -2163,7 +1571,6 @@ type Page interface {
 	ExpectDownload(cb func() error, options ...PageExpectDownloadOptions) (Download, error)
 	// Waits for event to fire and passes its value into the predicate function. Returns when the predicate returns truthy
 	// value. Will throw an error if the page is closed before the event is fired. Returns the event data value.
-	// **Usage**
 	ExpectEvent(event string, cb func() error, options ...PageWaitForEventOptions) (interface{}, error)
 	// Performs action and waits for a new `FileChooser` to be created. If predicate is provided, it passes `FileChooser`
 	// value into the `predicate` function and waits for `predicate(fileChooser)` to return a truthy value. Will throw an
@@ -2203,97 +1610,31 @@ type Page interface {
 	// method waits until a matching element appears in the DOM.
 	Focus(expression string, options ...FrameFocusOptions) error
 	// Returns frame matching the specified criteria. Either `name` or `url` must be specified.
-	// **Usage**
 	Frame(options PageFrameOptions) Frame
 	// An array of all frames attached to the page.
 	Frames() []Frame
 	// When working with iframes, you can create a frame locator that will enter the iframe and allow selecting elements
 	// in that iframe.
-	// **Usage**
-	// Following snippet locates element with text "Submit" in the iframe with id `my-frame`, like `<iframe
-	// id="my-frame">`:
 	FrameLocator(selector string) FrameLocator
 	// Returns element attribute value.
 	GetAttribute(selector string, name string, options ...PageGetAttributeOptions) (string, error)
 	// Allows locating elements by their alt text.
-	// **Usage**
-	// For example, this method will find the image by alt text "Playwright logo":
-	// ```html
-	// <img alt='Playwright logo'>
-	// ```
 	GetByAltText(text interface{}, options ...LocatorGetByAltTextOptions) (Locator, error)
 	// Allows locating input elements by the text of the associated label.
-	// **Usage**
-	// For example, this method will find the input by label text "Password" in the following DOM:
-	// ```html
-	// <label for="password-input">Password:</label>
-	// <input id="password-input">
-	// ```
 	GetByLabel(text interface{}, options ...LocatorGetByLabelOptions) (Locator, error)
 	// Allows locating input elements by the placeholder text.
-	// **Usage**
-	// For example, consider the following DOM structure.
-	// ```html
-	// <input type="email" placeholder="name@example.com" />
-	// ```
-	// You can fill the input after locating it by the placeholder text:
 	GetByPlaceholder(text interface{}, options ...LocatorGetByPlaceholderOptions) (Locator, error)
 	// Allows locating elements by their [ARIA role](https://www.w3.org/TR/wai-aria-1.2/#roles),
 	// [ARIA attributes](https://www.w3.org/TR/wai-aria-1.2/#aria-attributes) and
 	// [accessible name](https://w3c.github.io/accname/#dfn-accessible-name).
-	// **Usage**
-	// Consider the following DOM structure.
-	// ```html
-	// <h3>Sign up</h3>
-	// <label>
-	// <input type="checkbox" /> Subscribe
-	// </label>
-	// <br/>
-	// <button>Submit</button>
-	// ```
-	// You can locate each element by it's implicit role:
-	// **Details**
-	// Role selector **does not replace** accessibility audits and conformance tests, but rather gives early feedback
-	// about the ARIA guidelines.
-	// Many html elements have an implicitly [defined role](https://w3c.github.io/html-aam/#html-element-role-mappings)
-	// that is recognized by the role selector. You can find all the
-	// [supported roles here](https://www.w3.org/TR/wai-aria-1.2/#role_definitions). ARIA guidelines **do not recommend**
-	// duplicating implicit roles and attributes by setting `role` and/or `aria-*` attributes to default values.
 	GetByRole(role AriaRole, options ...LocatorGetByRoleOptions) (Locator, error)
 	// Locate element by the test id.
-	// **Usage**
-	// Consider the following DOM structure.
-	// ```html
-	// <button data-testid="directions">Itinéraire</button>
-	// ```
-	// You can locate the element by it's test id:
-	// **Details**
-	// By default, the `data-testid` attribute is used as a test id. Use Selectors.setTestIdAttribute() to
-	// configure a different test id attribute if necessary.
 	GetByTestId(testId interface{}) (Locator, error)
 	// Allows locating elements that contain given text.
 	// See also Locator.filter() that allows to match by another criteria, like an accessible role, and then
 	// filter by the text content.
-	// **Usage**
-	// Consider the following DOM structure:
-	// ```html
-	// <div>Hello <span>world</span></div>
-	// <div>Hello</div>
-	// ```
-	// You can locate by text substring, exact string, or a regular expression:
-	// **Details**
-	// Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into
-	// one, turns line breaks into spaces and ignores leading and trailing whitespace.
-	// Input elements of the type `button` and `submit` are matched by their `value` instead of the text content. For
-	// example, locating by text `"Log in"` matches `<input type=button value="Log in">`.
 	GetByText(text interface{}, options ...LocatorGetByTextOptions) (Locator, error)
 	// Allows locating elements by their title attribute.
-	// **Usage**
-	// Consider the following DOM structure.
-	// ```html
-	// <span title='Issues count'>25 issues</span>
-	// ```
-	// You can check the issues count after locating it by the title text:
 	GetByTitle(title interface{}, options ...LocatorGetByTitleOptions) (Locator, error)
 	// Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of
 	// the last redirect. If can not go back, returns `null`.
@@ -2324,7 +1665,7 @@ type Page interface {
 	// 1. Wait for [actionability](../actionability.md) checks on the matched element, unless `force` option is set. If
 	// the element is detached during the checks, the whole action is retried.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to hover over the center of the element, or the specified `position`.
+	// 1. Use Page.mouse() to hover over the center of the element, or the specified `position`.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
 	// Passing zero timeout disables this.
@@ -2365,34 +1706,8 @@ type Page interface {
 	// **NOTE** By default, `page.pdf()` generates a pdf with modified colors for printing. Use the
 	// [`-webkit-print-color-adjust`](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-print-color-adjust)
 	// property to force rendering of exact colors.
-	// **Usage**
-	// The `width`, `height`, and `margin` options accept values labeled with units. Unlabeled values are treated as
-	// pixels.
-	// A few examples:
-	// - `page.pdf({width: 100})` - prints with width set to 100 pixels
-	// - `page.pdf({width: '100px'})` - prints with width set to 100 pixels
-	// - `page.pdf({width: '10cm'})` - prints with width set to 10 centimeters.
-	// All possible units are:
-	// - `px` - pixel
-	// - `in` - inch
-	// - `cm` - centimeter
-	// - `mm` - millimeter
-	// The `format` options are:
-	// - `Letter`: 8.5in x 11in
-	// - `Legal`: 8.5in x 14in
-	// - `Tabloid`: 11in x 17in
-	// - `Ledger`: 17in x 11in
-	// - `A0`: 33.1in x 46.8in
-	// - `A1`: 23.4in x 33.1in
-	// - `A2`: 16.54in x 23.4in
-	// - `A3`: 11.7in x 16.54in
-	// - `A4`: 8.27in x 11.7in
-	// - `A5`: 5.83in x 8.27in
-	// - `A6`: 4.13in x 5.83in
-	// **NOTE** `headerTemplate` and `footerTemplate` markup have the following limitations: > 1. Script tags inside
-	// templates are not evaluated. > 2. Page styles are not visible inside templates.
 	PDF(options ...PagePdfOptions) ([]byte, error)
-	// Focuses the element, and then uses Keyboard.down`] and [`method: Keyboard.up().
+	// Focuses the element, and then uses Keyboard.down() and Keyboard.up().
 	// `key` can specify the intended
 	// [keyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) value or a single character
 	// to generate the text for. A superset of the `key` values can be found
@@ -2406,7 +1721,6 @@ type Page interface {
 	// texts.
 	// Shortcuts such as `key: "Control+o"` or `key: "Control+Shift+T"` are supported as well. When specified with the
 	// modifier, modifier is pressed and being held while the subsequent key is being pressed.
-	// **Usage**
 	Press(selector, key string, options ...PagePressOptions) error
 	// The method finds an element matching the specified selector within the page. If no elements match the selector, the
 	// return value resolves to `null`. To wait for an element on the page, use Locator.waitFor().
@@ -2419,7 +1733,7 @@ type Page interface {
 	// redirect.
 	Reload(options ...PageReloadOptions) (Response, error)
 	// API testing helper associated with this page. This method returns the same instance as
-	// [`property: BrowserContext.request`] on the page's context. See [`property: BrowserContext.request`] for more
+	// BrowserContext.request() on the page's context. See BrowserContext.request() for more
 	// details.
 	Request() APIRequestContext
 	// Routing provides the capability to modify network requests that are made by a page.
@@ -2429,15 +1743,6 @@ type Page interface {
 	// **NOTE** Page.route() will not intercept requests intercepted by Service Worker. See
 	// [this](https://github.com/microsoft/playwright/issues/1090) issue. We recommend disabling Service Workers when
 	// using request interception by setting `Browser.newContext.serviceWorkers` to `'block'`.
-	// **Usage**
-	// An example of a naive handler that aborts all image requests:
-	// or the same snippet using a regex pattern instead:
-	// It is possible to examine the request to decide the route action. For example, mocking all requests that contain
-	// some post data, and leaving all other requests as is:
-	// Page routes take precedence over browser context routes (set up with BrowserContext.route()) when request
-	// matches both handlers.
-	// To remove a route with its handler you can use Page.unroute().
-	// **NOTE** Enabling routing disables http cache.
 	Route(url interface{}, handler routeHandler, times ...int) error
 	// If specified the network requests that are made in the page will be served from the HAR file. Read more about
 	// [Replaying from HAR](../network.md#replaying-from-har).
@@ -2455,7 +1760,6 @@ type Page interface {
 	// instead.
 	// Returns the array of option values that have been successfully selected.
 	// Triggers a `change` and `input` event once all the provided options have been selected.
-	// **Usage**
 	SelectOption(selector string, values SelectOptionValues, options ...FrameSelectOptionOptions) ([]string, error)
 	SetContent(content string, options ...PageSetContentOptions) error
 	// This setting will change the default maximum navigation time for the following methods and related shortcuts:
@@ -2466,11 +1770,11 @@ type Page interface {
 	// - Page.setContent()
 	// - Page.waitForNavigation()
 	// - Page.waitForURL()
-	// **NOTE** Page.setDefaultNavigationTimeout`] takes priority over [`method: Page.setDefaultTimeout(),
-	// BrowserContext.setDefaultTimeout`] and [`method: BrowserContext.setDefaultNavigationTimeout().
+	// **NOTE** Page.setDefaultNavigationTimeout() takes priority over Page.setDefaultTimeout(),
+	// BrowserContext.setDefaultTimeout() and BrowserContext.setDefaultNavigationTimeout().
 	SetDefaultNavigationTimeout(timeout float64)
 	// This setting will change the default maximum time for all the methods accepting `timeout` option.
-	// **NOTE** Page.setDefaultNavigationTimeout`] takes priority over [`method: Page.setDefaultTimeout().
+	// **NOTE** Page.setDefaultNavigationTimeout() takes priority over Page.setDefaultTimeout().
 	SetDefaultTimeout(timeout float64)
 	// The extra HTTP headers will be sent with every request the page initiates.
 	// **NOTE** Page.setExtraHTTPHeaders() does not guarantee the order of headers in the outgoing requests.
@@ -2488,14 +1792,13 @@ type Page interface {
 	// should set the viewport size before navigating to the page. Page.setViewportSize() will also reset
 	// `screen` size, use Browser.newContext() with `screen` and `viewport` parameters if you need better
 	// control of these properties.
-	// **Usage**
 	SetViewportSize(width, height int) error
 	// This method taps an element matching `selector` by performing the following steps:
 	// 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
 	// 1. Wait for [actionability](../actionability.md) checks on the matched element, unless `force` option is set. If
 	// the element is detached during the checks, the whole action is retried.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.touchscreen`] to tap the center of the element, or the specified `position`.
+	// 1. Use Page.touchscreen() to tap the center of the element, or the specified `position`.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
 	// Passing zero timeout disables this.
@@ -2508,7 +1811,6 @@ type Page interface {
 	// Sends a `keydown`, `keypress`/`input`, and `keyup` event for each character in the text. `page.type` can be used to
 	// send fine-grained keyboard events. To fill values in form fields, use Page.fill().
 	// To press a special key, like `Control` or `ArrowDown`, use Keyboard.press().
-	// **Usage**
 	Type(selector, text string, options ...PageTypeOptions) error
 	URL() string
 	// This method unchecks an element matching `selector` by performing the following steps:
@@ -2518,7 +1820,7 @@ type Page interface {
 	// 1. Wait for [actionability](../actionability.md) checks on the matched element, unless `force` option is set. If
 	// the element is detached during the checks, the whole action is retried.
 	// 1. Scroll the element into view if needed.
-	// 1. Use [`property: Page.mouse`] to click in the center of the element.
+	// 1. Use Page.mouse() to click in the center of the element.
 	// 1. Wait for initiated navigations to either succeed or fail, unless `noWaitAfter` option is set.
 	// 1. Ensure that the element is now unchecked. If not, this method throws.
 	// When all steps combined have not finished during the specified `timeout`, this method throws a `TimeoutError`.
@@ -2530,39 +1832,27 @@ type Page interface {
 	// Video object associated with this page.
 	Video() Video
 	ViewportSize() ViewportSize
-	// **NOTE** In most cases, you should use Page.waitForEvent().
+	// **NOTE** In most cases, you should use Page.ExpectForEvent().
 	// Waits for given `event` to fire. If predicate is provided, it passes event's value into the `predicate` function
 	// and waits for `predicate(event)` to return a truthy value. Will throw an error if the page is closed before the
 	// `event` is fired.
 	WaitForEvent(event string, options ...PageWaitForEventOptions) (interface{}, error)
 	// Returns when the `expression` returns a truthy value. It resolves to a JSHandle of the truthy value.
-	// **Usage**
-	// The Page.waitForFunction() can be used to observe viewport size change:
-	// To pass an argument to the predicate of Page.waitForFunction() function:
 	WaitForFunction(expression string, arg interface{}, options ...FrameWaitForFunctionOptions) (JSHandle, error)
 	// Returns when the required load state has been reached.
 	// This resolves when the page reaches a required load state, `load` by default. The navigation must have been
 	// committed when this method is called. If current document has already reached the required state, resolves
 	// immediately.
-	// **Usage**
 	WaitForLoadState(options ...PageWaitForLoadStateOptions) error
 	// Waits for the main frame navigation and returns the main resource response. In case of multiple redirects, the
 	// navigation will resolve with the response of the last redirect. In case of navigation to a different anchor or
 	// navigation due to History API usage, the navigation will resolve with `null`.
-	// **Usage**
-	// This resolves when the page navigates to a new URL or reloads. It is useful for when you run code which will
-	// indirectly cause the page to navigate. e.g. The click target has an `onclick` handler that triggers navigation from
-	// a `setTimeout`. Consider this example:
-	// **NOTE** Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to change the URL
-	// is considered a navigation.
 	WaitForNavigation(options ...PageWaitForNavigationOptions) (Response, error)
 	// Waits for the matching request and returns it. See [waiting for event](../events.md#waiting-for-event) for more
 	// details about events.
-	// **Usage**
 	WaitForRequest(url interface{}, options ...PageWaitForRequestOptions) (Request, error)
 	// Returns the matched response. See [waiting for event](../events.md#waiting-for-event) for more details about
 	// events.
-	// **Usage**
 	WaitForResponse(url interface{}, options ...PageWaitForResponseOptions) (Response, error)
 	// Returns when element specified by selector satisfies `state` option. Returns `null` if waiting for `hidden` or
 	// `detached`.
@@ -2571,13 +1861,10 @@ type Page interface {
 	// Wait for the `selector` to satisfy `state` option (either appear/disappear from dom, or become visible/hidden). If
 	// at the moment of calling the method `selector` already satisfies the condition, the method will return immediately.
 	// If the selector doesn't satisfy the condition for the `timeout` milliseconds, the function will throw.
-	// **Usage**
-	// This method works across navigations:
 	WaitForSelector(selector string, options ...PageWaitForSelectorOptions) (ElementHandle, error)
 	// Waits for the given `timeout` in milliseconds.
 	// Note that `page.waitForTimeout()` should only be used for debugging. Tests using the timer in production are going
 	// to be flaky. Use signals such as network events, selectors becoming visible and others instead.
-	// **Usage**
 	WaitForTimeout(timeout float64)
 	// This method returns all of the dedicated
 	// [WebWorkers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) associated with the page.
@@ -2585,7 +1872,6 @@ type Page interface {
 	Workers() []Worker
 	// This method drags the source element to the target element. It will first move to the source element, perform a
 	// `mousedown`, then move to the target element and perform a `mouseup`.
-	// **Usage**
 	DragAndDrop(source, target string, options ...FrameDragAndDropOptions) error
 	// Pauses script execution. Playwright will stop executing the script and wait for the user to either press 'Resume'
 	// button in the page overlay or to call `playwright.resume()` in the DevTools console.
@@ -2600,7 +1886,6 @@ type Page interface {
 	// control.
 	InputValue(selector string, options ...FrameInputValueOptions) (string, error)
 	// Waits for the main frame to navigate to the given URL.
-	// **Usage**
 	WaitForURL(url string, options ...FrameWaitForURLOptions) error
 }
 
@@ -2611,10 +1896,8 @@ type PageAssertions interface {
 	// contain `"error"`:
 	Not() PageAssertions
 	// Ensures the page has the given title.
-	// **Usage**
 	ToHaveTitle(titleOrRegExp interface{}, options ...PageAssertionsToHaveTitleOptions) error
 	// Ensures the page is navigated to the given URL.
-	// **Usage**
 	ToHaveURL(urlOrRegExp interface{}, options ...PageAssertionsToHaveURLOptions) error
 	// The opposite of PageAssertions.toHaveTitle().
 	NotToHaveTitle(titleOrRegExp interface{}, options ...PageAssertionsToHaveTitleOptions) error
@@ -2631,13 +1914,10 @@ type PageAssertions interface {
 // By default, the timeout for assertions is set to 5 seconds.
 type PlaywrightAssertions interface {
 	// Creates a `APIResponseAssertions` object for the given `APIResponse`.
-	// **Usage**
 	APIResponse(response APIResponse) APIResponseAssertions
 	// Creates a `LocatorAssertions` object for the given `Locator`.
-	// **Usage**
 	Locator(locator Locator) LocatorAssertions
 	// Creates a `PageAssertions` object for the given `Page`.
-	// **Usage**
 	Page(page Page) PageAssertions
 }
 
@@ -2662,8 +1942,6 @@ type Request interface {
 	HeaderValue(name string) (string, error)
 	HeaderValues(name string) ([]string, error)
 	// The method returns `null` unless this request has failed, as reported by `requestfailed` event.
-	// **Usage**
-	// Example of logging of all the failed requests:
 	Failure() *RequestFailure
 	// Returns the `Frame` that initiated this request.
 	Frame() Frame
@@ -2687,13 +1965,8 @@ type Request interface {
 	// When the server responds with a redirect, Playwright creates a new `Request` object. The two requests are connected
 	// by `redirectedFrom()` and `redirectedTo()` methods. When multiple server redirects has happened, it is possible to
 	// construct the whole redirect chain by repeatedly calling `redirectedFrom()`.
-	// **Usage**
-	// For example, if the website `http://example.com` redirects to `https://example.com`:
-	// If the website `https://google.com` has no redirects:
 	RedirectedFrom() Request
 	// New request issued by the browser if the server responded with redirect.
-	// **Usage**
-	// This method is the opposite of Request.redirectedFrom():
 	RedirectedTo() Request
 	// Contains the request's resource type as it was perceived by the rendering engine. ResourceType will be one of the
 	// following: `document`, `stylesheet`, `image`, `media`, `font`, `script`, `texttrack`, `xhr`, `fetch`,
@@ -2704,7 +1977,6 @@ type Request interface {
 	// Returns resource timing information for given request. Most of the timing values become available upon the
 	// response, `responseEnd` becomes available when request finishes. Find more information at
 	// [Resource Timing API](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming).
-	// **Usage**
 	Timing() *ResourceTiming
 	// URL of the request.
 	URL() string
@@ -2760,33 +2032,23 @@ type Response interface {
 	ServerAddr() (*ResponseServerAddrResult, error)
 }
 
-// Whenever a network route is set up with Page.route`] or [`method: BrowserContext.route(), the `Route`
+// Whenever a network route is set up with Page.route() or BrowserContext.route(), the `Route`
 // object allows to handle the route.
 // Learn more about [networking](../network.md).
 type Route interface {
 	// Aborts the route's request.
 	Abort(errorCode ...string) error
 	// Continues route's request with optional overrides.
-	// **Usage**
 	Continue(options ...RouteContinueOptions) error
 	// When several routes match the given pattern, they run in the order opposite to their registration. That way the
 	// last registered route can always override all the previous ones. In the example below, request will be handled by
 	// the bottom-most handler first, then it'll fall back to the previous one and in the end will be aborted by the first
 	// registered route.
-	// **Usage**
-	// Registering multiple routes is useful when you want separate handlers to handle different kinds of requests, for
-	// example API calls vs page resources or GET requests vs POST requests as in the example below.
-	// One can also modify request while falling back to the subsequent handler, that way intermediate route handler can
-	// modify url, method, headers and postData of the request.
 	Fallback(options ...RouteFallbackOptions) error
 	// Performs the request and fetches result without fulfilling it, so that the response could be modified and then
 	// fulfilled.
-	// **Usage**
 	Fetch(options ...RouteFetchOptions) (APIResponse, error)
 	// Fulfills route's request with given response.
-	// **Usage**
-	// An example of fulfilling all requests with 404 responses:
-	// An example of serving static file:
 	Fulfill(options RouteFulfillOptions) error
 	// A request to be routed.
 	Request() Request
@@ -2795,8 +2057,6 @@ type Route interface {
 // Selectors can be used to install custom selector engines. See [extensibility](../extensibility.md) for more
 // information.
 type Selectors interface {
-	// **Usage**
-	// An example of registering selector engine that queries elements based on a tag name:
 	Register(name string, option SelectorsRegisterOptions) error
 	// Defines custom attribute name to be used in Page.getByTestId(). `data-testid` is used by default.
 	SetTestIdAttribute(name string)
@@ -2819,7 +2079,7 @@ type WebSocket interface {
 	// Waits for event to fire and passes its value into the predicate function. Returns when the predicate returns truthy
 	// value. Will throw an error if the webSocket is closed before the event is fired. Returns the event data value.
 	ExpectEvent(event string, cb func() error, options ...WebSocketWaitForEventOptions) (interface{}, error)
-	// **NOTE** In most cases, you should use WebSocket.waitForEvent().
+	// **NOTE** In most cases, you should use WebSocket.ExpectForEvent().
 	// Waits for given `event` to fire. If predicate is provided, it passes event's value into the `predicate` function
 	// and waits for `predicate(event)` to return a truthy value. Will throw an error if the socket is closed before the
 	// `event` is fired.
@@ -2844,14 +2104,14 @@ type Video interface {
 type Worker interface {
 	EventEmitter
 	// Returns the return value of `expression`.
-	// If the function passed to the Worker.evaluate`] returns a [Promise], then [`method: Worker.evaluate()
+	// If the function passed to the Worker.evaluate() returns a [Promise], then Worker.evaluate()
 	// would wait for the promise to resolve and return its value.
 	// If the function passed to the Worker.evaluate() returns a non-[Serializable] value, then
 	// Worker.evaluate() returns `undefined`. Playwright also supports transferring some additional values that
 	// are not serializable by `JSON`: `-0`, `NaN`, `Infinity`, `-Infinity`.
 	Evaluate(expression string, options ...interface{}) (interface{}, error)
 	// Returns the return value of `expression` as a `JSHandle`.
-	// The only difference between Worker.evaluate`] and [`method: Worker.evaluateHandle() is that
+	// The only difference between Worker.evaluate() and Worker.evaluateHandle() is that
 	// Worker.evaluateHandle() returns `JSHandle`.
 	// If the function passed to the Worker.evaluateHandle() returns a [Promise], then
 	// Worker.evaluateHandle() would wait for the promise to resolve and return its value.

--- a/generated-interfaces.go
+++ b/generated-interfaces.go
@@ -902,6 +902,86 @@ type Frame interface {
 	FrameLocator(selector string) FrameLocator
 	// Returns element attribute value.
 	GetAttribute(selector string, name string, options ...PageGetAttributeOptions) (string, error)
+	// Allows locating elements by their alt text.
+	// **Usage**
+	// For example, this method will find the image by alt text "Playwright logo":
+	// ```html
+	// <img alt='Playwright logo'>
+	// ```
+	GetByAltText(text interface{}, options ...LocatorGetByAltTextOptions) (Locator, error)
+	// Allows locating input elements by the text of the associated label.
+	// **Usage**
+	// For example, this method will find the input by label text "Password" in the following DOM:
+	// ```html
+	// <label for="password-input">Password:</label>
+	// <input id="password-input">
+	// ```
+	GetByLabel(text interface{}, options ...LocatorGetByLabelOptions) (Locator, error)
+	// Allows locating input elements by the placeholder text.
+	// **Usage**
+	// For example, consider the following DOM structure.
+	// ```html
+	// <input type="email" placeholder="name@example.com" />
+	// ```
+	// You can fill the input after locating it by the placeholder text:
+	GetByPlaceholder(text interface{}, options ...LocatorGetByPlaceholderOptions) (Locator, error)
+	// Allows locating elements by their [ARIA role](https://www.w3.org/TR/wai-aria-1.2/#roles),
+	// [ARIA attributes](https://www.w3.org/TR/wai-aria-1.2/#aria-attributes) and
+	// [accessible name](https://w3c.github.io/accname/#dfn-accessible-name).
+	// **Usage**
+	// Consider the following DOM structure.
+	// ```html
+	// <h3>Sign up</h3>
+	// <label>
+	// <input type="checkbox" /> Subscribe
+	// </label>
+	// <br/>
+	// <button>Submit</button>
+	// ```
+	// You can locate each element by it's implicit role:
+	// **Details**
+	// Role selector **does not replace** accessibility audits and conformance tests, but rather gives early feedback
+	// about the ARIA guidelines.
+	// Many html elements have an implicitly [defined role](https://w3c.github.io/html-aam/#html-element-role-mappings)
+	// that is recognized by the role selector. You can find all the
+	// [supported roles here](https://www.w3.org/TR/wai-aria-1.2/#role_definitions). ARIA guidelines **do not recommend**
+	// duplicating implicit roles and attributes by setting `role` and/or `aria-*` attributes to default values.
+	GetByRole(role AriaRole, options ...LocatorGetByRoleOptions) (Locator, error)
+	// Locate element by the test id.
+	// **Usage**
+	// Consider the following DOM structure.
+	// ```html
+	// <button data-testid="directions">Itinéraire</button>
+	// ```
+	// You can locate the element by it's test id:
+	// **Details**
+	// By default, the `data-testid` attribute is used as a test id. Use Selectors.setTestIdAttribute() to
+	// configure a different test id attribute if necessary.
+	GetByTestId(testId interface{}) (Locator, error)
+	// Allows locating elements that contain given text.
+	// See also Locator.filter() that allows to match by another criteria, like an accessible role, and then
+	// filter by the text content.
+	// **Usage**
+	// Consider the following DOM structure:
+	// ```html
+	// <div>Hello <span>world</span></div>
+	// <div>Hello</div>
+	// ```
+	// You can locate by text substring, exact string, or a regular expression:
+	// **Details**
+	// Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into
+	// one, turns line breaks into spaces and ignores leading and trailing whitespace.
+	// Input elements of the type `button` and `submit` are matched by their `value` instead of the text content. For
+	// example, locating by text `"Log in"` matches `<input type=button value="Log in">`.
+	GetByText(text interface{}, options ...LocatorGetByTextOptions) (Locator, error)
+	// Allows locating elements by their title attribute.
+	// **Usage**
+	// Consider the following DOM structure.
+	// ```html
+	// <span title='Issues count'>25 issues</span>
+	// ```
+	// You can check the issues count after locating it by the title text:
+	GetByTitle(title interface{}, options ...LocatorGetByTitleOptions) (Locator, error)
 	// Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of
 	// the last redirect.
 	// The method will throw an error if:
@@ -1107,6 +1187,86 @@ type FrameLocator interface {
 	// options, similar to Locator.filter() method.
 	// [Learn more about locators](../locators.md).
 	Locator(selector string, options ...LocatorLocatorOptions) (Locator, error)
+	// Allows locating elements by their alt text.
+	// **Usage**
+	// For example, this method will find the image by alt text "Playwright logo":
+	// ```html
+	// <img alt='Playwright logo'>
+	// ```
+	GetByAltText(text interface{}, options ...LocatorGetByAltTextOptions) (Locator, error)
+	// Allows locating input elements by the text of the associated label.
+	// **Usage**
+	// For example, this method will find the input by label text "Password" in the following DOM:
+	// ```html
+	// <label for="password-input">Password:</label>
+	// <input id="password-input">
+	// ```
+	GetByLabel(text interface{}, options ...LocatorGetByLabelOptions) (Locator, error)
+	// Allows locating input elements by the placeholder text.
+	// **Usage**
+	// For example, consider the following DOM structure.
+	// ```html
+	// <input type="email" placeholder="name@example.com" />
+	// ```
+	// You can fill the input after locating it by the placeholder text:
+	GetByPlaceholder(text interface{}, options ...LocatorGetByPlaceholderOptions) (Locator, error)
+	// Allows locating elements by their [ARIA role](https://www.w3.org/TR/wai-aria-1.2/#roles),
+	// [ARIA attributes](https://www.w3.org/TR/wai-aria-1.2/#aria-attributes) and
+	// [accessible name](https://w3c.github.io/accname/#dfn-accessible-name).
+	// **Usage**
+	// Consider the following DOM structure.
+	// ```html
+	// <h3>Sign up</h3>
+	// <label>
+	// <input type="checkbox" /> Subscribe
+	// </label>
+	// <br/>
+	// <button>Submit</button>
+	// ```
+	// You can locate each element by it's implicit role:
+	// **Details**
+	// Role selector **does not replace** accessibility audits and conformance tests, but rather gives early feedback
+	// about the ARIA guidelines.
+	// Many html elements have an implicitly [defined role](https://w3c.github.io/html-aam/#html-element-role-mappings)
+	// that is recognized by the role selector. You can find all the
+	// [supported roles here](https://www.w3.org/TR/wai-aria-1.2/#role_definitions). ARIA guidelines **do not recommend**
+	// duplicating implicit roles and attributes by setting `role` and/or `aria-*` attributes to default values.
+	GetByRole(role AriaRole, options ...LocatorGetByRoleOptions) (Locator, error)
+	// Locate element by the test id.
+	// **Usage**
+	// Consider the following DOM structure.
+	// ```html
+	// <button data-testid="directions">Itinéraire</button>
+	// ```
+	// You can locate the element by it's test id:
+	// **Details**
+	// By default, the `data-testid` attribute is used as a test id. Use Selectors.setTestIdAttribute() to
+	// configure a different test id attribute if necessary.
+	GetByTestId(testId interface{}) (Locator, error)
+	// Allows locating elements that contain given text.
+	// See also Locator.filter() that allows to match by another criteria, like an accessible role, and then
+	// filter by the text content.
+	// **Usage**
+	// Consider the following DOM structure:
+	// ```html
+	// <div>Hello <span>world</span></div>
+	// <div>Hello</div>
+	// ```
+	// You can locate by text substring, exact string, or a regular expression:
+	// **Details**
+	// Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into
+	// one, turns line breaks into spaces and ignores leading and trailing whitespace.
+	// Input elements of the type `button` and `submit` are matched by their `value` instead of the text content. For
+	// example, locating by text `"Log in"` matches `<input type=button value="Log in">`.
+	GetByText(text interface{}, options ...LocatorGetByTextOptions) (Locator, error)
+	// Allows locating elements by their title attribute.
+	// **Usage**
+	// Consider the following DOM structure.
+	// ```html
+	// <span title='Issues count'>25 issues</span>
+	// ```
+	// You can check the issues count after locating it by the title text:
+	GetByTitle(title interface{}, options ...LocatorGetByTitleOptions) (Locator, error)
 	// Returns locator to the n-th matching frame. It's zero based, `nth(0)` selects the first frame.
 	Nth(index int) FrameLocator
 }
@@ -1211,6 +1371,9 @@ type Keyboard interface {
 // way to find element(s) on the page at any moment. Locator can be created with the Page.locator() method.
 // [Learn more about locators](../locators.md).
 type Locator interface {
+	// When locator points to a list of elements, returns array of locators, pointing to respective elements.
+	// **Usage**
+	All() ([]Locator, error)
 	// Returns an array of `node.innerText` values for all matching nodes.
 	// **Usage**
 	AllInnerTexts() ([]string, error)
@@ -1247,6 +1410,16 @@ type Locator interface {
 	// Passing zero timeout disables this.
 	// **Usage**
 	Check(options ...FrameCheckOptions) error
+	// Clear the input field.
+	// **Details**
+	// This method waits for [actionability](../actionability.md) checks, focuses the element, clears it and triggers an
+	// `input` event after clearing.
+	// If the target element is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an
+	// error. However, if the element is inside the `<label>` element that has an associated
+	// [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be cleared
+	// instead.
+	// **Usage**
+	Clear(options ...LocatorClearOptions) error
 	// Click an element.
 	// **Details**
 	// This method clicks the element by performing the following steps:
@@ -1344,6 +1517,10 @@ type Locator interface {
 	// instead.
 	// To send fine-grained keyboard events, use Locator.type().
 	Fill(value string, options ...FrameFillOptions) error
+	// This method narrows existing locator according to the options, for example filters by text. It can be chained to
+	// filter multiple times.
+	// **Usage**
+	Filter(options ...LocatorLocatorOptions) (Locator, error)
 	// Returns locator to the first matching element.
 	First() (Locator, error)
 	// Calls [focus](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus) on the matching element.
@@ -1354,6 +1531,86 @@ type Locator interface {
 	FrameLocator(selector string) FrameLocator
 	// Returns the matching element's attribute value.
 	GetAttribute(name string, options ...PageGetAttributeOptions) (string, error)
+	// Allows locating elements by their alt text.
+	// **Usage**
+	// For example, this method will find the image by alt text "Playwright logo":
+	// ```html
+	// <img alt='Playwright logo'>
+	// ```
+	GetByAltText(text interface{}, options ...LocatorGetByAltTextOptions) (Locator, error)
+	// Allows locating input elements by the text of the associated label.
+	// **Usage**
+	// For example, this method will find the input by label text "Password" in the following DOM:
+	// ```html
+	// <label for="password-input">Password:</label>
+	// <input id="password-input">
+	// ```
+	GetByLabel(text interface{}, options ...LocatorGetByLabelOptions) (Locator, error)
+	// Allows locating input elements by the placeholder text.
+	// **Usage**
+	// For example, consider the following DOM structure.
+	// ```html
+	// <input type="email" placeholder="name@example.com" />
+	// ```
+	// You can fill the input after locating it by the placeholder text:
+	GetByPlaceholder(text interface{}, options ...LocatorGetByPlaceholderOptions) (Locator, error)
+	// Allows locating elements by their [ARIA role](https://www.w3.org/TR/wai-aria-1.2/#roles),
+	// [ARIA attributes](https://www.w3.org/TR/wai-aria-1.2/#aria-attributes) and
+	// [accessible name](https://w3c.github.io/accname/#dfn-accessible-name).
+	// **Usage**
+	// Consider the following DOM structure.
+	// ```html
+	// <h3>Sign up</h3>
+	// <label>
+	// <input type="checkbox" /> Subscribe
+	// </label>
+	// <br/>
+	// <button>Submit</button>
+	// ```
+	// You can locate each element by it's implicit role:
+	// **Details**
+	// Role selector **does not replace** accessibility audits and conformance tests, but rather gives early feedback
+	// about the ARIA guidelines.
+	// Many html elements have an implicitly [defined role](https://w3c.github.io/html-aam/#html-element-role-mappings)
+	// that is recognized by the role selector. You can find all the
+	// [supported roles here](https://www.w3.org/TR/wai-aria-1.2/#role_definitions). ARIA guidelines **do not recommend**
+	// duplicating implicit roles and attributes by setting `role` and/or `aria-*` attributes to default values.
+	GetByRole(role AriaRole, options ...LocatorGetByRoleOptions) (Locator, error)
+	// Locate element by the test id.
+	// **Usage**
+	// Consider the following DOM structure.
+	// ```html
+	// <button data-testid="directions">Itinéraire</button>
+	// ```
+	// You can locate the element by it's test id:
+	// **Details**
+	// By default, the `data-testid` attribute is used as a test id. Use Selectors.setTestIdAttribute() to
+	// configure a different test id attribute if necessary.
+	GetByTestId(testId interface{}) (Locator, error)
+	// Allows locating elements that contain given text.
+	// See also Locator.filter() that allows to match by another criteria, like an accessible role, and then
+	// filter by the text content.
+	// **Usage**
+	// Consider the following DOM structure:
+	// ```html
+	// <div>Hello <span>world</span></div>
+	// <div>Hello</div>
+	// ```
+	// You can locate by text substring, exact string, or a regular expression:
+	// **Details**
+	// Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into
+	// one, turns line breaks into spaces and ignores leading and trailing whitespace.
+	// Input elements of the type `button` and `submit` are matched by their `value` instead of the text content. For
+	// example, locating by text `"Log in"` matches `<input type=button value="Log in">`.
+	GetByText(text interface{}, options ...LocatorGetByTextOptions) (Locator, error)
+	// Allows locating elements by their title attribute.
+	// **Usage**
+	// Consider the following DOM structure.
+	// ```html
+	// <span title='Issues count'>25 issues</span>
+	// ```
+	// You can check the issues count after locating it by the title text:
+	GetByTitle(title interface{}, options ...LocatorGetByTitleOptions) (Locator, error)
 	// Highlight the corresponding element(s) on the screen. Useful for debugging, don't commit the code that uses
 	// Locator.highlight().
 	Highlight() error
@@ -1780,6 +2037,86 @@ type Page interface {
 	FrameLocator(selector string) FrameLocator
 	// Returns element attribute value.
 	GetAttribute(selector string, name string, options ...PageGetAttributeOptions) (string, error)
+	// Allows locating elements by their alt text.
+	// **Usage**
+	// For example, this method will find the image by alt text "Playwright logo":
+	// ```html
+	// <img alt='Playwright logo'>
+	// ```
+	GetByAltText(text interface{}, options ...LocatorGetByAltTextOptions) (Locator, error)
+	// Allows locating input elements by the text of the associated label.
+	// **Usage**
+	// For example, this method will find the input by label text "Password" in the following DOM:
+	// ```html
+	// <label for="password-input">Password:</label>
+	// <input id="password-input">
+	// ```
+	GetByLabel(text interface{}, options ...LocatorGetByLabelOptions) (Locator, error)
+	// Allows locating input elements by the placeholder text.
+	// **Usage**
+	// For example, consider the following DOM structure.
+	// ```html
+	// <input type="email" placeholder="name@example.com" />
+	// ```
+	// You can fill the input after locating it by the placeholder text:
+	GetByPlaceholder(text interface{}, options ...LocatorGetByPlaceholderOptions) (Locator, error)
+	// Allows locating elements by their [ARIA role](https://www.w3.org/TR/wai-aria-1.2/#roles),
+	// [ARIA attributes](https://www.w3.org/TR/wai-aria-1.2/#aria-attributes) and
+	// [accessible name](https://w3c.github.io/accname/#dfn-accessible-name).
+	// **Usage**
+	// Consider the following DOM structure.
+	// ```html
+	// <h3>Sign up</h3>
+	// <label>
+	// <input type="checkbox" /> Subscribe
+	// </label>
+	// <br/>
+	// <button>Submit</button>
+	// ```
+	// You can locate each element by it's implicit role:
+	// **Details**
+	// Role selector **does not replace** accessibility audits and conformance tests, but rather gives early feedback
+	// about the ARIA guidelines.
+	// Many html elements have an implicitly [defined role](https://w3c.github.io/html-aam/#html-element-role-mappings)
+	// that is recognized by the role selector. You can find all the
+	// [supported roles here](https://www.w3.org/TR/wai-aria-1.2/#role_definitions). ARIA guidelines **do not recommend**
+	// duplicating implicit roles and attributes by setting `role` and/or `aria-*` attributes to default values.
+	GetByRole(role AriaRole, options ...LocatorGetByRoleOptions) (Locator, error)
+	// Locate element by the test id.
+	// **Usage**
+	// Consider the following DOM structure.
+	// ```html
+	// <button data-testid="directions">Itinéraire</button>
+	// ```
+	// You can locate the element by it's test id:
+	// **Details**
+	// By default, the `data-testid` attribute is used as a test id. Use Selectors.setTestIdAttribute() to
+	// configure a different test id attribute if necessary.
+	GetByTestId(testId interface{}) (Locator, error)
+	// Allows locating elements that contain given text.
+	// See also Locator.filter() that allows to match by another criteria, like an accessible role, and then
+	// filter by the text content.
+	// **Usage**
+	// Consider the following DOM structure:
+	// ```html
+	// <div>Hello <span>world</span></div>
+	// <div>Hello</div>
+	// ```
+	// You can locate by text substring, exact string, or a regular expression:
+	// **Details**
+	// Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into
+	// one, turns line breaks into spaces and ignores leading and trailing whitespace.
+	// Input elements of the type `button` and `submit` are matched by their `value` instead of the text content. For
+	// example, locating by text `"Log in"` matches `<input type=button value="Log in">`.
+	GetByText(text interface{}, options ...LocatorGetByTextOptions) (Locator, error)
+	// Allows locating elements by their title attribute.
+	// **Usage**
+	// Consider the following DOM structure.
+	// ```html
+	// <span title='Issues count'>25 issues</span>
+	// ```
+	// You can check the issues count after locating it by the title text:
+	GetByTitle(title interface{}, options ...LocatorGetByTitleOptions) (Locator, error)
 	// Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of
 	// the last redirect. If can not go back, returns `null`.
 	// Navigate to the previous page in history.
@@ -2234,6 +2571,16 @@ type Route interface {
 	Fulfill(options RouteFulfillOptions) error
 	// A request to be routed.
 	Request() Request
+}
+
+// Selectors can be used to install custom selector engines. See [extensibility](../extensibility.md) for more
+// information.
+type Selectors interface {
+	// **Usage**
+	// An example of registering selector engine that queries elements based on a tag name:
+	Register(name string, option SelectorsRegisterOptions) error
+	// Defines custom attribute name to be used in Page.getByTestId(). `data-testid` is used by default.
+	SetTestIdAttribute(name string)
 }
 
 // The Touchscreen class operates in main-frame CSS pixels relative to the top-left corner of the viewport. Methods on

--- a/generated-interfaces.go
+++ b/generated-interfaces.go
@@ -1210,6 +1210,8 @@ type Locator interface {
 	// Returns an array of `node.textContent` values for all matching nodes.
 	// **Usage**
 	AllTextContents() ([]string, error)
+	// Calls [blur](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/blur) on the element.
+	Blur(options ...LocatorBlurOptions) error
 	// This method returns the bounding box of the element matching the locator, or `null` if the element is not visible.
 	// The bounding box is calculated relative to the main frame viewport - which is usually the same as the browser
 	// window.

--- a/generated-interfaces.go
+++ b/generated-interfaces.go
@@ -249,6 +249,10 @@ type BrowserContext interface {
 	// value. Will throw an error if the context closes before the event is fired. Returns the event data value.
 	// **Usage**
 	ExpectEvent(event string, cb func() error, options ...BrowserContextWaitForEventOptions) (interface{}, error)
+	// Performs action and waits for a new `Page` to be created in the context. If predicate is provided, it passes `Page`
+	// value into the `predicate` function and waits for `predicate(event)` to return a truthy value. Will throw an error
+	// if the context closes before new `Page` is created.
+	ExpectPage(cb func() error, options ...BrowserContextExpectPageOptions) (Page, error)
 	// The method adds a function called `name` on the `window` object of every frame in every page in the context. When
 	// called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`.
 	// If the `callback` returns a [Promise], it will be awaited.

--- a/generated-interfaces.go
+++ b/generated-interfaces.go
@@ -204,6 +204,20 @@ type Browser interface {
 	// **NOTE** CDP Sessions are only supported on Chromium-based browsers.
 	// Returns the newly created browser session.
 	NewBrowserCDPSession() (CDPSession, error)
+	// **NOTE** This API controls
+	// [Chromium Tracing](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool) which is a low-level
+	// chromium-specific debugging tool. API to control [Playwright Tracing](../trace-viewer) could be found
+	// [here](./class-tracing).
+	// You can use Browser.startTracing`] and [`method: Browser.stopTracing() to create a trace file that can be
+	// opened in Chrome DevTools performance panel.
+	// **Usage**
+	StartTracing(options ...BrowserStartTracingOptions) error
+	// **NOTE** This API controls
+	// [Chromium Tracing](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool) which is a low-level
+	// chromium-specific debugging tool. API to control [Playwright Tracing](../trace-viewer) could be found
+	// [here](./class-tracing).
+	// Returns the buffer with trace data.
+	StopTracing() ([]byte, error)
 	// Returns the browser version.
 	Version() string
 }

--- a/generated-structs.go
+++ b/generated-structs.go
@@ -585,6 +585,13 @@ type BrowserContextExpectEventOptions struct {
 	// `0` to disable timeout. The default value can be changed by using the BrowserContext.SetDefaultTimeout().
 	Timeout *float64 `json:"timeout"`
 }
+type BrowserContextExpectPageOptions struct {
+	// Receives the Page object and resolves to truthy value when the waiting should resolve.
+	Predicate func(Page) bool `json:"predicate"`
+	// Maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass
+	// `0` to disable timeout. The default value can be changed by using the BrowserContext.SetDefaultTimeout().
+	Timeout *float64 `json:"timeout"`
+}
 type BrowserContextWaitForEventOptions struct {
 	// Receives the event data and resolves to truthy value when the waiting should resolve.
 	Predicate interface{} `json:"predicate"`

--- a/generated-structs.go
+++ b/generated-structs.go
@@ -3312,6 +3312,14 @@ type PageWaitForRequestOptions struct {
 	// method.
 	Timeout *float64 `json:"timeout"`
 }
+type PageExpectRequestFinishedOptions struct {
+	// Receives the Request object and resolves to truthy value when the waiting should
+	// resolve.
+	Predicate func(Request) bool `json:"predicate"`
+	// Maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass
+	// `0` to disable timeout. The default value can be changed by using the BrowserContext.SetDefaultTimeout().
+	Timeout *float64 `json:"timeout"`
+}
 type PageWaitForResponseOptions struct {
 	// Maximum wait time in milliseconds, defaults to 30 seconds, pass `0` to disable the
 	// timeout. The default value can be changed by using the BrowserContext.SetDefaultTimeout()
@@ -3562,6 +3570,20 @@ type FrameReceivedPayload struct {
 type FrameSentPayload struct {
 	// frame payload
 	Payload interface{} `json:"payload"`
+}
+type WebSocketExpectEventOptions struct {
+	// Receives the event data and resolves to truthy value when the waiting should resolve.
+	Predicate interface{} `json:"predicate"`
+	// Maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass
+	// `0` to disable timeout. The default value can be changed by using the BrowserContext.SetDefaultTimeout().
+	Timeout *float64 `json:"timeout"`
+}
+type WebSocketWaitForEventOptions struct {
+	// Receives the event data and resolves to truthy value when the waiting should resolve.
+	Predicate interface{} `json:"predicate"`
+	// Maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass
+	// `0` to disable timeout. The default value can be changed by using the BrowserContext.SetDefaultTimeout().
+	Timeout *float64 `json:"timeout"`
 }
 type WorkerEvaluateOptions struct {
 	// Optional argument to pass to `expression`.

--- a/generated-structs.go
+++ b/generated-structs.go
@@ -2419,31 +2419,91 @@ type LocatorWaitForOptions struct {
 }
 type LocatorAssertionsToBeCheckedOptions struct {
 	Checked *bool `json:"checked"`
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToBeDisabledOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
 }
 type LocatorAssertionsToBeEditableOptions struct {
 	Editable *bool `json:"editable"`
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToBeEmptyOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
 }
 type LocatorAssertionsToBeEnabledOptions struct {
 	Enabled *bool `json:"enabled"`
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToBeFocusedOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToBeHiddenOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
 }
 type LocatorAssertionsToBeVisibleOptions struct {
-	Visible *bool `json:"visible"`
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+	Visible *bool    `json:"visible"`
 }
 type LocatorAssertionsToContainTextOptions struct {
 	// Whether to perform case-insensitive match. `ignoreCase` option takes precedence
 	// over the corresponding regular expression flag if specified.
 	IgnoreCase *bool `json:"ignoreCase"`
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
 	// Whether to use `element.innerText` instead of `element.textContent` when retrieving
 	// DOM node text.
 	UseInnerText *bool `json:"useInnerText"`
+}
+type LocatorAssertionsToHaveAttributeOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToHaveClassOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToHaveCountOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToHaveCSSOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToHaveIdOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToHaveJSPropertyOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
 }
 type LocatorAssertionsToHaveTextOptions struct {
 	// Whether to perform case-insensitive match. `ignoreCase` option takes precedence
 	// over the corresponding regular expression flag if specified.
 	IgnoreCase *bool `json:"ignoreCase"`
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
 	// Whether to use `element.innerText` instead of `element.textContent` when retrieving
 	// DOM node text.
 	UseInnerText *bool `json:"useInnerText"`
+}
+type LocatorAssertionsToHaveValueOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type LocatorAssertionsToHaveValuesOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
 }
 type MouseClickOptions struct {
 	// Defaults to `left`.
@@ -3381,6 +3441,14 @@ type PageWaitForEventOptions struct {
 	Predicate interface{} `json:"predicate"`
 	// Maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass
 	// `0` to disable timeout. The default value can be changed by using the BrowserContext.SetDefaultTimeout().
+	Timeout *float64 `json:"timeout"`
+}
+type PageAssertionsToHaveTitleOptions struct {
+	// Time to retry the assertion for.
+	Timeout *float64 `json:"timeout"`
+}
+type PageAssertionsToHaveURLOptions struct {
+	// Time to retry the assertion for.
 	Timeout *float64 `json:"timeout"`
 }
 

--- a/generated-structs.go
+++ b/generated-structs.go
@@ -3535,6 +3535,12 @@ type SelectorsRegisterOptions struct {
 	// Defaults to `false`. Note that running as a content script is not guaranteed when
 	// this engine is used together with other registered engines.
 	ContentScript *bool `json:"contentScript"`
+	// Script that evaluates to a selector engine instance. The script is evaluated in
+	// the page context.
+	Path *string `json:"path"`
+	// Script that evaluates to a selector engine instance. The script is evaluated in
+	// the page context.
+	Script *string `json:"script"`
 }
 type TracingStartOptions struct {
 	// If specified, the trace is going to be saved into the file with the given name inside

--- a/generated-structs.go
+++ b/generated-structs.go
@@ -527,6 +527,16 @@ type BrowserNewPageOptions struct {
 	// disables the fixed viewport.
 	Viewport *ViewportSize `json:"viewport"`
 }
+type BrowserStartTracingOptions struct {
+	// specify custom categories to use instead of default.
+	Categories []string `json:"categories"`
+	// Optional, if specified, tracing includes screenshots of the given page.
+	Page Page `json:"page"`
+	// A path to write the trace file to.
+	Path *string `json:"path"`
+	// captures screenshots in the trace.
+	Screenshots *bool `json:"screenshots"`
+}
 type BrowserContextAddCookiesOptions struct {
 	Cookies []OptionalCookie `json:"cookies"`
 }

--- a/generated-structs.go
+++ b/generated-structs.go
@@ -3508,6 +3508,9 @@ type RouteFulfillOptions struct {
 	// If `path` is a relative path, then it is resolved relative to the current working
 	// directory.
 	Path *string `json:"path"`
+	// APIResponse to fulfill route's request with. Individual fields of the response (such
+	// as headers) can be overridden using fulfill options.
+	Response APIResponse `json:"response"`
 	// Response status code, defaults to `200`.
 	Status *int `json:"status"`
 }

--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,13 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/h2non/filetype v1.1.3
 	github.com/stretchr/testify v1.8.2
+	github.com/tidwall/gjson v1.14.4
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,12 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
+github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/har_router.go
+++ b/har_router.go
@@ -1,0 +1,115 @@
+package playwright
+
+import (
+	"errors"
+	"log"
+)
+
+type harRouter struct {
+	localUtils     *localUtilsImpl
+	harId          string
+	notFoundAction HarNotFound
+	urlOrPredicate interface{}
+	err            error
+}
+
+func (r *harRouter) addContextRoute(context BrowserContext) error {
+	if r.err != nil {
+		return r.err
+	}
+	err := context.Route(r.urlOrPredicate, func(route Route) {
+		err := r.handle(route)
+		if err != nil {
+			log.Println(err)
+		}
+	})
+	if err != nil {
+		return err
+	}
+	context.Once("close", r.dispose)
+	return r.err
+}
+
+func (r *harRouter) addPageRoute(page Page) error {
+	if r.err != nil {
+		return r.err
+	}
+	err := page.Route(r.urlOrPredicate, func(route Route) {
+		err := r.handle(route)
+		if err != nil {
+			log.Println(err)
+		}
+	})
+	if err != nil {
+		return err
+	}
+	page.Once("close", r.dispose)
+	return r.err
+}
+
+func (r *harRouter) dispose() {
+	go func() {
+		r.err = r.localUtils.HarClose(r.harId)
+	}()
+}
+
+func (r *harRouter) handle(route Route) error {
+	if r.err != nil {
+		return r.err
+	}
+	request := route.Request()
+	postData, err := request.PostDataBuffer()
+	if err != nil {
+		return err
+	}
+	response, err := r.localUtils.HarLookup(harLookupOptions{
+		HarId:               r.harId,
+		URL:                 request.URL(),
+		Method:              request.Method(),
+		Headers:             request.Headers(),
+		IsNavigationRequest: request.IsNavigationRequest(),
+		PostData:            postData,
+	})
+	if err != nil {
+		return err
+	}
+	switch response.Action {
+	case "redirect":
+		if response.RedirectURL == nil {
+			return errors.New("redirect url is null")
+		}
+		return route.(*routeImpl).redirectedNavigationRequest(*response.RedirectURL)
+	case "fulfill":
+		if response.Body == nil {
+			return errors.New("fulfill body is null")
+		}
+		return route.Fulfill(RouteFulfillOptions{
+			Body:    *response.Body,
+			Status:  response.Status,
+			Headers: deserializeNameAndValueToMap(response.Headers),
+		})
+	case "error":
+		log.Printf("har action error: %v", *response.Message)
+		fallthrough
+	case "noentry":
+	}
+	if r.notFoundAction == *HarNotFoundAbort {
+		return route.Abort()
+	}
+	return route.Fallback()
+}
+
+func newHarRouter(localUtils *localUtilsImpl, file string, notFoundAction HarNotFound, urlOrPredicate interface{}) *harRouter {
+	harId, err := localUtils.HarOpen(file)
+	var url interface{} = "**/*"
+	if urlOrPredicate != nil {
+		url = urlOrPredicate
+	}
+	return &harRouter{
+		localUtils:     localUtils,
+		harId:          harId,
+		notFoundAction: notFoundAction,
+		urlOrPredicate: url,
+		err:            err,
+	}
+}

--- a/helpers.go
+++ b/helpers.go
@@ -169,13 +169,6 @@ func remapMapToStruct(inputMap interface{}, outStruct interface{}) {
 	remapValue(reflect.ValueOf(inputMap), reflect.ValueOf(outStruct).Elem())
 }
 
-func isFunctionBody(expression string) bool {
-	expression = strings.TrimSpace(expression)
-	return strings.HasPrefix(expression, "function") ||
-		strings.HasPrefix(expression, "async ") ||
-		strings.Contains(expression, "=> ")
-}
-
 type urlMatcher struct {
 	urlOrPredicate interface{}
 }

--- a/helpers.go
+++ b/helpers.go
@@ -220,8 +220,15 @@ type routeHandlerEntry struct {
 	count   int32
 }
 
-func (r *routeHandlerEntry) Hit() {
+func (r *routeHandlerEntry) Matches(url string) bool {
+	return r.matcher.Matches(url)
+}
+
+func (r *routeHandlerEntry) Handle(route Route) chan bool {
+	handled := route.(*routeImpl).startHandling()
 	atomic.AddInt32(&r.count, 1)
+	r.handler(route)
+	return handled
 }
 
 func (r *routeHandlerEntry) WillExceed() bool {
@@ -473,4 +480,59 @@ func assignStructFields(dest, src interface{}, omitExtra bool) error {
 	}
 
 	return nil
+}
+
+func deserializeNameAndValueToMap(headersArray []map[string]string) map[string]string {
+	unserialized := make(map[string]string)
+	for _, item := range headersArray {
+		unserialized[item["name"]] = item["value"]
+	}
+	return unserialized
+}
+
+type recordHarOptions struct {
+	Path           string            `json:"path"`
+	Content        *HarContentPolicy `json:"content,omitempty"`
+	Mode           *HarMode          `json:"mode,omitempty"`
+	UrlGlob        *string           `json:"urlGlob,omitempty"`
+	UrlRegexSource *string           `json:"urlRegexSource,omitempty"`
+	UrlRegexFlags  *string           `json:"urlRegexFlags,omitempty"`
+}
+
+type recordHarInputOptions struct {
+	Path        string
+	URL         interface{}
+	Mode        *HarMode
+	Content     *HarContentPolicy
+	OmitContent *bool
+}
+
+type harRecordingMetadata struct {
+	Path    string
+	Content *HarContentPolicy
+}
+
+func prepareRecordHarOptions(option recordHarInputOptions) recordHarOptions {
+	out := recordHarOptions{
+		Path: option.Path,
+	}
+	if option.URL != nil {
+		switch option.URL.(type) {
+		case *regexp.Regexp:
+			pattern, flags := convertRegexp(option.URL.(*regexp.Regexp))
+			out.UrlRegexSource = String(pattern)
+			out.UrlRegexFlags = String(flags)
+		case string:
+			out.UrlGlob = String(option.URL.(string))
+		}
+	}
+	if option.Mode != nil {
+		out.Mode = option.Mode
+	}
+	if option.Content != nil {
+		out.Content = option.Content
+	} else if option.OmitContent != nil && *option.OmitContent {
+		out.Content = HarContentPolicyOmit
+	}
+	return out
 }

--- a/input.go
+++ b/input.go
@@ -48,6 +48,14 @@ func (m *mouseImpl) Dblclick(x, y float64, options ...MouseDblclickOptions) erro
 	})
 }
 
+func (m *mouseImpl) Wheel(deltaX, deltaY float64) error {
+	_, err := m.channel.Send("mouseWheel", map[string]interface{}{
+		"deltaX": deltaX,
+		"deltaY": deltaY,
+	})
+	return err
+}
+
 type keyboardImpl struct {
 	channel *channel
 }

--- a/js_handle.go
+++ b/js_handle.go
@@ -17,19 +17,11 @@ type jsHandleImpl struct {
 
 func (j *jsHandleImpl) Evaluate(expression string, options ...interface{}) (interface{}, error) {
 	var arg interface{}
-	forceExpression := false
-	if !isFunctionBody(expression) {
-		forceExpression = true
-	}
 	if len(options) == 1 {
 		arg = options[0]
-	} else if len(options) == 2 {
-		arg = options[0]
-		forceExpression = options[1].(bool)
 	}
 	result, err := j.channel.Send("evaluateExpression", map[string]interface{}{
 		"expression": expression,
-		"isFunction": !forceExpression,
 		"arg":        serializeArgument(arg),
 	})
 	if err != nil {
@@ -40,19 +32,11 @@ func (j *jsHandleImpl) Evaluate(expression string, options ...interface{}) (inte
 
 func (j *jsHandleImpl) EvaluateHandle(expression string, options ...interface{}) (JSHandle, error) {
 	var arg interface{}
-	forceExpression := false
-	if !isFunctionBody(expression) {
-		forceExpression = true
-	}
 	if len(options) == 1 {
 		arg = options[0]
-	} else if len(options) == 2 {
-		arg = options[0]
-		forceExpression = options[1].(bool)
 	}
 	result, err := j.channel.Send("evaluateExpressionHandle", map[string]interface{}{
 		"expression": expression,
-		"isFunction": !forceExpression,
 		"arg":        serializeArgument(arg),
 	})
 	if err != nil {

--- a/local_utils.go
+++ b/local_utils.go
@@ -1,7 +1,117 @@
 package playwright
 
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
 type localUtilsImpl struct {
 	channelOwner
+}
+
+type (
+	localUtilsZipOptions struct {
+		ZipFile string        `json:"zipFile"`
+		Entries []interface{} `json:"entries"`
+	}
+
+	harLookupOptions struct {
+		HarId               string            `json:"harId"`
+		URL                 string            `json:"url"`
+		Method              string            `json:"method"`
+		Headers             map[string]string `json:"headers"`
+		IsNavigationRequest bool              `json:"isNavigationRequest"`
+		PostData            interface{}       `json:"postData,omitempty"`
+	}
+
+	harLookupResult struct {
+		Action      string              `json:"action"`
+		Message     *string             `json:"message,omitempty"`
+		RedirectURL *string             `json:"redirectUrl,omitempty"`
+		Status      *int                `json:"status,omitempty"`
+		Headers     []map[string]string `json:"headers,omitempty"`
+		Body        *string             `json:"body,omitempty"`
+	}
+)
+
+func (l *localUtilsImpl) Zip(options localUtilsZipOptions) (interface{}, error) {
+	return l.channel.Send("zip", options)
+}
+
+func (l *localUtilsImpl) HarOpen(file string) (string, error) {
+	harId, err := l.channel.Send("harOpen", []map[string]interface{}{
+		{
+			"file": file,
+		},
+	})
+	if harId == nil {
+		return "", err
+	}
+	return harId.(string), err
+}
+
+func (l *localUtilsImpl) HarLookup(option harLookupOptions) (*harLookupResult, error) {
+	overrides := make(map[string]interface{})
+	overrides["harId"] = option.HarId
+	overrides["url"] = option.URL
+	overrides["method"] = option.Method
+	if option.Headers != nil {
+		overrides["headers"] = serializeMapToNameAndValue(option.Headers)
+	}
+	overrides["isNavigationRequest"] = option.IsNavigationRequest
+	if option.PostData != nil {
+		switch v := option.PostData.(type) {
+		case string:
+			overrides["postData"] = base64.StdEncoding.EncodeToString([]byte(v))
+		case []byte:
+			overrides["postData"] = base64.StdEncoding.EncodeToString(v)
+		}
+	}
+	ret, err := l.channel.SendReturnAsDict("harLookup", overrides)
+	if ret == nil {
+		return nil, err
+	}
+	retMap, ok := ret.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("expected harLookupResult, got %T", retMap)
+	}
+	var result harLookupResult
+	mJson, err := json.Marshal(ret)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(mJson, &result)
+	if err != nil {
+		return nil, err
+	}
+	if result.Body != nil {
+		body, err := base64.StdEncoding.DecodeString(*result.Body)
+		if err != nil {
+			return nil, err
+		}
+		result.Body = String(string(body))
+	}
+	return &result, err
+}
+
+func (l *localUtilsImpl) HarClose(harId string) error {
+	_, err := l.channel.Send("harClose", []map[string]interface{}{
+		{
+			"harId": harId,
+		},
+	})
+	return err
+}
+
+func (l *localUtilsImpl) HarUnzip(zipFile, harFile string) error {
+	_, err := l.channel.Send("harUnzip", []map[string]interface{}{
+		{
+			"zipFile": zipFile,
+			"harFile": harFile,
+		},
+	})
+	return err
 }
 
 func newLocalUtils(parent *channelOwner, objectType string, guid string, initializer map[string]interface{}) *localUtilsImpl {

--- a/locator.go
+++ b/locator.go
@@ -21,7 +21,8 @@ func newLocator(frame *frameImpl, selector string, options ...LocatorLocatorOpti
 		if option.HasText != nil {
 			switch hasText := option.HasText.(type) {
 			case *regexp.Regexp:
-				selector += fmt.Sprintf(" >> :scope:text-matches(%s)", convertRegexp(hasText))
+				pattern, flags := convertRegexp(hasText)
+				selector += fmt.Sprintf(" >> :scope:text-matches('%s', '%s')", pattern, flags)
 			case string:
 				selector += fmt.Sprintf(" >> :scope:has-text('%s')", hasText)
 			}
@@ -42,17 +43,16 @@ func newLocator(frame *frameImpl, selector string, options ...LocatorLocatorOpti
 	return &locatorImpl{frame: frame, selector: selector, options: option}, nil
 }
 
-func convertRegexp(reg *regexp.Regexp) string {
+func convertRegexp(reg *regexp.Regexp) (pattern, flags string) {
 	matches := regexp.MustCompile(`\(\?([imsU]+)\)(.+)`).FindStringSubmatch(reg.String())
 
-	var pattern, flags string
 	if len(matches) == 3 {
 		pattern = matches[2]
 		flags = matches[1]
 	} else {
 		pattern = reg.String()
 	}
-	return fmt.Sprintf("'%s', '%s'", pattern, flags)
+	return
 }
 
 func (l *locatorImpl) AllInnerTexts() ([]string, error) {

--- a/locator.go
+++ b/locator.go
@@ -81,6 +81,20 @@ func (l *locatorImpl) AllTextContents() ([]string, error) {
 	return result, nil
 }
 
+func (l *locatorImpl) Blur(options ...LocatorBlurOptions) error {
+	params := map[string]interface{}{
+		"selector": l.selector,
+		"strict":   true,
+	}
+	if len(options) == 1 {
+		if options[0].Timeout != nil {
+			params["timeout"] = options[0].Timeout
+		}
+	}
+	_, err := l.frame.channel.Send("blur", params)
+	return err
+}
+
 func (l *locatorImpl) BoundingBox(options ...LocatorBoundingBoxOptions) (*Rect, error) {
 	var option PageWaitForSelectorOptions
 	if len(options) == 1 {

--- a/locator_assertions.go
+++ b/locator_assertions.go
@@ -1,0 +1,422 @@
+package playwright
+
+import (
+	"regexp"
+)
+
+type locatorAssertionsImpl struct {
+	assertionsBase
+}
+
+func newLocatorAssertions(locator Locator, isNot bool, defaultTimeout *float64) *locatorAssertionsImpl {
+	return &locatorAssertionsImpl{
+		assertionsBase: assertionsBase{
+			actualLocator:  locator,
+			isNot:          isNot,
+			defaultTimeout: defaultTimeout,
+		},
+	}
+}
+
+func (la *locatorAssertionsImpl) ToBeChecked(options ...LocatorAssertionsToBeCheckedOptions) error {
+	var expression = "to.be.checked"
+	var timeout *float64
+	if len(options) == 1 {
+		if options[0].Checked != nil && !*options[0].Checked {
+			expression = "to.be.unchecked"
+		}
+		timeout = options[0].Timeout
+	}
+	return la.expect(
+		expression,
+		frameExpectOptions{Timeout: timeout},
+		nil,
+		"Locator expected to be checked",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToBeDisabled(options ...LocatorAssertionsToBeDisabledOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	return la.expect(
+		"to.be.disabled",
+		frameExpectOptions{Timeout: timeout},
+		nil,
+		"Locator expected to be disabled",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToBeEditable(options ...LocatorAssertionsToBeEditableOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	return la.expect(
+		"to.be.editable",
+		frameExpectOptions{Timeout: timeout},
+		nil,
+		"Locator expected to be editable",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToBeEmpty(options ...LocatorAssertionsToBeEmptyOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	return la.expect(
+		"to.be.empty",
+		frameExpectOptions{Timeout: timeout},
+		nil,
+		"Locator expected to be empty",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToBeEnabled(options ...LocatorAssertionsToBeEnabledOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	return la.expect(
+		"to.be.enabled",
+		frameExpectOptions{Timeout: timeout},
+		nil,
+		"Locator expected to be enabled",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToBeFocused(options ...LocatorAssertionsToBeFocusedOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	return la.expect(
+		"to.be.focused",
+		frameExpectOptions{Timeout: timeout},
+		nil,
+		"Locator expected to be focused",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToBeHidden(options ...LocatorAssertionsToBeHiddenOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	return la.expect(
+		"to.be.hidden",
+		frameExpectOptions{Timeout: timeout},
+		nil,
+		"Locator expected to be hidden",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToBeVisible(options ...LocatorAssertionsToBeVisibleOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	return la.expect(
+		"to.be.visible",
+		frameExpectOptions{Timeout: timeout},
+		nil,
+		"Locator expected to be visible",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToContainText(expected interface{}, options ...LocatorAssertionsToContainTextOptions) error {
+	var (
+		timeout      *float64
+		useInnerText *bool
+		ignoreCase   *bool
+	)
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+		useInnerText = options[0].UseInnerText
+		ignoreCase = options[0].IgnoreCase
+	}
+
+	switch expected.(type) {
+	case []string, []*regexp.Regexp:
+		expectedText := toExpectedTextValues(convertToInterfaceList(expected), true, true, ignoreCase)
+		return la.expect(
+			"to.contain.text.array",
+			frameExpectOptions{
+				ExpectedText: expectedText,
+				UseInnerText: useInnerText,
+				Timeout:      timeout,
+			},
+			expected,
+			"Locator expected to contain text",
+		)
+	default:
+		expectedText := toExpectedTextValues([]interface{}{expected}, true, true, ignoreCase)
+		return la.expect(
+			"to.have.text",
+			frameExpectOptions{
+				ExpectedText: expectedText,
+				UseInnerText: useInnerText,
+				Timeout:      timeout,
+			},
+			expected,
+			"Locator expected to contain text",
+		)
+	}
+}
+
+func (la *locatorAssertionsImpl) ToHaveAttribute(name string, value interface{}, options ...LocatorAssertionsToHaveAttributeOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	expectedText := toExpectedTextValues([]interface{}{value}, false, false, nil)
+	return la.expect(
+		"to.have.attribute",
+		frameExpectOptions{
+			ExpressionArg: name,
+			ExpectedText:  expectedText,
+			Timeout:       timeout,
+		},
+		value,
+		"Locator expected to have attribute",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToHaveClass(expected interface{}, options ...LocatorAssertionsToHaveClassOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	switch expected.(type) {
+	case []string, []*regexp.Regexp:
+		expectedText := toExpectedTextValues(convertToInterfaceList(expected), false, false, nil)
+		return la.expect(
+			"to.have.class.array",
+			frameExpectOptions{
+				ExpectedText: expectedText,
+				Timeout:      timeout,
+			},
+			expected,
+			"Locator expected to have class",
+		)
+	default:
+		expectedText := toExpectedTextValues([]interface{}{expected}, false, false, nil)
+		return la.expect(
+			"to.have.class",
+			frameExpectOptions{
+				ExpectedText: expectedText,
+				Timeout:      timeout,
+			},
+			expected,
+			"Locator expected to have class",
+		)
+	}
+}
+
+func (la *locatorAssertionsImpl) ToHaveCount(count int, options ...LocatorAssertionsToHaveCountOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	return la.expect(
+		"to.have.count",
+		frameExpectOptions{ExpectedNumber: &count, Timeout: timeout},
+		count,
+		"Locator expected to have count",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToHaveCSS(name string, value interface{}, options ...LocatorAssertionsToHaveCSSOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	expectedText := toExpectedTextValues([]interface{}{value}, false, false, nil)
+	return la.expect(
+		"to.have.css",
+		frameExpectOptions{
+			ExpressionArg: name,
+			ExpectedText:  expectedText,
+			Timeout:       timeout,
+		},
+		value,
+		"Locator expected to have CSS",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToHaveId(id interface{}, options ...LocatorAssertionsToHaveIdOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	expectedText := toExpectedTextValues([]interface{}{id}, false, false, nil)
+	return la.expect(
+		"to.have.id",
+		frameExpectOptions{ExpectedText: expectedText, Timeout: timeout},
+		id,
+		"Locator expected to have ID",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToHaveJSProperty(name string, value interface{}, options ...LocatorAssertionsToHaveJSPropertyOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	return la.expect(
+		"to.have.property",
+		frameExpectOptions{
+			ExpressionArg: name,
+			ExpectedValue: value,
+			Timeout:       timeout,
+		},
+		value,
+		"Locator expected to have JS Property",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToHaveText(expected interface{}, options ...LocatorAssertionsToHaveTextOptions) error {
+	var (
+		timeout      *float64
+		useInnerText *bool
+		ignoreCase   *bool
+	)
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+		useInnerText = options[0].UseInnerText
+		ignoreCase = options[0].IgnoreCase
+	}
+
+	switch expected.(type) {
+	case []string, []*regexp.Regexp:
+		expectedText := toExpectedTextValues(convertToInterfaceList(expected), false, true, ignoreCase)
+		return la.expect(
+			"to.have.text.array",
+			frameExpectOptions{
+				ExpectedText: expectedText,
+				UseInnerText: useInnerText,
+				Timeout:      timeout,
+			},
+			expected,
+			"Locator expected to have text",
+		)
+	default:
+		expectedText := toExpectedTextValues([]interface{}{expected}, false, true, ignoreCase)
+		return la.expect(
+			"to.have.text",
+			frameExpectOptions{
+				ExpectedText: expectedText,
+				UseInnerText: useInnerText,
+				Timeout:      timeout,
+			},
+			expected,
+			"Locator expected to have text",
+		)
+	}
+}
+
+func (la *locatorAssertionsImpl) ToHaveValue(value interface{}, options ...LocatorAssertionsToHaveValueOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	expectedText := toExpectedTextValues([]interface{}{value}, false, false, nil)
+	return la.expect(
+		"to.have.value",
+		frameExpectOptions{ExpectedText: expectedText, Timeout: timeout},
+		value,
+		"Locator expected to have Value",
+	)
+}
+
+func (la *locatorAssertionsImpl) ToHaveValues(values []interface{}, options ...LocatorAssertionsToHaveValuesOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	expectedText := toExpectedTextValues(values, false, false, nil)
+	return la.expect(
+		"to.have.values",
+		frameExpectOptions{ExpectedText: expectedText, Timeout: timeout},
+		values,
+		"Locator expected to have Values",
+	)
+}
+
+func (la *locatorAssertionsImpl) NotToBeChecked(options ...LocatorAssertionsToBeCheckedOptions) error {
+	return la.Not().ToBeChecked(options...)
+}
+
+func (la *locatorAssertionsImpl) NotToBeDisabled(options ...LocatorAssertionsToBeDisabledOptions) error {
+	return la.Not().ToBeDisabled(options...)
+}
+
+func (la *locatorAssertionsImpl) NotToBeEditable(options ...LocatorAssertionsToBeEditableOptions) error {
+	return la.Not().ToBeEditable(options...)
+}
+
+func (la *locatorAssertionsImpl) NotToBeEmpty(options ...LocatorAssertionsToBeEmptyOptions) error {
+	return la.Not().ToBeEmpty(options...)
+}
+
+func (la *locatorAssertionsImpl) NotToBeEnabled(options ...LocatorAssertionsToBeEnabledOptions) error {
+	return la.Not().ToBeEnabled(options...)
+}
+
+func (la *locatorAssertionsImpl) NotToBeFocused(options ...LocatorAssertionsToBeFocusedOptions) error {
+	return la.Not().ToBeFocused(options...)
+}
+
+func (la *locatorAssertionsImpl) NotToBeHidden(options ...LocatorAssertionsToBeHiddenOptions) error {
+	return la.Not().ToBeHidden(options...)
+}
+
+func (la *locatorAssertionsImpl) NotToBeVisible(options ...LocatorAssertionsToBeVisibleOptions) error {
+	return la.Not().ToBeVisible(options...)
+}
+
+func (la *locatorAssertionsImpl) NotToContainText(expected interface{}, options ...LocatorAssertionsToContainTextOptions) error {
+	return la.Not().ToContainText(expected, options...)
+}
+
+func (la *locatorAssertionsImpl) NotToHaveAttribute(name string, value interface{}, options ...LocatorAssertionsToHaveAttributeOptions) error {
+	return la.Not().ToHaveAttribute(name, value, options...)
+}
+
+func (la *locatorAssertionsImpl) NotToHaveClass(expected interface{}, options ...LocatorAssertionsToHaveClassOptions) error {
+	return la.Not().ToHaveClass(expected, options...)
+}
+
+func (la *locatorAssertionsImpl) NotToHaveCount(count int, options ...LocatorAssertionsToHaveCountOptions) error {
+	return la.Not().ToHaveCount(count, options...)
+}
+
+func (la *locatorAssertionsImpl) NotToHaveCSS(name string, value interface{}, options ...LocatorAssertionsToHaveCSSOptions) error {
+	return la.Not().ToHaveCSS(name, value, options...)
+}
+
+func (la *locatorAssertionsImpl) NotToHaveId(id interface{}, options ...LocatorAssertionsToHaveIdOptions) error {
+	return la.Not().ToHaveId(id, options...)
+}
+
+func (la *locatorAssertionsImpl) NotToHaveJSProperty(name string, value interface{}, options ...LocatorAssertionsToHaveJSPropertyOptions) error {
+	return la.Not().ToHaveJSProperty(name, value, options...)
+}
+
+func (la *locatorAssertionsImpl) NotToHaveText(expected interface{}, options ...LocatorAssertionsToHaveTextOptions) error {
+	return la.Not().ToHaveText(expected, options...)
+}
+
+func (la *locatorAssertionsImpl) NotToHaveValue(value interface{}, options ...LocatorAssertionsToHaveValueOptions) error {
+	return la.Not().ToHaveValue(value, options...)
+}
+
+func (la *locatorAssertionsImpl) NotToHaveValues(values []interface{}, options ...LocatorAssertionsToHaveValuesOptions) error {
+	return la.Not().ToHaveValues(values, options...)
+}
+
+func (la *locatorAssertionsImpl) Not() LocatorAssertions {
+	return newLocatorAssertions(la.actualLocator, true, la.defaultTimeout)
+}

--- a/objectFactory.go
+++ b/objectFactory.go
@@ -55,7 +55,7 @@ func createObjectFactory(parent *channelOwner, objectType string, guid string, i
 	case "Route":
 		return newRoute(parent, objectType, guid, initializer)
 	case "Selectors":
-		return nil
+		return newSelectorsOwner(parent, objectType, guid, initializer)
 	case "SocksSupport":
 		return nil
 	case "Stream":

--- a/page.go
+++ b/page.go
@@ -554,6 +554,32 @@ func (p *pageImpl) ExpectRequest(url interface{}, cb func() error, options ...Pa
 	return ret.(*requestImpl), err
 }
 
+func (p *pageImpl) ExpectRequestFinished(cb func() error, options ...PageExpectRequestFinishedOptions) (Request, error) {
+	option := PageWaitForEventOptions{}
+	if len(options) == 1 {
+		option.Timeout = options[0].Timeout
+		option.Predicate = options[0].Predicate
+	}
+	ret, err := p.waiterForEvent("requestfinished", option).Expect(cb)
+	if ret == nil {
+		return nil, err
+	}
+	return ret.(*requestImpl), err
+}
+
+func (p *pageImpl) ExpectWebSocket(cb func() error, options ...PageExpectWebSocketOptions) (WebSocket, error) {
+	option := PageWaitForEventOptions{}
+	if len(options) == 1 {
+		option.Timeout = options[0].Timeout
+		option.Predicate = options[0].Predicate
+	}
+	ret, err := p.waiterForEvent("websocket", option).Expect(cb)
+	if ret == nil {
+		return nil, err
+	}
+	return ret.(*webSocketImpl), err
+}
+
 func (p *pageImpl) ExpectWorker(cb func() error, options ...PageExpectWorkerOptions) (Worker, error) {
 	option := PageWaitForEventOptions{}
 	if len(options) == 1 {

--- a/page.go
+++ b/page.go
@@ -999,6 +999,64 @@ func (p *pageImpl) Locator(selector string, options ...PageLocatorOptions) (Loca
 	return p.mainFrame.Locator(selector, option)
 }
 
+func (p *pageImpl) GetByAltText(text interface{}, options ...LocatorGetByAltTextOptions) (Locator, error) {
+	exact := false
+	if len(options) == 1 {
+		if *options[0].Exact {
+			exact = true
+		}
+	}
+	return p.Locator(getByAltTextSelector(text, exact))
+}
+
+func (p *pageImpl) GetByLabel(text interface{}, options ...LocatorGetByLabelOptions) (Locator, error) {
+	exact := false
+	if len(options) == 1 {
+		if *options[0].Exact {
+			exact = true
+		}
+	}
+	return p.Locator(getByLabelSelector(text, exact))
+}
+
+func (p *pageImpl) GetByPlaceholder(text interface{}, options ...LocatorGetByPlaceholderOptions) (Locator, error) {
+	exact := false
+	if len(options) == 1 {
+		if *options[0].Exact {
+			exact = true
+		}
+	}
+	return p.Locator(getByPlaceholderSelector(text, exact))
+}
+
+func (p *pageImpl) GetByRole(role AriaRole, options ...LocatorGetByRoleOptions) (Locator, error) {
+	return p.Locator(getByRoleSelector(role, options...))
+}
+
+func (p *pageImpl) GetByTestId(testId interface{}) (Locator, error) {
+	return p.Locator(getByTestIdSelector(getTestIdAttributeName(), testId))
+}
+
+func (p *pageImpl) GetByText(text interface{}, options ...LocatorGetByTextOptions) (Locator, error) {
+	exact := false
+	if len(options) == 1 {
+		if *options[0].Exact {
+			exact = true
+		}
+	}
+	return p.Locator(getByTextSelector(text, exact))
+}
+
+func (p *pageImpl) GetByTitle(text interface{}, options ...LocatorGetByTitleOptions) (Locator, error) {
+	exact := false
+	if len(options) == 1 {
+		if *options[0].Exact {
+			exact = true
+		}
+	}
+	return p.Locator(getByTitleSelector(text, exact))
+}
+
 func (p *pageImpl) FrameLocator(selector string) FrameLocator {
 	return p.mainFrame.FrameLocator(selector)
 }

--- a/page.go
+++ b/page.go
@@ -415,7 +415,7 @@ func (p *pageImpl) waiterForResponse(url interface{}, options ...PageWaitForResp
 }
 
 func (p *pageImpl) ExpectEvent(event string, cb func() error, options ...PageWaitForEventOptions) (interface{}, error) {
-	return p.waiterForEvent(event, options...).Expect(cb)
+	return p.waiterForEvent(event, options...).RunAndWait(cb)
 }
 
 func (p *pageImpl) ExpectNavigation(cb func() error, options ...PageWaitForNavigationOptions) (Response, error) {
@@ -443,7 +443,7 @@ func (p *pageImpl) ExpectNavigation(cb func() error, options ...PageWaitForNavig
 	}
 	waiter := p.mainFrame.(*frameImpl).setNavigationWaiter(option.Timeout)
 
-	eventData, err := waiter.WaitForEvent(p.mainFrame.(*frameImpl), "navigated", predicate).Expect(cb)
+	eventData, err := waiter.WaitForEvent(p.mainFrame.(*frameImpl), "navigated", predicate).RunAndWait(cb)
 	if err != nil || eventData == nil {
 		return nil, err
 	}
@@ -470,7 +470,7 @@ func (p *pageImpl) ExpectConsoleMessage(cb func() error, options ...PageExpectCo
 		option.Timeout = options[0].Timeout
 		option.Predicate = options[0].Predicate
 	}
-	ret, err := p.waiterForEvent("console", option).Expect(cb)
+	ret, err := p.waiterForEvent("console", option).RunAndWait(cb)
 	if ret == nil {
 		return nil, err
 	}
@@ -478,7 +478,7 @@ func (p *pageImpl) ExpectConsoleMessage(cb func() error, options ...PageExpectCo
 }
 
 func (p *pageImpl) ExpectedDialog(cb func() error) (Dialog, error) {
-	ret, err := newWaiter().WaitForEvent(p, "dialog", nil).Expect(cb)
+	ret, err := newWaiter().WaitForEvent(p, "dialog", nil).RunAndWait(cb)
 	if ret == nil {
 		return nil, err
 	}
@@ -491,7 +491,7 @@ func (p *pageImpl) ExpectDownload(cb func() error, options ...PageExpectDownload
 		option.Timeout = options[0].Timeout
 		option.Predicate = options[0].Predicate
 	}
-	ret, err := p.waiterForEvent("download", option).Expect(cb)
+	ret, err := p.waiterForEvent("download", option).RunAndWait(cb)
 	if ret == nil {
 		return nil, err
 	}
@@ -504,7 +504,7 @@ func (p *pageImpl) ExpectFileChooser(cb func() error, options ...PageExpectFileC
 		option.Timeout = options[0].Timeout
 		option.Predicate = options[0].Predicate
 	}
-	ret, err := p.waiterForEvent("filechooser", option).Expect(cb)
+	ret, err := p.waiterForEvent("filechooser", option).RunAndWait(cb)
 	if ret == nil {
 		return nil, err
 	}
@@ -531,7 +531,7 @@ func (p *pageImpl) ExpectPopup(cb func() error, options ...PageExpectPopupOption
 		option.Timeout = options[0].Timeout
 		option.Predicate = options[0].Predicate
 	}
-	ret, err := p.waiterForEvent("popup", option).Expect(cb)
+	ret, err := p.waiterForEvent("popup", option).RunAndWait(cb)
 	if ret == nil {
 		return nil, err
 	}
@@ -539,7 +539,7 @@ func (p *pageImpl) ExpectPopup(cb func() error, options ...PageExpectPopupOption
 }
 
 func (p *pageImpl) ExpectResponse(url interface{}, cb func() error, options ...PageWaitForResponseOptions) (Response, error) {
-	ret, err := p.waiterForResponse(url, options...).Expect(cb)
+	ret, err := p.waiterForResponse(url, options...).RunAndWait(cb)
 	if ret == nil {
 		return nil, err
 	}
@@ -547,7 +547,7 @@ func (p *pageImpl) ExpectResponse(url interface{}, cb func() error, options ...P
 }
 
 func (p *pageImpl) ExpectRequest(url interface{}, cb func() error, options ...PageWaitForRequestOptions) (Request, error) {
-	ret, err := p.waiterForRequest(url, options...).Expect(cb)
+	ret, err := p.waiterForRequest(url, options...).RunAndWait(cb)
 	if ret == nil {
 		return nil, err
 	}
@@ -560,7 +560,7 @@ func (p *pageImpl) ExpectRequestFinished(cb func() error, options ...PageExpectR
 		option.Timeout = options[0].Timeout
 		option.Predicate = options[0].Predicate
 	}
-	ret, err := p.waiterForEvent("requestfinished", option).Expect(cb)
+	ret, err := p.waiterForEvent("requestfinished", option).RunAndWait(cb)
 	if ret == nil {
 		return nil, err
 	}
@@ -573,7 +573,7 @@ func (p *pageImpl) ExpectWebSocket(cb func() error, options ...PageExpectWebSock
 		option.Timeout = options[0].Timeout
 		option.Predicate = options[0].Predicate
 	}
-	ret, err := p.waiterForEvent("websocket", option).Expect(cb)
+	ret, err := p.waiterForEvent("websocket", option).RunAndWait(cb)
 	if ret == nil {
 		return nil, err
 	}
@@ -586,7 +586,7 @@ func (p *pageImpl) ExpectWorker(cb func() error, options ...PageExpectWorkerOpti
 		option.Timeout = options[0].Timeout
 		option.Predicate = options[0].Predicate
 	}
-	ret, err := p.waiterForEvent("worker", option).Expect(cb)
+	ret, err := p.waiterForEvent("worker", option).RunAndWait(cb)
 	if ret == nil {
 		return nil, err
 	}

--- a/page.go
+++ b/page.go
@@ -283,6 +283,10 @@ func (p *pageImpl) Workers() []Worker {
 	return p.workers
 }
 
+func (p *pageImpl) Request() APIRequestContext {
+	return p.Context().Request()
+}
+
 func (p *pageImpl) Screenshot(options ...PageScreenshotOptions) ([]byte, error) {
 	var path *string
 	if len(options) > 0 {

--- a/page_assertions.go
+++ b/page_assertions.go
@@ -1,0 +1,71 @@
+package playwright
+
+import (
+	"net/url"
+	"path"
+)
+
+type pageAssertionsImpl struct {
+	assertionsBase
+	actualPage Page
+}
+
+func newPageAssertions(page Page, isNot bool, defaultTimeout *float64) *pageAssertionsImpl {
+	locator, _ := page.Locator(":root")
+	return &pageAssertionsImpl{
+		assertionsBase: assertionsBase{
+			actualLocator:  locator,
+			isNot:          isNot,
+			defaultTimeout: defaultTimeout,
+		},
+		actualPage: page,
+	}
+}
+
+func (pa *pageAssertionsImpl) ToHaveTitle(titleOrRegExp interface{}, options ...PageAssertionsToHaveTitleOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	expectedValues := toExpectedTextValues([]interface{}{titleOrRegExp}, false, true, nil)
+	return pa.expect(
+		"to.have.title",
+		frameExpectOptions{ExpectedText: expectedValues, Timeout: timeout},
+		titleOrRegExp,
+		"Page title expected to be",
+	)
+}
+
+func (pa *pageAssertionsImpl) ToHaveURL(urlOrRegExp interface{}, options ...PageAssertionsToHaveURLOptions) error {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+
+	baseURL := pa.actualPage.Context().(*browserContextImpl).options.BaseURL
+	if urlPath, ok := urlOrRegExp.(string); ok && baseURL != nil {
+		u, _ := url.Parse(*baseURL)
+		u.Path = path.Join(u.Path, urlPath)
+		urlOrRegExp = u.String()
+	}
+
+	expectedValues := toExpectedTextValues([]interface{}{urlOrRegExp}, false, false, nil)
+	return pa.expect(
+		"to.have.url",
+		frameExpectOptions{ExpectedText: expectedValues, Timeout: timeout},
+		urlOrRegExp,
+		"Page URL expected to be",
+	)
+}
+
+func (pa *pageAssertionsImpl) NotToHaveTitle(titleOrRegExp interface{}, options ...PageAssertionsToHaveTitleOptions) error {
+	return pa.Not().ToHaveTitle(titleOrRegExp, options...)
+}
+
+func (pa *pageAssertionsImpl) NotToHaveURL(urlOrRegExp interface{}, options ...PageAssertionsToHaveURLOptions) error {
+	return pa.Not().ToHaveURL(urlOrRegExp, options...)
+}
+
+func (pa *pageAssertionsImpl) Not() PageAssertions {
+	return newPageAssertions(pa.actualPage, true, pa.defaultTimeout)
+}

--- a/patches/main.patch
+++ b/patches/main.patch
@@ -354,7 +354,7 @@ index 49b77defd..6ba16526f 100644
  
  ### option: Frame.waitForLoadState.timeout = %%-navigation-timeout-%%
 diff --git a/docs/src/api/class-page.md b/docs/src/api/class-page.md
-index ef2baf1ab..098414d93 100644
+index ef2baf1ab..832d10c27 100644
 --- a/docs/src/api/class-page.md
 +++ b/docs/src/api/class-page.md
 @@ -631,6 +631,20 @@ Script to be evaluated in all pages in the browser context.
@@ -560,7 +560,17 @@ index ef2baf1ab..098414d93 100644
    - alias-python: expect_popup
    - alias-csharp: RunAndWaitForPopup
  - returns: <[Page]>
-@@ -4556,7 +4594,8 @@ await page.WaitForURLAsync("**/target.html");
+@@ -4220,7 +4258,8 @@ changed by using the [`method: Page.setDefaultTimeout`] method.
+ 
+ ## async method: Page.waitForRequestFinished
+ * since: v1.12
+-* langs: java, python, csharp
++* langs: java, python, csharp, go
++  - alias-go: ExpectRequestFinished
+   - alias-python: expect_request_finished
+   - alias-csharp: RunAndWaitForRequestFinished
+ - returns: <[Request]>
+@@ -4556,7 +4595,8 @@ await page.WaitForURLAsync("**/target.html");
  
  ## async method: Page.waitForWebSocket
  * since: v1.9
@@ -570,7 +580,7 @@ index ef2baf1ab..098414d93 100644
    - alias-python: expect_websocket
    - alias-csharp: RunAndWaitForWebSocket
  - returns: <[WebSocket]>
-@@ -4576,7 +4615,8 @@ Receives the [WebSocket] object and resolves to truthy value when the waiting sh
+@@ -4576,7 +4616,8 @@ Receives the [WebSocket] object and resolves to truthy value when the waiting sh
  
  ## async method: Page.waitForWorker
  * since: v1.9
@@ -580,7 +590,7 @@ index ef2baf1ab..098414d93 100644
    - alias-python: expect_worker
    - alias-csharp: RunAndWaitForWorker
  - returns: <[Worker]>
-@@ -4607,7 +4647,8 @@ This does not contain ServiceWorkers
+@@ -4607,7 +4648,8 @@ This does not contain ServiceWorkers
  
  ## async method: Page.waitForEvent2
  * since: v1.8
@@ -630,6 +640,30 @@ index 9999aac53..0519fd7c0 100644
  - `body` <[string]|[Buffer]>
  
  Response body.
+diff --git a/docs/src/api/class-websocket.md b/docs/src/api/class-websocket.md
+index 95157bddd..59cc7156f 100644
+--- a/docs/src/api/class-websocket.md
++++ b/docs/src/api/class-websocket.md
+@@ -53,7 +53,8 @@ Contains the URL of the WebSocket.
+ 
+ ## async method: WebSocket.waitForEvent
+ * since: v1.8
+-* langs: js, python
++* langs: js, python, go
++  - alias-go: ExpectEvent
+   - alias-python: expect_event
+ - returns: <[any]>
+ 
+@@ -113,7 +114,8 @@ Receives the [WebSocketFrame] object and resolves to truthy value when the waiti
+ 
+ ## async method: WebSocket.waitForEvent2
+ * since: v1.8
+-* langs: python
++* langs: python, go
++  - alias-go: WaitForEvent
+   - alias-python: wait_for_event
+ - returns: <[any]>
+ 
 diff --git a/docs/src/api/params.md b/docs/src/api/params.md
 index a58da7d77..83ffb2855 100644
 --- a/docs/src/api/params.md

--- a/patches/main.patch
+++ b/patches/main.patch
@@ -640,6 +640,27 @@ index 9999aac53..0519fd7c0 100644
  - `body` <[string]|[Buffer]>
  
  Response body.
+diff --git a/docs/src/api/class-selectors.md b/docs/src/api/class-selectors.md
+index 897f0fab4..492d9cead 100644
+--- a/docs/src/api/class-selectors.md
++++ b/docs/src/api/class-selectors.md
+@@ -202,14 +202,14 @@ Script that evaluates to a selector engine instance. The script is evaluated in
+ 
+ ### option: Selectors.register.script
+ * since: v1.8
+-* langs: csharp
++* langs: csharp, go
+ - `script` <[string]>
+ 
+ Script that evaluates to a selector engine instance. The script is evaluated in the page context.
+ 
+ ### option: Selectors.register.path
+ * since: v1.8
+-* langs: csharp
++* langs: csharp, go
+ - `path` <[path]>
+ 
+ Script that evaluates to a selector engine instance. The script is evaluated in the page context.
 diff --git a/docs/src/api/class-websocket.md b/docs/src/api/class-websocket.md
 index 95157bddd..59cc7156f 100644
 --- a/docs/src/api/class-websocket.md

--- a/patches/main.patch
+++ b/patches/main.patch
@@ -234,7 +234,7 @@ index 1297d2d4f..6ecc65ae7 100644
  
  Returns the JSON representation of response body.
 diff --git a/docs/src/api/class-browsercontext.md b/docs/src/api/class-browsercontext.md
-index fe3edc74b..2e961136c 100644
+index fe3edc74b..4724d280a 100644
 --- a/docs/src/api/class-browsercontext.md
 +++ b/docs/src/api/class-browsercontext.md
 @@ -226,6 +226,7 @@ await context.AddCookiesAsync(new[] { cookie1, cookie2 });
@@ -299,7 +299,26 @@ index fe3edc74b..2e961136c 100644
    - alias-python: expect_event
  - returns: <[any]>
  
-@@ -1377,7 +1400,8 @@ Receives the [Page] object and resolves to truthy value when the waiting should
+@@ -1356,7 +1379,8 @@ Either a predicate that receives an event or an options object. Optional.
+ 
+ ## async method: BrowserContext.waitForPage
+ * since: v1.9
+-* langs: java, python, csharp
++* langs: java, python, csharp, go
++  - alias-go: ExpectPage
+   - alias-python: expect_page
+   - alias-csharp: RunAndWaitForPage
+ - returns: <[Page]>
+@@ -1367,7 +1391,7 @@ Will throw an error if the context closes before new [Page] is created.
+ 
+ ### option: BrowserContext.waitForPage.predicate =
+ * since: v1.9
+-* langs: csharp, java, python
++* langs: csharp, java, python, go
+ - `predicate` <[function]\([Page]\):[boolean]>
+ 
+ Receives the [Page] object and resolves to truthy value when the waiting should resolve.
+@@ -1377,7 +1401,8 @@ Receives the [Page] object and resolves to truthy value when the waiting should
  
  ## async method: BrowserContext.waitForEvent2
  * since: v1.8

--- a/patches/main.patch
+++ b/patches/main.patch
@@ -246,6 +246,47 @@ index b46565f0a..bf9e2535c 100644
  - returns: <[APIResponseAssertions]>
  
  Makes the assertion check for the opposite condition. For example, this code tests that the response status is not successful:
+diff --git a/docs/src/api/class-browser.md b/docs/src/api/class-browser.md
+index bb516be61..4ce1d6a0b 100644
+--- a/docs/src/api/class-browser.md
++++ b/docs/src/api/class-browser.md
+@@ -287,7 +287,7 @@ testing frameworks should explicitly create [`method: Browser.newContext`] follo
+ 
+ ## async method: Browser.startTracing
+ * since: v1.11
+-* langs: java, js, python
++* langs: java, js, python, go
+ 
+ :::note
+ This API controls [Chromium Tracing](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool) which is a low-level chromium-specific debugging tool. API to control [Playwright Tracing](../trace-viewer) could be found [here](./class-tracing).
+@@ -325,10 +325,18 @@ browser.stop_tracing()
+ 
+ ### param: Browser.startTracing.page
+ * since: v1.11
++* langs: js, java, python, csharp
+ - `page` ?<[Page]>
+ 
+ Optional, if specified, tracing includes screenshots of the given page.
+ 
++### option: Browser.startTracing.page
++* since: v1.11
++* langs: go
++- `page` <[Page]>
++
++Optional, if specified, tracing includes screenshots of the given page.
++
+ ### option: Browser.startTracing.path
+ * since: v1.11
+ - `path` <[path]>
+@@ -349,7 +357,7 @@ specify custom categories to use instead of default.
+ 
+ ## async method: Browser.stopTracing
+ * since: v1.11
+-* langs: java, js, python
++* langs: java, js, python, go
+ - returns: <[Buffer]>
+ 
+ :::note
 diff --git a/docs/src/api/class-browsercontext.md b/docs/src/api/class-browsercontext.md
 index fe3edc74b..4724d280a 100644
 --- a/docs/src/api/class-browsercontext.md

--- a/patches/main.patch
+++ b/patches/main.patch
@@ -572,7 +572,7 @@ index ef2baf1ab..098414d93 100644
  - returns: <[any]>
  
 diff --git a/docs/src/api/class-route.md b/docs/src/api/class-route.md
-index 9999aac53..430d7637b 100644
+index 9999aac53..0519fd7c0 100644
 --- a/docs/src/api/class-route.md
 +++ b/docs/src/api/class-route.md
 @@ -121,7 +121,7 @@ If set changes the post data of request.
@@ -611,21 +611,6 @@ index 9999aac53..430d7637b 100644
  - `body` <[string]|[Buffer]>
  
  Response body.
-@@ -652,12 +652,14 @@ is resolved relative to the current working directory.
- 
- ### option: Route.fulfill.response
- * since: v1.15
-+* langs: js, python, java, csharp
- - `response` <[APIResponse]>
- 
- [APIResponse] to fulfill route's request with. Individual fields of the response (such as headers) can be overridden using fulfill options.
- 
- ## method: Route.request
- * since: v1.8
-+* langs: js, python, csharp, java
- - returns: <[Request]>
- 
- A request to be routed.
 diff --git a/docs/src/api/params.md b/docs/src/api/params.md
 index a58da7d77..83ffb2855 100644
 --- a/docs/src/api/params.md

--- a/patches/main.patch
+++ b/patches/main.patch
@@ -233,6 +233,19 @@ index 1297d2d4f..6ecc65ae7 100644
  - returns: <[Serializable]>
  
  Returns the JSON representation of response body.
+diff --git a/docs/src/api/class-apiresponseassertions.md b/docs/src/api/class-apiresponseassertions.md
+index b46565f0a..bf9e2535c 100644
+--- a/docs/src/api/class-apiresponseassertions.md
++++ b/docs/src/api/class-apiresponseassertions.md
+@@ -48,7 +48,7 @@ def test_navigates_to_login_page(page: Page) -> None:
+ 
+ ## property: APIResponseAssertions.not
+ * since: v1.20
+-* langs: java, js, csharp
++* langs: java, js, csharp, go
+ - returns: <[APIResponseAssertions]>
+ 
+ Makes the assertion check for the opposite condition. For example, this code tests that the response status is not successful:
 diff --git a/docs/src/api/class-browsercontext.md b/docs/src/api/class-browsercontext.md
 index fe3edc74b..4724d280a 100644
 --- a/docs/src/api/class-browsercontext.md
@@ -353,6 +366,19 @@ index 49b77defd..6ba16526f 100644
  * since: v1.8
  
  ### option: Frame.waitForLoadState.timeout = %%-navigation-timeout-%%
+diff --git a/docs/src/api/class-locatorassertions.md b/docs/src/api/class-locatorassertions.md
+index f7c5e7a2f..fb5f07ea1 100644
+--- a/docs/src/api/class-locatorassertions.md
++++ b/docs/src/api/class-locatorassertions.md
+@@ -69,7 +69,7 @@ public class ExampleTests : PageTest
+ 
+ ## property: LocatorAssertions.not
+ * since: v1.20
+-* langs: java, js, csharp
++* langs: java, js, csharp, go
+ - returns: <[LocatorAssertions]>
+ 
+ Makes the assertion check for the opposite condition. For example, this code tests that the Locator doesn't contain text `"error"`:
 diff --git a/docs/src/api/class-page.md b/docs/src/api/class-page.md
 index ef2baf1ab..832d10c27 100644
 --- a/docs/src/api/class-page.md
@@ -600,6 +626,47 @@ index ef2baf1ab..832d10c27 100644
    - alias-python: wait_for_event
  - returns: <[any]>
  
+diff --git a/docs/src/api/class-pageassertions.md b/docs/src/api/class-pageassertions.md
+index b1e68dc2f..9963a0edc 100644
+--- a/docs/src/api/class-pageassertions.md
++++ b/docs/src/api/class-pageassertions.md
+@@ -71,7 +71,7 @@ public class ExampleTests : PageTest
+ 
+ ## property: PageAssertions.not
+ * since: v1.20
+-* langs: java, js, csharp
++* langs: java, js, csharp, go
+ - returns: <[PageAssertions]>
+ 
+ Makes the assertion check for the opposite condition. For example, this code tests that the page URL doesn't contain `"error"`:
+diff --git a/docs/src/api/class-playwrightassertions.md b/docs/src/api/class-playwrightassertions.md
+index 62f12df97..0c8a56652 100644
+--- a/docs/src/api/class-playwrightassertions.md
++++ b/docs/src/api/class-playwrightassertions.md
+@@ -80,6 +80,7 @@ By default, the timeout for assertions is set to 5 seconds.
+   - alias-python: expect
+   - alias-js: expect
+   - alias-csharp: Expect
++  - alias-go: APIResponse
+ - returns: <[APIResponseAssertions]>
+ 
+ Creates a [APIResponseAssertions] object for the given [APIResponse].
+@@ -103,6 +104,7 @@ PlaywrightAssertions.assertThat(response).isOK();
+   - alias-python: expect
+   - alias-js: expect
+   - alias-csharp: Expect
++  - alias-go: Locator
+ - returns: <[LocatorAssertions]>
+ 
+ Creates a [LocatorAssertions] object for the given [Locator].
+@@ -130,6 +132,7 @@ await Expect(locator).ToBeVisibleAsync();
+   - alias-python: expect
+   - alias-js: expect
+   - alias-csharp: Expect
++  - alias-go: Page
+ - returns: <[PageAssertions]>
+ 
+ Creates a [PageAssertions] object for the given [Page].
 diff --git a/docs/src/api/class-route.md b/docs/src/api/class-route.md
 index 9999aac53..0519fd7c0 100644
 --- a/docs/src/api/class-route.md
@@ -686,7 +753,7 @@ index 95157bddd..59cc7156f 100644
  - returns: <[any]>
  
 diff --git a/docs/src/api/params.md b/docs/src/api/params.md
-index a58da7d77..83ffb2855 100644
+index a58da7d77..aa9acd8ee 100644
 --- a/docs/src/api/params.md
 +++ b/docs/src/api/params.md
 @@ -145,8 +145,8 @@ Defaults to `'visible'`. Can be either:
@@ -950,6 +1017,15 @@ index a58da7d77..83ffb2855 100644
  - `timeout` <[float]>
  
  Maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
+@@ -787,7 +812,7 @@ using the [`method: AndroidDevice.setDefaultTimeout`] method.
+ Time to retry the assertion for. Defaults to `timeout` in `TestConfig.expect`.
+ 
+ ## csharp-java-python-assertions-timeout
+-* langs: java, python, csharp
++* langs: java, python, csharp, go
+ - `timeout` <[float]>
+ 
+ Time to retry the assertion for.
 @@ -917,7 +942,7 @@ Firefox user preferences. Learn more about the Firefox user preferences at
  [`about:config`](https://support.mozilla.org/en-US/kb/about-config-editor-firefox).
  
@@ -969,7 +1045,7 @@ index a58da7d77..83ffb2855 100644
  Specify locators that should be masked when the screenshot is taken. Masked elements will be overlaid with
 diff --git a/utils/doclint/generateGoApi.js b/utils/doclint/generateGoApi.js
 new file mode 100644
-index 000000000..6b3cfa844
+index 000000000..58257a741
 --- /dev/null
 +++ b/utils/doclint/generateGoApi.js
 @@ -0,0 +1,821 @@
@@ -1304,7 +1380,7 @@ index 000000000..6b3cfa844
 +        const text = member.spec
 +        if (text.length > 0) {
 +          text.forEach(line => {
-+            let words = line.text.replace(/↵/g, ' ').split(' ');
++            let words = line.text ? line.text.replace(/↵/g, ' ').split(' ') : '';
 +            let lines = [];
 +            let lineText = "";
 +            for (let i = 0; i < words.length; i++) {

--- a/playwright.go
+++ b/playwright.go
@@ -16,12 +16,13 @@ type DeviceDescriptor struct {
 // Playwright represents a Playwright instance
 type Playwright struct {
 	channelOwner
-	utils    *localUtilsImpl
-	Chromium BrowserType
-	Firefox  BrowserType
-	WebKit   BrowserType
-	Request  APIRequest
-	Devices  map[string]*DeviceDescriptor
+	utils     *localUtilsImpl
+	Selectors Selectors
+	Chromium  BrowserType
+	Firefox   BrowserType
+	WebKit    BrowserType
+	Request   APIRequest
+	Devices   map[string]*DeviceDescriptor
 }
 
 // Stop stops the Playwright instance
@@ -29,12 +30,30 @@ func (p *Playwright) Stop() error {
 	return p.connection.Stop()
 }
 
+func (p *Playwright) setSelectors(selectors Selectors) {
+	selectorsOwner := fromChannel(p.initializer["selectors"]).(*selectorsOwnerImpl)
+	p.Selectors.(*selectorsImpl).removeChannel(selectorsOwner)
+	p.Selectors = selectors
+	p.Selectors.(*selectorsImpl).addChannel(selectorsOwner)
+}
+
 func newPlaywright(parent *channelOwner, objectType string, guid string, initializer map[string]interface{}) *Playwright {
 	pw := &Playwright{
-		Chromium: fromChannel(initializer["chromium"]).(*browserTypeImpl),
-		Firefox:  fromChannel(initializer["firefox"]).(*browserTypeImpl),
-		WebKit:   fromChannel(initializer["webkit"]).(*browserTypeImpl),
-		Devices:  make(map[string]*DeviceDescriptor),
+		Selectors: newSelectorsImpl(),
+		Chromium:  fromChannel(initializer["chromium"]).(*browserTypeImpl),
+		Firefox:   fromChannel(initializer["firefox"]).(*browserTypeImpl),
+		WebKit:    fromChannel(initializer["webkit"]).(*browserTypeImpl),
+		Devices:   make(map[string]*DeviceDescriptor),
+	}
+	pw.createChannelOwner(pw, parent, objectType, guid, initializer)
+	pw.Request = newApiRequestImpl(pw)
+	pw.Chromium.(*browserTypeImpl).playwright = pw
+	pw.Firefox.(*browserTypeImpl).playwright = pw
+	pw.WebKit.(*browserTypeImpl).playwright = pw
+	selectorsOwner := fromChannel(initializer["selectors"]).(*selectorsOwnerImpl)
+	pw.Selectors.(*selectorsImpl).addChannel(selectorsOwner)
+	pw.connection.afterClose = func() {
+		pw.Selectors.(*selectorsImpl).removeChannel(selectorsOwner)
 	}
 	for _, dd := range initializer["deviceDescriptors"].([]interface{}) {
 		entry := dd.(map[string]interface{})
@@ -44,8 +63,6 @@ func newPlaywright(parent *channelOwner, objectType string, guid string, initial
 		remapMapToStruct(entry["descriptor"], pw.Devices[entry["name"].(string)])
 	}
 	pw.utils = fromChannel(initializer["utils"]).(*localUtilsImpl)
-	pw.createChannelOwner(pw, parent, objectType, guid, initializer)
-	pw.Request = newApiRequestImpl(pw)
 	return pw
 }
 

--- a/response.go
+++ b/response.go
@@ -13,6 +13,10 @@ type responseImpl struct {
 	finished           chan bool
 }
 
+func (r *responseImpl) FromServiceWorker() bool {
+	return r.initializer["fromServiceWorker"].(bool)
+}
+
 func (r *responseImpl) URL() string {
 	return r.initializer["url"].(string)
 }

--- a/route.go
+++ b/route.go
@@ -2,6 +2,7 @@ package playwright
 
 import (
 	"encoding/base64"
+	"errors"
 	"net/http"
 	"os"
 	"reflect"
@@ -11,6 +12,34 @@ import (
 
 type routeImpl struct {
 	channelOwner
+	handling *chan bool
+}
+
+func (r *routeImpl) startHandling() chan bool {
+	r.Lock()
+	defer r.Unlock()
+	handling := make(chan bool, 1)
+	r.handling = &handling
+	return *r.handling
+}
+
+func (r *routeImpl) reportHandled(done bool) {
+	r.Lock()
+	defer r.Unlock()
+	if r.handling != nil {
+		handling := *r.handling
+		r.handling = nil
+		handling <- done
+	}
+}
+
+func (r *routeImpl) checkNotHandled() error {
+	r.RLock()
+	defer r.RUnlock()
+	if r.handling == nil {
+		return errors.New("Route is already handled!")
+	}
+	return nil
 }
 
 func (r *routeImpl) Request() Request {
@@ -23,19 +52,70 @@ func unpackOptionalArgument(input interface{}) interface{} {
 		panic("Needs to be a slice")
 	}
 	if inputValue.Len() == 0 {
-		return Null()
+		return nil
 	}
 	return inputValue.Index(0).Interface()
 }
 
 func (r *routeImpl) Abort(errorCode ...string) error {
-	_, err := r.channel.Send("abort", map[string]interface{}{
-		"errorCode": unpackOptionalArgument(errorCode),
+	err := r.checkNotHandled()
+	if err != nil {
+		return err
+	}
+	err = r.raceWithPageClose(func() error {
+		_, err := r.channel.Send("abort", map[string]interface{}{
+			"errorCode": unpackOptionalArgument(errorCode),
+		})
+		return err
 	})
+	r.reportHandled(true)
 	return err
 }
 
+func (r *routeImpl) raceWithPageClose(f func() error) error {
+	page, ok := r.Request().Frame().Page().(*pageImpl)
+	if !ok || page == nil {
+		return f()
+	}
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- f()
+	}()
+
+	select {
+	case <-page.closedOrCrashed:
+		return errors.New("Page is closed or crashed")
+	case err := <-errChan:
+		return err
+	}
+}
+
 func (r *routeImpl) Fulfill(options RouteFulfillOptions) error {
+	err := r.checkNotHandled()
+	if err != nil {
+		return err
+	}
+	overrides := map[string]interface{}{
+		"status": 200,
+	}
+	headers := make(map[string]string)
+
+	if options.Response != nil {
+		overrides["status"] = options.Response.Status()
+		headers = options.Response.Headers()
+		response, ok := options.Response.(*apiResponseImpl)
+		if options.Body == nil && options.Path == nil && ok && response.request.connection == r.connection {
+			overrides["fetchResponseUid"] = response.fetchUid()
+		} else {
+			options.Body, _ = options.Response.Body()
+		}
+		options.Response = nil
+	}
+	if options.Status != nil {
+		overrides["status"] = *options.Status
+		options.Status = nil
+	}
+
 	length := 0
 	isBase64 := false
 	var fileContentType string
@@ -56,8 +136,8 @@ func (r *routeImpl) Fulfill(options RouteFulfillOptions) error {
 		length = len(content)
 	}
 
-	headers := make(map[string]string)
 	if options.Headers != nil {
+		headers = make(map[string]string)
 		for key, val := range options.Headers {
 			headers[strings.ToLower(key)] = val
 		}
@@ -65,44 +145,100 @@ func (r *routeImpl) Fulfill(options RouteFulfillOptions) error {
 	}
 	if options.ContentType != nil {
 		headers["content-type"] = *options.ContentType
+		options.ContentType = nil
 	} else if options.Path != nil {
 		headers["content-type"] = fileContentType
 	}
 	if _, ok := headers["content-length"]; !ok && length > 0 {
 		headers["content-length"] = strconv.Itoa(length)
 	}
+	overrides["headers"] = serializeMapToNameAndValue(headers)
+	overrides["isBase64"] = isBase64
 
 	options.Path = nil
-	_, err := r.channel.Send("fulfill", options, map[string]interface{}{
-		"isBase64": isBase64,
-		"headers":  serializeMapToNameAndValue(headers),
+	err = r.raceWithPageClose(func() error {
+		_, err := r.channel.Send("fulfill", options, overrides)
+		return err
 	})
+	r.reportHandled(true)
 	return err
 }
 
-func (r *routeImpl) Continue(options ...RouteContinueOptions) error {
-	overrides := make(map[string]interface{})
+func (r *routeImpl) Fallback(options ...RouteFallbackOptions) error {
+	err := r.checkNotHandled()
+	if err != nil {
+		return err
+	}
+	opt := RouteFallbackOptions{}
 	if len(options) == 1 {
-		option := options[0]
-		if option.URL != nil {
-			overrides["url"] = option.URL
-		}
-		if option.Method != nil {
-			overrides["method"] = option.Method
-		}
-		if option.Headers != nil {
-			overrides["headers"] = serializeMapToNameAndValue(option.Headers)
-		}
-		if option.PostData != nil {
-			switch v := option.PostData.(type) {
-			case string:
-				overrides["postData"] = base64.StdEncoding.EncodeToString([]byte(v))
-			case []byte:
-				overrides["postData"] = base64.StdEncoding.EncodeToString(v)
-			}
+		opt = options[0]
+	}
+	r.Request().(*requestImpl).applyFallbackOverrides(opt)
+	r.reportHandled(false)
+	return nil
+}
+
+func (r *routeImpl) Fetch(options ...RouteFetchOptions) (APIResponse, error) {
+	request := r.Request().Frame().Page().Context().Request().(*apiRequestContextImpl)
+	opt := APIRequestContextFetchOptions{}
+	url := ""
+	if len(options) > 0 {
+		opt.Headers = options[0].Headers
+		opt.Method = options[0].Method
+		opt.Data = options[0].PostData
+		if options[0].URL != nil {
+			url = *options[0].URL
 		}
 	}
-	_, err := r.channel.Send("continue", overrides)
+	return request.innerFetch(url, r.Request(), opt)
+}
+
+func (r *routeImpl) Continue(options ...RouteContinueOptions) error {
+	option := &RouteFallbackOptions{}
+	if len(options) == 1 {
+		err := assignStructFields(option, options[0], true)
+		if err != nil {
+			return err
+		}
+	}
+
+	err := r.checkNotHandled()
+	if err != nil {
+		return err
+	}
+	r.Request().(*requestImpl).applyFallbackOverrides(*option)
+	err = r.internalContinue(false)
+	r.reportHandled(true)
+	return err
+}
+
+func (r *routeImpl) internalContinue(isInternal bool) error {
+	overrides := make(map[string]interface{})
+	overrides["url"] = r.Request().(*requestImpl).fallbackOverrides.URL
+	overrides["method"] = r.Request().(*requestImpl).fallbackOverrides.Method
+	headers := r.Request().(*requestImpl).fallbackOverrides.Headers
+	if headers != nil {
+		overrides["headers"] = serializeMapToNameAndValue(headers)
+	}
+	postDataBuf := r.Request().(*requestImpl).fallbackOverrides.PostDataBuffer
+	if postDataBuf != nil {
+		overrides["postData"] = base64.StdEncoding.EncodeToString(postDataBuf)
+	}
+	return r.raceWithPageClose(func() error {
+		_, err := r.channel.Send("continue", overrides)
+		return err
+	})
+}
+
+func (r *routeImpl) redirectedNavigationRequest(url string) error {
+	err := r.checkNotHandled()
+	if err != nil {
+		return err
+	}
+	_, err = r.channel.Send("redirectNavigationRequest", map[string]interface{}{
+		"url": url,
+	})
+	r.reportHandled(true)
 	return err
 }
 

--- a/scripts/data/interfaces.json
+++ b/scripts/data/interfaces.json
@@ -183,6 +183,10 @@
 			"event string, cb func() error, options ...BrowserContextWaitForEventOptions",
 			"(interface{}, error)"
 		],
+		"ExpectPage": [
+			"cb func() error, options ...BrowserContextExpectPageOptions",
+			"Page, error"
+		],
 		"ExposeBinding": [
 			"name string, binding BindingCallFunction, handle ...bool",
 			"error"

--- a/scripts/data/interfaces.json
+++ b/scripts/data/interfaces.json
@@ -223,6 +223,10 @@
 			"gelocation *Geolocation",
 			"error"
 		],
+		"Request": [
+			null,
+			"APIRequestContext"
+		],
 		"ResetGeolocation": [
 			null,
 			"error"
@@ -233,6 +237,10 @@
 		],
 		"SetOffline": [
 			"offline bool",
+			"error"
+		],
+		"RouteFromHAR": [
+			"har string, options ...BrowserContextRouteFromHAROptions",
 			"error"
 		],
 		"StorageState": [
@@ -1327,6 +1335,10 @@
 			"url interface{}, handler routeHandler, times ...int",
 			"error"
 		],
+		"RouteFromHAR": [
+			"har string, options ...PageRouteFromHAROptions",
+			"error"
+		],
 		"Screenshot": [
 			"options ...PageScreenshotOptions",
 			"([]byte, error)"
@@ -1604,6 +1616,14 @@
 		"Continue": [
 			"options ...RouteContinueOptions",
 			"error"
+		],
+		"Fallback": [
+			"options ...RouteFallbackOptions",
+			"error"
+		],
+		"Fetch": [
+			"options ...RouteFetchOptions",
+			"(APIResponse, error)"
 		],
 		"Fulfill": [
 			"options RouteFulfillOptions",

--- a/scripts/data/interfaces.json
+++ b/scripts/data/interfaces.json
@@ -91,6 +91,20 @@
 			"string"
 		]
 	},
+	"APIResponseAssertions": {
+		"Not": [
+			null,
+			"APIResponseAssertions"
+		],
+		"ToBeOK": [
+			null,
+			"error"
+		],
+		"NotToBeOK": [
+			null,
+			"error"
+		]
+	},
 	"BindingCall": {
 		"Call": [
 			"f BindingCallFunction",
@@ -1173,6 +1187,156 @@
 			"error"
 		]
 	},
+	"LocatorAssertions": {
+		"Not": [
+			null,
+			"LocatorAssertions"
+		],
+		"ToBeChecked": [
+			"options ...LocatorAssertionsToBeCheckedOptions",
+			"error"
+		],
+		"ToBeDisabled": [
+			"options ...LocatorAssertionsToBeDisabledOptions",
+			"error"
+		],
+		"ToBeEditable": [
+			"options ...LocatorAssertionsToBeEditableOptions",
+			"error"
+		],
+		"ToBeEmpty": [
+			"options ...LocatorAssertionsToBeEmptyOptions",
+			"error"
+		],
+		"ToBeEnabled": [
+			"options ...LocatorAssertionsToBeEnabledOptions",
+			"error"
+		],
+		"ToBeFocused": [
+			"options ...LocatorAssertionsToBeFocusedOptions",
+			"error"
+		],
+		"ToBeHidden": [
+			"options ...LocatorAssertionsToBeHiddenOptions",
+			"error"
+		],
+		"ToBeVisible": [
+			"options ...LocatorAssertionsToBeVisibleOptions",
+			"error"
+		],
+		"ToContainText": [
+			"expected interface{}, options ...LocatorAssertionsToContainTextOptions",
+			"error"
+		],
+		"ToHaveAttribute": [
+			"name string, value interface{}, options ...LocatorAssertionsToHaveAttributeOptions",
+			"error"
+		],
+		"ToHaveClass": [
+			"expected interface{}, options ...LocatorAssertionsToHaveClassOptions",
+			"error"
+		],
+		"ToHaveCount": [
+			"count int, options ...LocatorAssertionsToHaveCountOptions",
+			"error"
+		],
+		"ToHaveCSS": [
+			"name string, value interface{}, options ...LocatorAssertionsToHaveCSSOptions",
+			"error"
+		],
+		"ToHaveId": [
+			"id interface{}, options ...LocatorAssertionsToHaveIdOptions",
+			"error"
+		],
+		"ToHaveJSProperty": [
+			"name string, value interface{}, options ...LocatorAssertionsToHaveJSPropertyOptions",
+			"error"
+		],
+		"ToHaveText": [
+			"expected interface{}, options ...LocatorAssertionsToHaveTextOptions",
+			"error"
+		],
+		"ToHaveValue": [
+			"value interface{}, options ...LocatorAssertionsToHaveValueOptions",
+			"error"
+		],
+		"ToHaveValues": [
+			"values []interface{}, options ...LocatorAssertionsToHaveValuesOptions",
+			"error"
+		],
+		"NotToBeChecked": [
+			"options ...LocatorAssertionsToBeCheckedOptions",
+			"error"
+		],
+		"NotToBeDisabled": [
+			"options ...LocatorAssertionsToBeDisabledOptions",
+			"error"
+		],
+		"NotToBeEditable": [
+			"options ...LocatorAssertionsToBeEditableOptions",
+			"error"
+		],
+		"NotToBeEmpty": [
+			"options ...LocatorAssertionsToBeEmptyOptions",
+			"error"
+		],
+		"NotToBeEnabled": [
+			"options ...LocatorAssertionsToBeEnabledOptions",
+			"error"
+		],
+		"NotToBeFocused": [
+			"options ...LocatorAssertionsToBeFocusedOptions",
+			"error"
+		],
+		"NotToBeHidden": [
+			"options ...LocatorAssertionsToBeHiddenOptions",
+			"error"
+		],
+		"NotToBeVisible": [
+			"options ...LocatorAssertionsToBeVisibleOptions",
+			"error"
+		],
+		"NotToContainText": [
+			"expected interface{}, options ...LocatorAssertionsToContainTextOptions",
+			"error"
+		],
+		"NotToHaveAttribute": [
+			"name string, value interface{}, options ...LocatorAssertionsToHaveAttributeOptions",
+			"error"
+		],
+		"NotToHaveClass": [
+			"expected interface{}, options ...LocatorAssertionsToHaveClassOptions",
+			"error"
+		],
+		"NotToHaveCount": [
+			"count int, options ...LocatorAssertionsToHaveCountOptions",
+			"error"
+		],
+		"NotToHaveCSS": [
+			"name string, value interface{}, options ...LocatorAssertionsToHaveCSSOptions",
+			"error"
+		],
+		"NotToHaveId": [
+			"id interface{}, options ...LocatorAssertionsToHaveIdOptions",
+			"error"
+		],
+		"NotToHaveJSProperty": [
+			"name string, value interface{}, options ...LocatorAssertionsToHaveJSPropertyOptions",
+			"error"
+		],
+		"NotToHaveText": [
+			"expected interface{}, options ...LocatorAssertionsToHaveTextOptions",
+			"error"
+		],
+		"NotToHaveValue": [
+			"value interface{}, options ...LocatorAssertionsToHaveValueOptions",
+			"error"
+		],
+		"NotToHaveValues": [
+			"values []interface{}, options ...LocatorAssertionsToHaveValuesOptions",
+			"error"
+		]
+	},
 	"Mouse": {
 		"Click": [
 			"x, y float64, options ...MouseClickOptions",
@@ -1479,6 +1643,10 @@
 			"options ...PageReloadOptions",
 			"Response, error"
 		],
+		"Request": [
+			null,
+			"APIRequestContext"
+		],
 		"Route": [
 			"url interface{}, handler routeHandler, times ...int",
 			"error"
@@ -1606,6 +1774,42 @@
 		"WaitForURL": [
 			"url string, options ...FrameWaitForURLOptions",
 			"error"
+		]
+	},
+	"PageAssertions": {
+		"Not": [
+			null,
+			"PageAssertions"
+		],
+		"ToHaveTitle": [
+			"titleOrRegExp interface{}, options ...PageAssertionsToHaveTitleOptions",
+			"error"
+		],
+		"ToHaveURL": [
+			"urlOrRegExp interface{}, options ...PageAssertionsToHaveURLOptions",
+			"error"
+		],
+		"NotToHaveTitle": [
+			"titleOrRegExp interface{}, options ...PageAssertionsToHaveTitleOptions",
+			"error"
+		],
+		"NotToHaveURL": [
+			"urlOrRegExp interface{}, options ...PageAssertionsToHaveURLOptions",
+			"error"
+		]
+	},
+	"PlaywrightAssertions": {
+		"APIResponse": [
+			"response APIResponse",
+			"APIResponseAssertions"
+		],
+		"Locator": [
+			"locator Locator",
+			"LocatorAssertions"
+		],
+		"Page": [
+			"page Page",
+			"PageAssertions"
 		]
 	},
 	"Request": {

--- a/scripts/data/interfaces.json
+++ b/scripts/data/interfaces.json
@@ -211,6 +211,10 @@
 			null,
 			"[]Page"
 		],
+		"ServiceWorkers": [
+			null,
+			"[]Worker"
+		],
 		"SetDefaultNavigationTimeout": [
 			"timeout float64",
 			null
@@ -1093,6 +1097,10 @@
 		"Up": [
 			"options ...MouseUpOptions",
 			"error"
+		],
+		"Wheel": [
+			"deltaX, deltaY float64",
+			"error"
 		]
 	},
 	"Page": {
@@ -1219,9 +1227,17 @@
 			"url interface{}, cb func() error, options ...PageWaitForRequestOptions",
 			"Request, error"
 		],
+		"ExpectRequestFinished": [
+			"cb func() error, options ...PageExpectRequestFinishedOptions",
+			"Request, error"
+		],
 		"ExpectResponse": [
 			"url interface{}, cb func() error, options ...PageWaitForResponseOptions",
 			"Response, error"
+		],
+		"ExpectWebSocket": [
+			"cb func() error, options ...PageExpectWebSocketOptions",
+			"WebSocket, error"
 		],
 		"ExpectWorker": [
 			"cb func() error, options ...PageExpectWorkerOptions",
@@ -1575,6 +1591,10 @@
 			null,
 			"Frame"
 		],
+		"FromServiceWorker": [
+			null,
+			"bool"
+		],
 		"Headers": [
 			null,
 			"map[string]string"
@@ -1660,8 +1680,12 @@
 			null,
 			"string"
 		],
+		"ExpectEvent": [
+			"event string, cb func() error, options ...WebSocketWaitForEventOptions",
+			"interface{}, error"
+		],
 		"WaitForEvent": [
-			"event string, predicate ...interface{}",
+			"event string, options ...WebSocketWaitForEventOptions",
 			"interface{}, error"
 		]
 	},

--- a/scripts/data/interfaces.json
+++ b/scripts/data/interfaces.json
@@ -888,6 +888,10 @@
 			null,
 			"[]string, error"
 		],
+		"Blur": [
+			"options ...LocatorBlurOptions",
+			"error"
+		],
 		"BoundingBox": [
 			"options ...LocatorBoundingBoxOptions",
 			"*Rect, error"

--- a/scripts/data/interfaces.json
+++ b/scripts/data/interfaces.json
@@ -143,6 +143,14 @@
 			null,
 			"(CDPSession, error)"
 		],
+		"StartTracing": [
+			"options ...BrowserStartTracingOptions",
+			"error"
+		],
+		"StopTracing": [
+			null,
+			"[]byte, error"
+		],
 		"Version": [
 			null,
 			"string"

--- a/scripts/data/interfaces.json
+++ b/scripts/data/interfaces.json
@@ -664,6 +664,34 @@
 			"selector string, name string, options ...PageGetAttributeOptions",
 			"string, error"
 		],
+		"GetByAltText": [
+			"text interface{}, options ...LocatorGetByAltTextOptions",
+			"Locator, error"
+		],
+		"GetByLabel": [
+			"text interface{}, options ...LocatorGetByLabelOptions",
+			"Locator, error"
+		],
+		"GetByPlaceholder": [
+			"text interface{}, options ...LocatorGetByPlaceholderOptions",
+			"Locator, error"
+		],
+		"GetByRole": [
+			"role AriaRole, options ...LocatorGetByRoleOptions",
+			"Locator, error"
+		],
+		"GetByTestId": [
+			"testId interface{}",
+			"Locator, error"
+		],
+		"GetByText": [
+			"text interface{}, options ...LocatorGetByTextOptions",
+			"Locator, error"
+		],
+		"GetByTitle": [
+			"title interface{}, options ...LocatorGetByTitleOptions",
+			"Locator, error"
+		],
 		"Goto": [
 			"url string, options ...PageGotoOptions",
 			"Response, error"
@@ -826,6 +854,34 @@
 			"selector string, options ...LocatorLocatorOptions",
 			"(Locator, error)"
 		],
+				"GetByAltText": [
+			"text interface{}, options ...LocatorGetByAltTextOptions",
+			"Locator, error"
+		],
+		"GetByLabel": [
+			"text interface{}, options ...LocatorGetByLabelOptions",
+			"Locator, error"
+		],
+		"GetByPlaceholder": [
+			"text interface{}, options ...LocatorGetByPlaceholderOptions",
+			"Locator, error"
+		],
+		"GetByRole": [
+			"role AriaRole, options ...LocatorGetByRoleOptions",
+			"Locator, error"
+		],
+		"GetByTestId": [
+			"testId interface{}",
+			"Locator, error"
+		],
+		"GetByText": [
+			"text interface{}, options ...LocatorGetByTextOptions",
+			"Locator, error"
+		],
+		"GetByTitle": [
+			"title interface{}, options ...LocatorGetByTitleOptions",
+			"Locator, error"
+		],
 		"Nth": [
 			"index int",
 			"FrameLocator"
@@ -888,6 +944,10 @@
 		]
 	},
 	"Locator": {
+		"All": [
+			null,
+			"[]Locator, error"
+		],
 		"AllInnerTexts": [
 			null,
 			"[]string, error"
@@ -906,6 +966,10 @@
 		],
 		"Check": [
 			"options ...FrameCheckOptions",
+			"error"
+		],
+		"Clear": [
+			"options ...LocatorClearOptions",
 			"error"
 		],
 		"Click": [
@@ -952,6 +1016,10 @@
 			"value string, options ...FrameFillOptions",
 			"error"
 		],
+		"Filter": [
+			"options ...LocatorLocatorOptions",
+			"Locator, error"
+		],
 		"First": [
 			null,
 			"Locator, error"
@@ -967,6 +1035,34 @@
 		"GetAttribute": [
 			"name string, options ...PageGetAttributeOptions",
 			"string, error"
+		],
+				"GetByAltText": [
+			"text interface{}, options ...LocatorGetByAltTextOptions",
+			"Locator, error"
+		],
+		"GetByLabel": [
+			"text interface{}, options ...LocatorGetByLabelOptions",
+			"Locator, error"
+		],
+		"GetByPlaceholder": [
+			"text interface{}, options ...LocatorGetByPlaceholderOptions",
+			"Locator, error"
+		],
+		"GetByRole": [
+			"role AriaRole, options ...LocatorGetByRoleOptions",
+			"Locator, error"
+		],
+		"GetByTestId": [
+			"testId interface{}",
+			"Locator, error"
+		],
+		"GetByText": [
+			"text interface{}, options ...LocatorGetByTextOptions",
+			"Locator, error"
+		],
+		"GetByTitle": [
+			"title interface{}, options ...LocatorGetByTitleOptions",
+			"Locator, error"
 		],
 		"Highlight": [
 			null,
@@ -1270,6 +1366,34 @@
 		"GetAttribute": [
 			"selector string, name string, options ...PageGetAttributeOptions",
 			"(string, error)"
+		],
+				"GetByAltText": [
+			"text interface{}, options ...LocatorGetByAltTextOptions",
+			"Locator, error"
+		],
+		"GetByLabel": [
+			"text interface{}, options ...LocatorGetByLabelOptions",
+			"Locator, error"
+		],
+		"GetByPlaceholder": [
+			"text interface{}, options ...LocatorGetByPlaceholderOptions",
+			"Locator, error"
+		],
+		"GetByRole": [
+			"role AriaRole, options ...LocatorGetByRoleOptions",
+			"Locator, error"
+		],
+		"GetByTestId": [
+			"testId interface{}",
+			"Locator, error"
+		],
+		"GetByText": [
+			"text interface{}, options ...LocatorGetByTextOptions",
+			"Locator, error"
+		],
+		"GetByTitle": [
+			"title interface{}, options ...LocatorGetByTitleOptions",
+			"Locator, error"
 		],
 		"GoBack": [
 			"options ...PageGoBackOptions",
@@ -1660,6 +1784,16 @@
 		"Request": [
 			null,
 			"Request"
+		]
+	},
+	"Selectors": {
+		"Register": [
+			"name string, option SelectorsRegisterOptions",
+			"error"
+		],
+		"SetTestIdAttribute": [
+			"name string",
+			null
 		]
 	},
 	"Touchscreen": {

--- a/scripts/generate-interfaces.js
+++ b/scripts/generate-interfaces.js
@@ -20,7 +20,9 @@ const transformReturnParameters = (input) => {
  * @param {string} comment
  */
 const writeComment = (comment) => {
-  comment = comment.replace(/\[`method: (.*)`\]/g, "$1()")
+  comment = comment.replace(/\[`method: ([^\]]*)`\]/g, "$1()")
+    .replace(/\[`property: ([^\]]*)`\]/g, "$1()")
+    .replace(/should use ([^\(]*).waitFor/g, "should use $1.ExpectFor")
     .replace(/- extends: .*\n\n/, "")
   const lines = comment.split("\n")
   let inExample = false
@@ -31,7 +33,10 @@ const writeComment = (comment) => {
       lastWasBlank = true
       continue
     }
-    if (["js", "js browser", "py", "python sync", "python async", "java", "csharp"].includes(line.trim().substr(3)) && line.trim().startsWith("```"))
+    if (line.trim() === "**Usage**") {
+      break // ignore all usage
+    }
+    if (["js", "js browser", "py", "python sync", "python async", "java", "csharp", "python"].includes(line.trim().substr(3)) && line.trim().startsWith("```"))
       inExample = true
     if (!inExample) {
       if (lastWasBlank)

--- a/scripts/validate-interfaces.js
+++ b/scripts/validate-interfaces.js
@@ -4,7 +4,6 @@ const interfaceData = require("./data/interfaces.json")
 const api = getAPIDocs()
 
 const IGNORE_CLASSES = [
-  "APIRequestContext",
   "Android",
   "AndroidDevice",
   "AndroidInput",
@@ -13,14 +12,19 @@ const IGNORE_CLASSES = [
   "Electron",
   "ElectronApplication",
   "Coverage",
-  "Selectors",
   "Logger",
   "BrowserServer",
   "Accessibility",
-  "TimeoutError", 
-  "Locator", 
-  "APIRequest",
-  "APIResponse"
+  "TimeoutError",
+  "Playwright",
+  "RequestOptions",
+  "WebSocketFrame",
+  "FormData",
+  "PlaywrightAssertions",
+  "APIResponseAssertions",
+  "LocatorAssertions",
+  "PageAssertions",
+  "SnapshotAssertions"
 ]
 const shouldIgnoreClass = ({ name }) =>
   !IGNORE_CLASSES.includes(name) &&
@@ -32,6 +36,7 @@ const allowedMissing = [
   "BrowserType.LaunchServer",
   "Download.CreateReadStream",
   "BrowserContext.SetHTTPCredentials",
+  "Page.FrameByUrl",
 ]
 
 const missingFunctions = []
@@ -39,13 +44,16 @@ const missingFunctions = []
 for (const classData of api.filter(shouldIgnoreClass)) {
   const className = classData.name
   for (const funcData of classData.members.filter(member => member.kind === "method")) {
-    if (funcData?.langs?.only?.includes("python"))
-      continue
-    const funcName = funcData.name
+    if (funcData?.langs?.only) {
+      let langs = funcData.langs.only
+      if ((langs.length === 1) && (!langs.includes("python"))) {
+        continue
+      }
+    }
+
+    const funcName = funcData?.langs?.aliases?.go ? funcData.langs.aliases.go : funcData.name
     const goFuncName = transformMethodNamesToGo(funcName)
     const functionSignature = `${className}.${goFuncName}`;
-    if (functionSignature === "WebSocket.WaitForEvent2")
-      debugger
     if (!interfaceData[className] || !interfaceData[className][goFuncName] && !allowedMissing.includes(functionSignature)) {
       missingFunctions.push(functionSignature)
     }

--- a/scripts/validate-interfaces.js
+++ b/scripts/validate-interfaces.js
@@ -20,10 +20,6 @@ const IGNORE_CLASSES = [
   "RequestOptions",
   "WebSocketFrame",
   "FormData",
-  "PlaywrightAssertions",
-  "APIResponseAssertions",
-  "LocatorAssertions",
-  "PageAssertions",
   "SnapshotAssertions"
 ]
 const shouldIgnoreClass = ({ name }) =>

--- a/selectors.go
+++ b/selectors.go
@@ -1,0 +1,86 @@
+package playwright
+
+import (
+	"errors"
+	"os"
+	"sync"
+)
+
+type selectorsOwnerImpl struct {
+	channelOwner
+}
+
+func newSelectorsOwner(parent *channelOwner, objectType string, guid string, initializer map[string]interface{}) *selectorsOwnerImpl {
+	obj := &selectorsOwnerImpl{}
+	obj.createChannelOwner(obj, parent, objectType, guid, initializer)
+	return obj
+}
+
+type selectorsImpl struct {
+	channels      sync.Map
+	registrations []map[string]interface{}
+}
+
+func (s *selectorsImpl) Register(name string, option SelectorsRegisterOptions) error {
+	if option.Script == nil && option.Path == nil {
+		return errors.New("Either source or path should be specified")
+	}
+	script := ""
+	if option.Path != nil {
+		content, err := os.ReadFile(*option.Path)
+		if err != nil {
+			return err
+		}
+		script = string(content)
+	} else {
+		script = *option.Script
+	}
+	params := map[string]interface{}{
+		"name":   name,
+		"source": script,
+	}
+	if option.ContentScript != nil && *option.ContentScript {
+		params["contentScript"] = true
+	}
+	var err error
+	s.channels.Range(func(key, value any) bool {
+		_, err = value.(*selectorsOwnerImpl).channel.Send("register", params)
+		return err == nil
+	})
+	if err != nil {
+		return err
+	}
+	s.registrations = append(s.registrations, params)
+	return nil
+}
+
+func (s *selectorsImpl) SetTestIdAttribute(name string) {
+	setTestIdAttributeName(name)
+	s.channels.Range(func(key, value any) bool {
+		value.(*selectorsOwnerImpl).channel.SendNoReply("setTestIdAttributeName", map[string]interface{}{
+			"testIdAttributeName": name,
+		})
+		return true
+	})
+}
+
+func (s *selectorsImpl) addChannel(channel *selectorsOwnerImpl) {
+	s.channels.Store(channel.guid, channel)
+	for _, params := range s.registrations {
+		channel.channel.SendNoReply("register", params)
+		channel.channel.SendNoReply("setTestIdAttributeName", map[string]interface{}{
+			"testIdAttributeName": getTestIdAttributeName(),
+		})
+	}
+}
+
+func (s *selectorsImpl) removeChannel(channel *selectorsOwnerImpl) {
+	s.channels.Delete(channel.guid)
+}
+
+func newSelectorsImpl() *selectorsImpl {
+	return &selectorsImpl{
+		channels:      sync.Map{},
+		registrations: make([]map[string]interface{}, 0),
+	}
+}

--- a/tests/apiresponse_assertions_test.go
+++ b/tests/apiresponse_assertions_test.go
@@ -1,0 +1,63 @@
+package playwright_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssertionsResponseIsOKPass(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	response, err := page.Request().Get(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	require.NoError(t, expect.APIResponse(response).ToBeOK())
+	require.Error(t, expect.APIResponse(response).NotToBeOK())
+}
+
+func TestAssertionsShouldPrintResponseWithTextContentTypeIfToBeOKFails(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	server.SetRoute("/text-content-type", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("Text error"))
+	})
+	server.SetRoute("/no-content-type", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("No content type error"))
+	})
+	server.SetRoute("/binary-content-type", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/bmp")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("Image content type error"))
+	})
+
+	response, err := page.Request().Get(server.PREFIX + "/text-content-type")
+	require.NoError(t, err)
+	require.NoError(t, expect.APIResponse(response).Not().ToBeOK())
+	err = expect.APIResponse(response).ToBeOK()
+	require.ErrorContains(t, err, "→ GET "+server.PREFIX+"/text-content-type")
+	require.ErrorContains(t, err, "← 404 Not Found")
+	require.ErrorContains(t, err, "Response Text:")
+	require.ErrorContains(t, err, "Text error")
+
+	response, err = page.Request().Get(server.PREFIX + "/no-content-type")
+	require.NoError(t, err)
+	require.NoError(t, expect.APIResponse(response).NotToBeOK())
+	err = expect.APIResponse(response).ToBeOK()
+	require.ErrorContains(t, err, "→ GET "+server.PREFIX+"/no-content-type")
+	require.ErrorContains(t, err, "← 404 Not Found")
+	require.NotContains(t, err.Error(), "Response Text:")
+	require.NotContains(t, err.Error(), "No content type error")
+
+	response, err = page.Request().Get(server.PREFIX + "/binary-content-type")
+	require.NoError(t, err)
+	err = expect.APIResponse(response).ToBeOK()
+	require.ErrorContains(t, err, "→ GET "+server.PREFIX+"/binary-content-type")
+	require.ErrorContains(t, err, "← 404 Not Found")
+	require.NotContains(t, err.Error(), "Response Text:")
+	require.NotContains(t, err.Error(), "Image content type error")
+}

--- a/tests/assets/consolelog.html
+++ b/tests/assets/consolelog.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <script>
-      console.log('yellow')
+      console.log('here:' + location.href)
     </script>
   </body>
 </html>

--- a/tests/assets/drag-n-drop.html
+++ b/tests/assets/drag-n-drop.html
@@ -1,14 +1,31 @@
 <style>
+* {
+  box-sizing: border-box;
+}
+body, html {
+  margin: 0;
+  padding: 0;
+}
 div:not(.mouse-helper) {
-  margin: 0em;
-  padding: 2em;
+  margin: 0;
+  padding: 0;
 }
 #source {
   color: blue;
   border: 1px solid black;
+  position: absolute;
+  left: 20px;
+  top: 20px;
+  width: 200px;
+  height: 100px;
 }
 #target {
   border: 1px solid black;
+  position: absolute;
+  left: 40px;
+  top: 200px;
+  width: 400px;
+  height: 300px;
 }
 </style>
 

--- a/tests/assets/har-fulfill.har
+++ b/tests/assets/har-fulfill.har
@@ -1,0 +1,366 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "Playwright",
+      "version": "1.23.0-next"
+    },
+    "browser": {
+      "name": "chromium",
+      "version": "103.0.5060.33"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2022-06-10T04:27:32.125Z",
+        "id": "page@b17b177f1c2e66459db3dcbe44636ffd",
+        "title": "Hey",
+        "pageTimings": {
+          "onContentLoad": 70,
+          "onLoad": 70
+        }
+      }
+    ],
+    "entries": [
+      {
+        "_frameref": "frame@c7467fc0f1f86f09fc3b0d727a3862ea",
+        "_monotonicTime": 270572145.898,
+        "startedDateTime": "2022-06-10T04:27:32.146Z",
+        "time": 8.286,
+        "request": {
+          "method": "GET",
+          "url": "http://no.playwright/",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Accept",
+              "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+            },
+            {
+              "name": "Upgrade-Insecure-Requests",
+              "value": "1"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.33 Safari/537.36"
+            }
+          ],
+          "queryString": [],
+          "headersSize": 326,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-length",
+              "value": "111"
+            },
+            {
+              "name": "content-type",
+              "value": "text/html"
+            }
+          ],
+          "content": {
+            "size": 111,
+            "mimeType": "text/html",
+            "compression": 0,
+            "text": "<title>Hey</title><link rel='stylesheet' href='./style.css'><script src='./script.js'></script><div>hello</div>"
+          },
+          "headersSize": 65,
+          "bodySize": 170,
+          "redirectURL": "",
+          "_transferSize": 170
+        },
+        "cache": {
+          "beforeRequest": null,
+          "afterRequest": null
+        },
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 8.286,
+          "receive": -1
+        },
+        "pageref": "page@b17b177f1c2e66459db3dcbe44636ffd",
+        "_securityDetails": {}
+      },
+      {
+        "_frameref": "frame@c7467fc0f1f86f09fc3b0d727a3862ea",
+        "_monotonicTime": 270572174.683,
+        "startedDateTime": "2022-06-10T04:27:32.172Z",
+        "time": 7.132,
+        "request": {
+          "method": "POST",
+          "url": "http://no.playwright/style.css",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Accept",
+              "value": "text/css,*/*;q=0.1"
+            },
+            {
+              "name": "Referer",
+              "value": "http://no.playwright/"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.33 Safari/537.36"
+            }
+          ],
+          "queryString": [],
+          "headersSize": 220,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-length",
+              "value": "24"
+            },
+            {
+              "name": "content-type",
+              "value": "text/css"
+            }
+          ],
+          "content": {
+            "size": 24,
+            "mimeType": "text/css",
+            "compression": 0,
+            "text": "body { background:cyan }"
+          },
+          "headersSize": 63,
+          "bodySize": 81,
+          "redirectURL": "",
+          "_transferSize": 81
+        },
+        "cache": {
+          "beforeRequest": null,
+          "afterRequest": null
+        },
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 8.132,
+          "receive": -1
+        },
+        "pageref": "page@b17b177f1c2e66459db3dcbe44636ffd",
+        "_securityDetails": {}
+      },
+      {
+        "_frameref": "frame@c7467fc0f1f86f09fc3b0d727a3862ea",
+        "_monotonicTime": 270572174.683,
+        "startedDateTime": "2022-06-10T04:27:32.174Z",
+        "time": 8.132,
+        "request": {
+          "method": "GET",
+          "url": "http://no.playwright/style.css",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Accept",
+              "value": "text/css,*/*;q=0.1"
+            },
+            {
+              "name": "Referer",
+              "value": "http://no.playwright/"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.33 Safari/537.36"
+            }
+          ],
+          "queryString": [],
+          "headersSize": 220,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-length",
+              "value": "24"
+            },
+            {
+              "name": "content-type",
+              "value": "text/css"
+            }
+          ],
+          "content": {
+            "size": 24,
+            "mimeType": "text/css",
+            "compression": 0,
+            "text": "body { background: red }"
+          },
+          "headersSize": 63,
+          "bodySize": 81,
+          "redirectURL": "",
+          "_transferSize": 81
+        },
+        "cache": {
+          "beforeRequest": null,
+          "afterRequest": null
+        },
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 8.132,
+          "receive": -1
+        },
+        "pageref": "page@b17b177f1c2e66459db3dcbe44636ffd",
+        "_securityDetails": {}
+      },
+      {
+        "_frameref": "frame@c7467fc0f1f86f09fc3b0d727a3862ea",
+        "_monotonicTime": 270572175.042,
+        "startedDateTime": "2022-06-10T04:27:32.175Z",
+        "time": 15.997,
+        "request": {
+          "method": "GET",
+          "url": "http://no.playwright/script.js",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Accept",
+              "value": "*/*"
+            },
+            {
+              "name": "Referer",
+              "value": "http://no.playwright/"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.33 Safari/537.36"
+            }
+          ],
+          "queryString": [],
+          "headersSize": 205,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 301,
+          "statusText": "Moved Permanently",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "location",
+              "value": "http://no.playwright/script2.js"
+            }
+          ],
+          "content": {
+            "size": -1,
+            "mimeType": "x-unknown",
+            "compression": 0
+          },
+          "headersSize": 77,
+          "bodySize": 0,
+          "redirectURL": "http://no.playwright/script2.js",
+          "_transferSize": 77
+        },
+        "cache": {
+          "beforeRequest": null,
+          "afterRequest": null
+        },
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 7.673,
+          "receive": 8.324
+        },
+        "pageref": "page@b17b177f1c2e66459db3dcbe44636ffd",
+        "_securityDetails": {}
+      },
+      {
+        "_frameref": "frame@c7467fc0f1f86f09fc3b0d727a3862ea",
+        "_monotonicTime": 270572181.822,
+        "startedDateTime": "2022-06-10T04:27:32.182Z",
+        "time": 6.735,
+        "request": {
+          "method": "GET",
+          "url": "http://no.playwright/script2.js",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Accept",
+              "value": "*/*"
+            },
+            {
+              "name": "Referer",
+              "value": "http://no.playwright/"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.33 Safari/537.36"
+            }
+          ],
+          "queryString": [],
+          "headersSize": 206,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-length",
+              "value": "18"
+            },
+            {
+              "name": "content-type",
+              "value": "text/javascript"
+            }
+          ],
+          "content": {
+            "size": 18,
+            "mimeType": "text/javascript",
+            "compression": 0,
+            "text": "window.value='foo'"
+          },
+          "headersSize": 70,
+          "bodySize": 82,
+          "redirectURL": "",
+          "_transferSize": 82
+        },
+        "cache": {
+          "beforeRequest": null,
+          "afterRequest": null
+        },
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 6.735,
+          "receive": -1
+        },
+        "pageref": "page@b17b177f1c2e66459db3dcbe44636ffd",
+        "_securityDetails": {}
+      }
+    ]
+  }
+}

--- a/tests/assets/har-redirect.har
+++ b/tests/assets/har-redirect.har
@@ -1,0 +1,620 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "Playwright",
+      "version": "1.23.0-next"
+    },
+    "browser": {
+      "name": "chromium",
+      "version": "103.0.5060.42"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2022-06-16T21:41:23.901Z",
+        "id": "page@8f314969edc000996eb5c2ab22f0e6b3",
+        "title": "Microsoft",
+        "pageTimings": {
+          "onContentLoad": 8363,
+          "onLoad": 8896
+        }
+      }
+    ],
+    "entries": [
+      {
+        "_frameref": "frame@3767e074ecde4cb8372abba2f6f9bb4f",
+        "_monotonicTime": 110928357.437,
+        "startedDateTime": "2022-06-16T21:41:23.951Z",
+        "time": 93.99,
+        "request": {
+          "method": "GET",
+          "url": "https://theverge.com/",
+          "httpVersion": "HTTP/2.0",
+          "cookies": [],
+          "headers": [
+            {
+              "name": ":authority",
+              "value": "theverge.com"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            },
+            {
+              "name": ":path",
+              "value": "/"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": "accept",
+              "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, br"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.9"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"103\", \".Not/A)Brand\";v=\"99\""
+            },
+            {
+              "name": "sec-ch-ua-mobile",
+              "value": "?0"
+            },
+            {
+              "name": "sec-ch-ua-platform",
+              "value": "\"Linux\""
+            },
+            {
+              "name": "sec-fetch-dest",
+              "value": "document"
+            },
+            {
+              "name": "sec-fetch-mode",
+              "value": "navigate"
+            },
+            {
+              "name": "sec-fetch-site",
+              "value": "none"
+            },
+            {
+              "name": "sec-fetch-user",
+              "value": "?1"
+            },
+            {
+              "name": "upgrade-insecure-requests",
+              "value": "1"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.42 Safari/537.36"
+            }
+          ],
+          "queryString": [],
+          "headersSize": 644,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 301,
+          "statusText": "",
+          "httpVersion": "HTTP/2.0",
+          "cookies": [
+            {
+              "name": "vmidv1",
+              "value": "9faf31ab-1415-4b90-b367-24b670205f41",
+              "expires": "2027-06-15T21:41:24.000Z",
+              "domain": "theverge.com",
+              "path": "/",
+              "sameSite": "Lax",
+              "secure": true
+            }
+          ],
+          "headers": [
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 16 Jun 2022 21:41:24 GMT"
+            },
+            {
+              "name": "location",
+              "value": "http://www.theverge.com/"
+            },
+            {
+              "name": "retry-after",
+              "value": "0"
+            },
+            {
+              "name": "server",
+              "value": "Varnish"
+            },
+            {
+              "name": "set-cookie",
+              "value": "vmidv1=9faf31ab-1415-4b90-b367-24b670205f41;Expires=Tue, 15 Jun 2027 21:41:24 GMT;Domain=theverge.com;Path=/;SameSite=Lax;Secure"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish"
+            },
+            {
+              "name": "x-cache",
+              "value": "HIT"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-pao17442-PAO"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1655415684.005867,VS0,VE0"
+            }
+          ],
+          "content": {
+            "size": -1,
+            "mimeType": "x-unknown",
+            "compression": 0
+          },
+          "headersSize": 425,
+          "bodySize": 0,
+          "redirectURL": "http://www.theverge.com/",
+          "_transferSize": 425
+        },
+        "cache": {
+          "beforeRequest": null,
+          "afterRequest": null
+        },
+        "timings": {
+          "dns": 0,
+          "connect": 34.151,
+          "ssl": 28.074,
+          "send": 0,
+          "wait": 27.549,
+          "receive": 4.216
+        },
+        "pageref": "page@8f314969edc000996eb5c2ab22f0e6b3",
+        "serverIPAddress": "151.101.65.52",
+        "_serverPort": 443,
+        "_securityDetails": {
+          "protocol": "TLS 1.2",
+          "subjectName": "*.americanninjawarriornation.com",
+          "issuer": "GlobalSign Atlas R3 DV TLS CA 2022 Q1",
+          "validFrom": 1644853133,
+          "validTo": 1679153932
+        }
+      },
+      {
+        "_frameref": "frame@3767e074ecde4cb8372abba2f6f9bb4f",
+        "_monotonicTime": 110928427.603,
+        "startedDateTime": "2022-06-16T21:41:24.022Z",
+        "time": 44.39499999999999,
+        "request": {
+          "method": "GET",
+          "url": "http://www.theverge.com/",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Accept",
+              "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-US,en;q=0.9"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "Host",
+              "value": "www.theverge.com"
+            },
+            {
+              "name": "Upgrade-Insecure-Requests",
+              "value": "1"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.42 Safari/537.36"
+            }
+          ],
+          "queryString": [],
+          "headersSize": 423,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 301,
+          "statusText": "Moved Permanently",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [
+            {
+              "name": "_chorus_geoip_continent",
+              "value": "NA"
+            },
+            {
+              "name": "vmidv1",
+              "value": "4e0c1265-10f8-4cb1-a5de-1c3cf70b531c",
+              "expires": "2027-06-15T21:41:24.000Z",
+              "domain": "www.theverge.com",
+              "path": "/",
+              "sameSite": "Lax",
+              "secure": true
+            }
+          ],
+          "headers": [
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "Age",
+              "value": "2615"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "Content-Length",
+              "value": "0"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/html"
+            },
+            {
+              "name": "Date",
+              "value": "Thu, 16 Jun 2022 21:41:24 GMT"
+            },
+            {
+              "name": "Location",
+              "value": "https://www.theverge.com/"
+            },
+            {
+              "name": "Server",
+              "value": "nginx"
+            },
+            {
+              "name": "Set-Cookie",
+              "value": "_chorus_geoip_continent=NA; expires=Fri, 17 Jun 2022 21:41:24 GMT; path=/;"
+            },
+            {
+              "name": "Set-Cookie",
+              "value": "vmidv1=4e0c1265-10f8-4cb1-a5de-1c3cf70b531c;Expires=Tue, 15 Jun 2027 21:41:24 GMT;Domain=www.theverge.com;Path=/;SameSite=Lax;Secure"
+            },
+            {
+              "name": "Vary",
+              "value": "X-Forwarded-Proto, Cookie, X-Chorus-Unison-Testing, X-Chorus-Require-Privacy-Consent, X-Chorus-Restrict-In-Privacy-Consent-Region, Accept-Encoding"
+            },
+            {
+              "name": "Via",
+              "value": "1.1 varnish"
+            },
+            {
+              "name": "X-Cache",
+              "value": "HIT"
+            },
+            {
+              "name": "X-Cache-Hits",
+              "value": "2"
+            },
+            {
+              "name": "X-Served-By",
+              "value": "cache-pao17450-PAO"
+            },
+            {
+              "name": "X-Timer",
+              "value": "S1655415684.035748,VS0,VE0"
+            }
+          ],
+          "content": {
+            "size": -1,
+            "mimeType": "text/html",
+            "compression": 0
+          },
+          "headersSize": 731,
+          "bodySize": 0,
+          "redirectURL": "https://www.theverge.com/",
+          "_transferSize": 731
+        },
+        "cache": {
+          "beforeRequest": null,
+          "afterRequest": null
+        },
+        "timings": {
+          "dns": 2.742,
+          "connect": 10.03,
+          "ssl": 14.123,
+          "send": 0,
+          "wait": 15.023,
+          "receive": 2.477
+        },
+        "pageref": "page@8f314969edc000996eb5c2ab22f0e6b3",
+        "serverIPAddress": "151.101.189.52",
+        "_serverPort": 80,
+        "_securityDetails": {}
+      },
+      {
+        "_frameref": "frame@3767e074ecde4cb8372abba2f6f9bb4f",
+        "_monotonicTime": 110928455.901,
+        "startedDateTime": "2022-06-16T21:41:24.050Z",
+        "time": 50.29199999999999,
+        "request": {
+          "method": "GET",
+          "url": "https://www.theverge.com/",
+          "httpVersion": "HTTP/2.0",
+          "cookies": [
+            {
+              "name": "vmidv1",
+              "value": "9faf31ab-1415-4b90-b367-24b670205f41"
+            },
+            {
+              "name": "_chorus_geoip_continent",
+              "value": "NA"
+            }
+          ],
+          "headers": [
+            {
+              "name": ":authority",
+              "value": "www.theverge.com"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            },
+            {
+              "name": ":path",
+              "value": "/"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": "accept",
+              "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, br"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.9"
+            },
+            {
+              "name": "cookie",
+              "value": "vmidv1=9faf31ab-1415-4b90-b367-24b670205f41; _chorus_geoip_continent=NA"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"103\", \".Not/A)Brand\";v=\"99\""
+            },
+            {
+              "name": "sec-ch-ua-mobile",
+              "value": "?0"
+            },
+            {
+              "name": "sec-ch-ua-platform",
+              "value": "\"Linux\""
+            },
+            {
+              "name": "sec-fetch-dest",
+              "value": "document"
+            },
+            {
+              "name": "sec-fetch-mode",
+              "value": "navigate"
+            },
+            {
+              "name": "sec-fetch-site",
+              "value": "none"
+            },
+            {
+              "name": "sec-fetch-user",
+              "value": "?1"
+            },
+            {
+              "name": "upgrade-insecure-requests",
+              "value": "1"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.42 Safari/537.36"
+            }
+          ],
+          "queryString": [],
+          "headersSize": 729,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "",
+          "httpVersion": "HTTP/2.0",
+          "cookies": [
+            {
+              "name": "_chorus_geoip_continent",
+              "value": "NA"
+            },
+            {
+              "name": "vmidv1",
+              "value": "40d8fd14-5ac3-4757-9e9c-efb106e82d3a",
+              "expires": "2027-06-15T21:41:24.000Z",
+              "domain": "www.theverge.com",
+              "path": "/",
+              "sameSite": "Lax",
+              "secure": true
+            }
+          ],
+          "headers": [
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "263"
+            },
+            {
+              "name": "cache-control",
+              "value": "max-age=0, public, must-revalidate"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-length",
+              "value": "14"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src https: data: 'unsafe-inline' 'unsafe-eval'; child-src https: data: blob:; connect-src https: data: blob: ; font-src https: data:; img-src https: data: blob:; media-src https: data: blob:; object-src https:; script-src https: data: blob: 'unsafe-inline' 'unsafe-eval'; style-src https: 'unsafe-inline'; block-all-mixed-content; upgrade-insecure-requests"
+            },
+            {
+              "name": "content-type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 16 Jun 2022 21:41:24 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"d498ef668223d015000070a66a181e85\""
+            },
+            {
+              "name": "link",
+              "value": "<https://concertads-configs.vox-cdn.com/sbn/verge/config.json>; rel=preload; as=fetch; crossorigin"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "set-cookie",
+              "value": "_chorus_geoip_continent=NA; expires=Fri, 17 Jun 2022 21:41:24 GMT; path=/;"
+            },
+            {
+              "name": "set-cookie",
+              "value": "vmidv1=40d8fd14-5ac3-4757-9e9c-efb106e82d3a;Expires=Tue, 15 Jun 2027 21:41:24 GMT;Domain=www.theverge.com;Path=/;SameSite=Lax;Secure"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31556952; preload"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding, X-Chorus-Unison-Testing, X-Chorus-Require-Privacy-Consent, X-Chorus-Restrict-In-Privacy-Consent-Region, Origin, X-Forwarded-Proto, Cookie, X-Chorus-Unison-Testing, X-Chorus-Require-Privacy-Consent, X-Chorus-Restrict-In-Privacy-Consent-Region"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish"
+            },
+            {
+              "name": "x-cache",
+              "value": "HIT"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "1"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-download-options",
+              "value": "noopen"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "x-request-id",
+              "value": "97363ad70e272e63641c0bb784fa06a01b848dfd"
+            },
+            {
+              "name": "x-runtime",
+              "value": "0.257911"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-pao17436-PAO"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1655415684.075077,VS0,VE1"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            }
+          ],
+          "content": {
+            "size": 14,
+            "mimeType": "text/html",
+            "compression": 0,
+            "text": "<h1>hello</h1>"
+          },
+          "headersSize": 1742,
+          "bodySize": 48716,
+          "redirectURL": "",
+          "_transferSize": 48716
+        },
+        "cache": {
+          "beforeRequest": null,
+          "afterRequest": null
+        },
+        "timings": {
+          "dns": 0.016,
+          "connect": 24.487,
+          "ssl": 17.406,
+          "send": 0,
+          "wait": 8.383,
+          "receive": -1
+        },
+        "pageref": "page@8f314969edc000996eb5c2ab22f0e6b3",
+        "serverIPAddress": "151.101.189.52",
+        "_serverPort": 443,
+        "_securityDetails": {
+          "protocol": "TLS 1.2",
+          "subjectName": "*.americanninjawarriornation.com",
+          "issuer": "GlobalSign Atlas R3 DV TLS CA 2022 Q1",
+          "validFrom": 1644853133,
+          "validTo": 1679153932
+        }
+      }
+    ]
+  }
+}

--- a/tests/assets/har-sha1-main-response.txt
+++ b/tests/assets/har-sha1-main-response.txt
@@ -1,0 +1,1 @@
+Hello, world

--- a/tests/assets/har-sha1.har
+++ b/tests/assets/har-sha1.har
@@ -1,0 +1,95 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "Playwright",
+      "version": "1.23.0-next"
+    },
+    "browser": {
+      "name": "chromium",
+      "version": "103.0.5060.33"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2022-06-10T04:27:32.125Z",
+        "id": "page@b17b177f1c2e66459db3dcbe44636ffd",
+        "title": "Hey",
+        "pageTimings": {
+          "onContentLoad": 70,
+          "onLoad": 70
+        }
+      }
+    ],
+    "entries": [
+      {
+        "_frameref": "frame@c7467fc0f1f86f09fc3b0d727a3862ea",
+        "_monotonicTime": 270572145.898,
+        "startedDateTime": "2022-06-10T04:27:32.146Z",
+        "time": 8.286,
+        "request": {
+          "method": "GET",
+          "url": "http://no.playwright/",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Accept",
+              "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+            },
+            {
+              "name": "Upgrade-Insecure-Requests",
+              "value": "1"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.33 Safari/537.36"
+            }
+          ],
+          "queryString": [],
+          "headersSize": 326,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-length",
+              "value": "12"
+            },
+            {
+              "name": "content-type",
+              "value": "text/html"
+            }
+          ],
+          "content": {
+            "size": 12,
+            "mimeType": "text/html",
+            "compression": 0,
+            "_file": "har-sha1-main-response.txt"
+          },
+          "headersSize": 64,
+          "bodySize": 71,
+          "redirectURL": "",
+          "_transferSize": 71
+        },
+        "cache": {
+          "beforeRequest": null,
+          "afterRequest": null
+        },
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 8.286,
+          "receive": -1
+        },
+        "pageref": "page@b17b177f1c2e66459db3dcbe44636ffd",
+        "_securityDetails": {}
+      }
+    ]
+  }
+}

--- a/tests/assets/input/fileupload.html
+++ b/tests/assets/input/fileupload.html
@@ -4,8 +4,8 @@
     <title>File upload test</title>
   </head>
   <body>
-    <form action="/input/fileupload.html">
-      <input type="file">
+    <form action="/upload" method="post" enctype="multipart/form-data">
+      <input type="file" name="file1">
       <input type="submit">
     </form>
   </body>

--- a/tests/assets/modernizr/mobile-safari-14-1.json
+++ b/tests/assets/modernizr/mobile-safari-14-1.json
@@ -292,7 +292,7 @@
   "cssresize": true,
   "scrollsnappoints": true,
   "shapes": true,
-  "textalignlast": false,
+  "textalignlast": true,
   "csstransforms": true,
   "csstransforms3d": true,
   "csstransformslevel2": true,

--- a/tests/assets/one-style.html
+++ b/tests/assets/one-style.html
@@ -1,2 +1,3 @@
+<!DOCTYPE html>
 <link rel='stylesheet' href='./one-style.css'>
 <div>hello, world!</div>

--- a/tests/assets/serviceworkers/fetch/sw.js
+++ b/tests/assets/serviceworkers/fetch/sw.js
@@ -1,7 +1,12 @@
+self.intercepted = [];
+
 self.addEventListener('fetch', event => {
+  self.intercepted.push(event.request.url)
   event.respondWith(fetch(event.request));
 });
 
 self.addEventListener('activate', event => {
   event.waitUntil(clients.claim());
 });
+
+fetch('/request-from-within-worker.txt')

--- a/tests/assets/serviceworkers/fetchdummy/sw.js
+++ b/tests/assets/serviceworkers/fetchdummy/sw.js
@@ -3,6 +3,10 @@ self.addEventListener('fetch', event => {
     event.respondWith(fetch(event.request));
     return;
   }
+  if (event.request.url.includes('error')) {
+    event.respondWith(Promise.reject(new Error('uh oh')));
+    return;
+  }
   const slash = event.request.url.lastIndexOf('/');
   const name = event.request.url.substring(slash + 1);
   const blob = new Blob(["responseFromServiceWorker:" + name], {type : 'text/css'});

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -315,3 +315,14 @@ func TestBrowserContextShouldReturnBackgroundPage(t *testing.T) {
 	require.Len(t, context.BackgroundPages(), 0)
 	require.Len(t, context.Pages(), 0)
 }
+
+func TestPageEventShouldHaveURL(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	newPage, err := context.ExpectPage(func() error {
+		_, err := page.Evaluate("url => window.open(url)", server.EMPTY_PAGE)
+		return err
+	})
+	require.NoError(t, err)
+	require.Equal(t, server.EMPTY_PAGE, newPage.URL())
+}

--- a/tests/console_message_test.go
+++ b/tests/console_message_test.go
@@ -1,6 +1,7 @@
 package playwright_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/playwright-community/playwright-go"
@@ -142,7 +143,7 @@ func TestConsoleShouldTriggerCorrectLog(t *testing.T) {
 	require.Equal(t, "error", message.Type())
 }
 
-func TestConsoleShouldHaveLocation(t *testing.T) {
+func TestConsoleShouldHaveLocationForConsoleAPICalls(t *testing.T) {
 	BeforeEach(t)
 	defer AfterEach(t)
 	messageEvent, err := page.ExpectEvent("console", func() error {
@@ -150,7 +151,7 @@ func TestConsoleShouldHaveLocation(t *testing.T) {
 		return err
 	}, playwright.PageWaitForEventOptions{
 		Predicate: func(m playwright.ConsoleMessage) bool {
-			return m.Text() == "yellow"
+			return strings.HasPrefix(m.Text(), "here:")
 		},
 	})
 	require.NoError(t, err)

--- a/tests/har_test.go
+++ b/tests/har_test.go
@@ -1,0 +1,820 @@
+package playwright_test
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestShouldWork(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	harPath := filepath.Join(t.TempDir(), "log.har")
+	context2, err := browser.NewContext(playwright.BrowserNewContextOptions{
+		RecordHarPath: playwright.String(harPath),
+	})
+	require.NoError(t, err)
+	_, err = page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	require.NoError(t, context2.Close())
+	require.FileExists(t, harPath)
+	data, err := os.ReadFile(harPath)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "log")
+}
+
+func TestShouldOmitContent(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	harPath := filepath.Join(t.TempDir(), "log.har")
+	context2, err := browser.NewContext(playwright.BrowserNewContextOptions{
+		RecordHarPath:    playwright.String(harPath),
+		RecordHarContent: playwright.HarContentPolicyOmit,
+	})
+	require.NoError(t, err)
+	_, err = page.Goto(server.PREFIX + "/har.html")
+	require.NoError(t, err)
+	require.NoError(t, context2.Close())
+	require.FileExists(t, harPath)
+	data, err := os.ReadFile(harPath)
+	require.NoError(t, err)
+	result := gjson.GetBytes(data, "log.entries.0.response.content")
+	require.False(t, result.Exists())
+}
+
+func TestShouldOmitContentLegacy(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	harPath := filepath.Join(t.TempDir(), "log.har")
+	context2, err := browser.NewContext(playwright.BrowserNewContextOptions{
+		RecordHarPath:        playwright.String(harPath),
+		RecordHarOmitContent: playwright.Bool(true),
+	})
+	require.NoError(t, err)
+	_, err = page.Goto(server.PREFIX + "/har.html")
+	require.NoError(t, err)
+	require.NoError(t, context2.Close())
+	require.FileExists(t, harPath)
+	data, err := os.ReadFile(harPath)
+	require.NoError(t, err)
+	result := gjson.GetBytes(data, "log.entries.0.response.content")
+	require.False(t, result.Exists())
+}
+
+func TestShouldAttachContent(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	harZipFile := filepath.Join(t.TempDir(), "log.har.zip")
+	context2, err := browser.NewContext(playwright.BrowserNewContextOptions{
+		RecordHarPath:    playwright.String(harZipFile),
+		RecordHarContent: playwright.HarContentPolicyAttach,
+	})
+	require.NoError(t, err)
+	page2, err := context2.NewPage()
+	require.NoError(t, err)
+	_, err = page2.Goto(server.PREFIX + "/har.html")
+	require.NoError(t, err)
+	_, err = page2.Evaluate(`() => fetch('/pptr.png').then(r => r.arrayBuffer())`)
+	require.NoError(t, err)
+	require.NoError(t, context2.Close())
+	require.FileExists(t, harZipFile)
+	data, err := readFromZip(harZipFile, "har.har")
+	require.NoError(t, err)
+	entries := gjson.GetBytes(data, "log.entries")
+	require.True(t, entries.Exists())
+	require.Equal(t, "text/html; charset=utf-8", entries.Get("0.response.content.mimeType").String())
+	require.Contains(t, entries.Get("0.response.content._file").String(), "75841480e2606c03389077304342fac2c58ccb1b")
+	require.GreaterOrEqual(t, entries.Get("0.response.content.size").Int(), int64(96))
+	require.Zero(t, entries.Get("0.response.content.compression").Int())
+
+	require.Equal(t, "text/css; charset=utf-8", entries.Get("1.response.content.mimeType").String())
+	require.Contains(t, entries.Get("1.response.content._file").String(), "79f739d7bc88e80f55b9891a22bf13a2b4e18adb")
+	require.GreaterOrEqual(t, entries.Get("1.response.content.size").Int(), int64(37))
+	require.Zero(t, entries.Get("1.response.content.compression").Int())
+
+	require.Equal(t, "image/png", entries.Get("2.response.content.mimeType").String())
+	require.Contains(t, entries.Get("2.response.content._file").String(), "a4c3a18f0bb83f5d9fe7ce561e065c36205762fa")
+	require.GreaterOrEqual(t, entries.Get("2.response.content.size").Int(), int64(6000))
+	require.Zero(t, entries.Get("2.response.content.compression").Int())
+}
+
+func TestShouldNotOmitContent(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	harPath := filepath.Join(t.TempDir(), "log.har")
+	context2, err := browser.NewContext(playwright.BrowserNewContextOptions{
+		RecordHarPath:        playwright.String(harPath),
+		RecordHarOmitContent: playwright.Bool(false),
+	})
+	require.NoError(t, err)
+	page2, err := context2.NewPage()
+	require.NoError(t, err)
+	_, err = page2.Goto(server.PREFIX + "/har.html")
+	require.NoError(t, err)
+	require.NoError(t, context2.Close())
+	require.FileExists(t, harPath)
+	data, err := os.ReadFile(harPath)
+	require.NoError(t, err)
+	result := gjson.GetBytes(data, "log.entries.0.response.content.text")
+	require.True(t, result.Exists())
+}
+
+func TestShouldIncludeContent(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	harPath := filepath.Join(t.TempDir(), "log.har")
+	context2, err := browser.NewContext(playwright.BrowserNewContextOptions{
+		RecordHarPath: playwright.String(harPath),
+	})
+	require.NoError(t, err)
+	page2, err := context2.NewPage()
+	require.NoError(t, err)
+	_, err = page2.Goto(server.PREFIX + "/har.html")
+	require.NoError(t, err)
+	require.NoError(t, context2.Close())
+	require.FileExists(t, harPath)
+	data, err := os.ReadFile(harPath)
+	require.NoError(t, err)
+	content := gjson.GetBytes(data, "log.entries.0.response.content")
+	require.Equal(t, "text/html; charset=utf-8", content.Get("mimeType").String())
+	require.Contains(t, content.Get("text").String(), "HAR Page")
+}
+
+func TestShouldDefaultToFullMode(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	harPath := filepath.Join(t.TempDir(), "log.har")
+	context2, err := browser.NewContext(playwright.BrowserNewContextOptions{
+		RecordHarPath: playwright.String(harPath),
+	})
+	require.NoError(t, err)
+	page2, err := context2.NewPage()
+	require.NoError(t, err)
+	_, err = page2.Goto(server.PREFIX + "/har.html")
+	require.NoError(t, err)
+	require.NoError(t, context2.Close())
+	require.FileExists(t, harPath)
+	data, err := os.ReadFile(harPath)
+	require.NoError(t, err)
+	bodySize := gjson.GetBytes(data, "log.entries.0.request.bodySize")
+	require.True(t, bodySize.Exists())
+	require.GreaterOrEqual(t, bodySize.Int(), int64(0))
+}
+
+func TestShouldSupportMinimalMode(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	harPath := filepath.Join(t.TempDir(), "log.har")
+	context2, err := browser.NewContext(playwright.BrowserNewContextOptions{
+		RecordHarPath: playwright.String(harPath),
+		RecordHarMode: playwright.HarModeMinimal,
+	})
+	require.NoError(t, err)
+	page2, err := context2.NewPage()
+	require.NoError(t, err)
+	_, err = page2.Goto(server.PREFIX + "/har.html")
+	require.NoError(t, err)
+	require.NoError(t, context2.Close())
+	require.FileExists(t, harPath)
+	data, err := os.ReadFile(harPath)
+	require.NoError(t, err)
+	bodySize := gjson.GetBytes(data, "log.entries.0.request.bodySize")
+	require.True(t, bodySize.Exists())
+	require.Equal(t, bodySize.Int(), int64(-1))
+}
+
+func TestShouldFilterByGlob(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	harPath := filepath.Join(t.TempDir(), "log.har")
+	context2, err := browser.NewContext(playwright.BrowserNewContextOptions{
+		BaseURL:            &server.PREFIX,
+		RecordHarPath:      playwright.String(harPath),
+		RecordHarUrlFilter: "/*.css",
+	})
+	require.NoError(t, err)
+	page2, err := context2.NewPage()
+	require.NoError(t, err)
+	_, err = page2.Goto(server.PREFIX + "/har.html")
+	require.NoError(t, err)
+	require.NoError(t, context2.Close())
+	require.FileExists(t, harPath)
+	data, err := os.ReadFile(harPath)
+	require.NoError(t, err)
+	require.Equal(t, len(gjson.GetBytes(data, "log.entries").Array()), 1)
+	url := gjson.GetBytes(data, "log.entries.0.request.url")
+	require.True(t, strings.HasSuffix(url.String(), "one-style.css"))
+}
+
+func TestShouldFilterByRegexp(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	harPath := filepath.Join(t.TempDir(), "log.har")
+	context2, err := browser.NewContext(playwright.BrowserNewContextOptions{
+		BaseURL:            &server.PREFIX,
+		RecordHarPath:      playwright.String(harPath),
+		RecordHarUrlFilter: regexp.MustCompile("(?i)HAR.X?HTML"),
+		IgnoreHttpsErrors:  playwright.Bool(true),
+	})
+	require.NoError(t, err)
+	page2, err := context2.NewPage()
+	require.NoError(t, err)
+	_, err = page2.Goto(server.PREFIX + "/har.html")
+	require.NoError(t, err)
+	require.NoError(t, context2.Close())
+	require.FileExists(t, harPath)
+	data, err := os.ReadFile(harPath)
+	require.NoError(t, err)
+	require.Equal(t, len(gjson.GetBytes(data, "log.entries").Array()), 1)
+	url := gjson.GetBytes(data, "log.entries.0.request.url")
+	require.True(t, strings.HasSuffix(url.String(), "har.html"))
+}
+
+func TestShouldContextRouteFromHarMatchingTheMethodAndFollowingRedirects(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	err := context.RouteFromHAR(Asset("har-fulfill.har"))
+	require.NoError(t, err)
+	_, err = page.Goto("http://no.playwright/")
+	require.NoError(t, err)
+	// HAR contains a redirect for the script that should be followed automatically.
+	data, err := page.Evaluate(`window.value`)
+	require.NoError(t, err)
+	require.Equal(t, "foo", data)
+	// HAR contains a POST for the css file that should not be used.
+	// TODO add "expect have css" test
+}
+
+func TestShouldPageRouteFromHarMatchingTheMethodAndFollowingRedirects(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	err := page.RouteFromHAR(Asset("har-fulfill.har"))
+	require.NoError(t, err)
+	_, err = page.Goto("http://no.playwright/")
+	require.NoError(t, err)
+	// HAR contains a redirect for the script that should be followed automatically.
+	data, err := page.Evaluate(`window.value`)
+	require.NoError(t, err)
+	require.Equal(t, "foo", data)
+	// HAR contains a POST for the css file that should not be used.
+	// TODO add "expect have css" test
+}
+
+func TestFallbackContinueShouldContinueWhenNotFoundInHar(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	err := context.RouteFromHAR(Asset("har-fulfill.har"), playwright.BrowserContextRouteFromHAROptions{
+		NotFound: playwright.HarNotFoundFallback,
+	})
+	require.NoError(t, err)
+	_, err = page.Goto(server.PREFIX + "/one-style.html")
+	require.NoError(t, err)
+	// TODO add "expect have css" test
+}
+
+func TestByDefaultShouldAbortRequestsNotFoundInHar(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	err := context.RouteFromHAR(Asset("har-fulfill.har"))
+	require.NoError(t, err)
+	page, err := context.NewPage()
+	require.NoError(t, err)
+	_, err = page.Goto(server.EMPTY_PAGE)
+	if isChromium {
+		require.ErrorContains(t, err, "net::ERR_FAILED")
+	} else if isWebKit {
+		require.ErrorContains(t, err, "Blocked by Web Inspector")
+	} else {
+		require.ErrorContains(t, err, "NS_ERROR_FAILURE")
+	}
+}
+
+func TestFallbackContinueShouldContinueRequestsOnBadHar(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	harPath := filepath.Join(t.TempDir(), "invalid.har")
+	require.NoError(t, os.WriteFile(harPath, []byte(`{"log": {}}`), 0644))
+	err := context.RouteFromHAR(harPath, playwright.BrowserContextRouteFromHAROptions{
+		NotFound: playwright.HarNotFoundFallback,
+	})
+	require.NoError(t, err)
+	_, err = page.Goto(server.PREFIX + "/one-style.html")
+	require.NoError(t, err)
+	// TODO add "expect have css" test
+}
+
+func TestShouldOnlyHandleRequestsMatchingUrlFilter(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	err := context.RouteFromHAR(Asset("har-fulfill.har"), playwright.BrowserContextRouteFromHAROptions{
+		NotFound: playwright.HarNotFoundFallback,
+		URL:      "**/*.js",
+	})
+	require.NoError(t, err)
+
+	err = context.Route("http://no.playwright/", func(r playwright.Route) {
+		require.Equal(t, r.Request().URL(), "http://no.playwright/")
+		require.NoError(t, r.Fulfill(playwright.RouteFulfillOptions{
+			Status:      playwright.Int(200),
+			ContentType: playwright.String("text/html"),
+			Body:        []byte(`<script src="./script.js"></script><div>hello</div>`),
+		}))
+	})
+	require.NoError(t, err)
+	_, err = page.Goto("http://no.playwright/")
+	require.NoError(t, err)
+	data, err := page.Evaluate(`window.value`)
+	require.NoError(t, err)
+	require.Equal(t, "foo", data)
+	// TODO add "expect have css" test
+}
+
+func TestShouldOnlyHandleRequestsMatchingUrlFilterNoFallback(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	err := context.RouteFromHAR(Asset("har-fulfill.har"), playwright.BrowserContextRouteFromHAROptions{
+		URL: "**/*.js",
+	})
+	require.NoError(t, err)
+
+	err = context.Route("http://no.playwright/", func(r playwright.Route) {
+		require.Equal(t, r.Request().URL(), "http://no.playwright/")
+		require.NoError(t, r.Fulfill(playwright.RouteFulfillOptions{
+			Status:      playwright.Int(200),
+			ContentType: playwright.String("text/html"),
+			Body:        []byte(`<script src="./script.js"></script><div>hello</div>`),
+		}))
+	})
+	require.NoError(t, err)
+	_, err = page.Goto("http://no.playwright/")
+	require.NoError(t, err)
+	data, err := page.Evaluate(`window.value`)
+	require.NoError(t, err)
+	require.Equal(t, "foo", data)
+	// TODO add "expect have css" test
+}
+
+func TestShouldOnlyHandleRequestsMatchingUrlFilterNoFallbackPage(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	err := page.RouteFromHAR(Asset("har-fulfill.har"), playwright.PageRouteFromHAROptions{
+		URL: "**/*.js",
+	})
+	require.NoError(t, err)
+
+	err = page.Route("http://no.playwright/", func(r playwright.Route) {
+		require.Equal(t, r.Request().URL(), "http://no.playwright/")
+		require.NoError(t, r.Fulfill(playwright.RouteFulfillOptions{
+			Status:      playwright.Int(200),
+			ContentType: playwright.String("text/html"),
+			Body:        []byte(`<script src="./script.js"></script><div>hello</div>`),
+		}))
+	})
+	require.NoError(t, err)
+	_, err = page.Goto("http://no.playwright/")
+	require.NoError(t, err)
+	data, err := page.Evaluate(`window.value`)
+	require.NoError(t, err)
+	require.Equal(t, "foo", data)
+	// TODO add "expect have css" test
+}
+
+func TestShouldSupportRegexFilter(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	urlPattern := regexp.MustCompile(`.*(\.js|.*\.css|no.playwright\/)`)
+	err := context.RouteFromHAR(Asset("har-fulfill.har"), playwright.BrowserContextRouteFromHAROptions{
+		URL: urlPattern,
+	})
+	require.NoError(t, err)
+	_, err = page.Goto("http://no.playwright/")
+	require.NoError(t, err)
+	data, err := page.Evaluate(`window.value`)
+	require.NoError(t, err)
+	require.Equal(t, "foo", data)
+	// TODO add "expect have css" test
+}
+
+func TestShouldGoBackToRedirectedNavigation(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	urlPattern := regexp.MustCompile(`/.*theverge.*/`)
+	err := context.RouteFromHAR(Asset("har-redirect.har"), playwright.BrowserContextRouteFromHAROptions{
+		URL: urlPattern,
+	})
+	require.NoError(t, err)
+	_, err = page.Goto("https://theverge.com/")
+	require.NoError(t, err)
+	response, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	require.Equal(t, server.EMPTY_PAGE, response.URL())
+
+	response, err = page.GoBack()
+	require.NoError(t, err)
+	require.Equal(t, "https://www.theverge.com/", response.URL())
+	data, err := page.Evaluate("window.location.href")
+	require.NoError(t, err)
+	require.Equal(t, "https://www.theverge.com/", data)
+}
+
+func TestShouldGoForwardToRedirectedNavigation(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	if isFirefox {
+		// skipped upstream (https://github.com/microsoft/playwright/blob/6a8d835145e2f4002ee00b67a80a1f70af956703/tests/library/browsercontext-har.spec.ts#L214)
+		t.Skip("skipped upstream")
+	}
+	urlPattern := regexp.MustCompile(`/.*theverge.*/`)
+	err := context.RouteFromHAR(Asset("har-redirect.har"), playwright.BrowserContextRouteFromHAROptions{
+		URL: urlPattern,
+	})
+	require.NoError(t, err)
+	_, err = page.Goto("https://theverge.com/")
+	require.NoError(t, err)
+	response, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	require.Equal(t, server.EMPTY_PAGE, response.URL())
+	response, err = page.Goto("https://theverge.com/")
+	require.NoError(t, err)
+	require.Equal(t, "https://www.theverge.com/", response.URL())
+	response, err = page.GoBack()
+	require.NoError(t, err)
+	require.Equal(t, server.EMPTY_PAGE, response.URL())
+	response, err = page.GoForward()
+	require.NoError(t, err)
+	require.Equal(t, "https://www.theverge.com/", response.URL())
+	data, err := page.Evaluate("window.location.href")
+	require.NoError(t, err)
+	require.Equal(t, "https://www.theverge.com/", data)
+}
+
+func TestShouldReloadRedirectedNavigation(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	urlPattern := regexp.MustCompile(`/.*theverge.*/`)
+	err := context.RouteFromHAR(Asset("har-redirect.har"), playwright.BrowserContextRouteFromHAROptions{
+		URL: urlPattern,
+	})
+	require.NoError(t, err)
+	response, err := page.Goto("https://theverge.com/")
+	require.NoError(t, err)
+	require.Equal(t, "https://www.theverge.com/", response.URL())
+	response, err = page.Reload()
+	require.NoError(t, err)
+	require.Equal(t, "https://www.theverge.com/", response.URL())
+	data, err := page.Evaluate("window.location.href")
+	require.NoError(t, err)
+	require.Equal(t, "https://www.theverge.com/", data)
+}
+
+func TestShouldFulfillFromHarWithContentInAFile(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	err := context.RouteFromHAR(Asset("har-sha1.har"))
+	require.NoError(t, err)
+	_, err = page.Goto("http://no.playwright/")
+	require.NoError(t, err)
+	content, err := page.Content()
+	require.NoError(t, err)
+	require.Equal(t, "<html><head></head><body>Hello, world</body></html>", content)
+}
+
+func TestShouldRoundTripHarZip(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	harPath := filepath.Join(t.TempDir(), "har.zip")
+	context1, err := browser.NewContext(playwright.BrowserNewContextOptions{
+		RecordHarMode: playwright.HarModeMinimal,
+		RecordHarPath: playwright.String(harPath),
+	})
+	require.NoError(t, err)
+	page1, err := context1.NewPage()
+	require.NoError(t, err)
+	_, err = page1.Goto(server.PREFIX + "/one-style.html")
+	require.NoError(t, err)
+	require.NoError(t, context1.Close())
+
+	context2, err := browser.NewContext()
+	require.NoError(t, err)
+
+	err = context2.RouteFromHAR(harPath, playwright.BrowserContextRouteFromHAROptions{
+		NotFound: playwright.HarNotFoundAbort,
+	})
+	require.NoError(t, err)
+	page2, err := context2.NewPage()
+	require.NoError(t, err)
+	_, err = page2.Goto(server.PREFIX + "/one-style.html")
+	require.NoError(t, err)
+	content, err := page2.Content()
+	require.NoError(t, err)
+	require.Contains(t, content, "hello, world!")
+}
+
+func TestShouldRoundTripHarWithPostData(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	server.SetRoute("/echo", func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		_, err = w.Write(body)
+		require.NoError(t, err)
+	})
+	const fetchFunction = `async (body) => {
+			const response = await fetch('/echo', { method: 'POST', body });
+			return response.text();
+		}`
+
+	harPath := filepath.Join(t.TempDir(), "har.zip")
+	context1, err := browser.NewContext(playwright.BrowserNewContextOptions{
+		RecordHarMode: playwright.HarModeMinimal,
+		RecordHarPath: playwright.String(harPath),
+	})
+	require.NoError(t, err)
+	page1, err := context1.NewPage()
+	require.NoError(t, err)
+	_, err = page1.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+
+	data, err := page1.Evaluate(fetchFunction, "1")
+	require.NoError(t, err)
+	require.Equal(t, "1", data)
+	data, err = page1.Evaluate(fetchFunction, "2")
+	require.NoError(t, err)
+	require.Equal(t, "2", data)
+	data, err = page1.Evaluate(fetchFunction, "3")
+	require.NoError(t, err)
+	require.Equal(t, "3", data)
+	require.NoError(t, context1.Close())
+
+	context2, err := browser.NewContext()
+	require.NoError(t, err)
+	err = context2.RouteFromHAR(harPath, playwright.BrowserContextRouteFromHAROptions{
+		NotFound: playwright.HarNotFoundAbort,
+	})
+	require.NoError(t, err)
+	page2, err := context2.NewPage()
+	require.NoError(t, err)
+	_, err = page2.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	data, err = page2.Evaluate(fetchFunction, "1")
+	require.NoError(t, err)
+	require.Equal(t, "1", data)
+	data, err = page2.Evaluate(fetchFunction, "2")
+	require.NoError(t, err)
+	require.Equal(t, "2", data)
+	data, err = page2.Evaluate(fetchFunction, "3")
+	require.NoError(t, err)
+	require.Equal(t, "3", data)
+	_, err = page2.Evaluate(fetchFunction, "4")
+	require.Error(t, err)
+}
+
+func TestShouldDisambiguateByHeader(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	server.SetRoute("/echo", func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(r.Header.Get("baz")))
+		require.NoError(t, err)
+	})
+	const fetchFunction = `
+		async (bazValue) => {
+			const response = await fetch('/echo', {
+			method: 'POST',
+			body: '',
+			headers: {
+					foo: 'foo-value',
+					bar: 'bar-value',
+					baz: bazValue,
+			}
+			});
+			return response.text();
+		}`
+
+	harPath := filepath.Join(t.TempDir(), "har.zip")
+	context1, err := browser.NewContext(playwright.BrowserNewContextOptions{
+		RecordHarMode: playwright.HarModeMinimal,
+		RecordHarPath: playwright.String(harPath),
+	})
+	require.NoError(t, err)
+	page1, err := context1.NewPage()
+	require.NoError(t, err)
+	_, err = page1.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+
+	data, err := page1.Evaluate(fetchFunction, "baz1")
+	require.NoError(t, err)
+	require.Equal(t, "baz1", data)
+	data, err = page1.Evaluate(fetchFunction, "baz2")
+	require.NoError(t, err)
+	require.Equal(t, "baz2", data)
+	data, err = page1.Evaluate(fetchFunction, "baz3")
+	require.NoError(t, err)
+	require.Equal(t, "baz3", data)
+	require.NoError(t, context1.Close())
+
+	context2, err := browser.NewContext()
+	require.NoError(t, err)
+	err = context2.RouteFromHAR(harPath)
+	require.NoError(t, err)
+	page2, err := context2.NewPage()
+	require.NoError(t, err)
+	_, err = page2.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	data, err = page2.Evaluate(fetchFunction, "baz1")
+	require.NoError(t, err)
+	require.Equal(t, "baz1", data)
+	data, err = page2.Evaluate(fetchFunction, "baz2")
+	require.NoError(t, err)
+	require.Equal(t, "baz2", data)
+	data, err = page2.Evaluate(fetchFunction, "baz3")
+	require.NoError(t, err)
+	require.Equal(t, "baz3", data)
+	_, err = page2.Evaluate(fetchFunction, "baz4")
+	require.NoError(t, err)
+	// why does this equals baz1 in playwright-python?
+	require.Equal(t, "baz3", data)
+}
+
+func TestShouldProduceExtractedZip(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	harPath := filepath.Join(t.TempDir(), "har.har")
+	context1, err := browser.NewContext(playwright.BrowserNewContextOptions{
+		RecordHarMode:    playwright.HarModeMinimal,
+		RecordHarPath:    playwright.String(harPath),
+		RecordHarContent: playwright.HarContentPolicyAttach,
+	})
+	require.NoError(t, err)
+	page1, err := context1.NewPage()
+	require.NoError(t, err)
+	_, err = page1.Goto(server.PREFIX + "/one-style.html")
+	require.NoError(t, err)
+	require.NoError(t, context1.Close())
+
+	require.FileExists(t, harPath)
+	content, err := os.ReadFile(harPath)
+	require.NoError(t, err)
+	require.Contains(t, string(content), "log")
+	require.NotContains(t, string(content), "background-color")
+
+	context2, err := browser.NewContext()
+	require.NoError(t, err)
+	err = context2.RouteFromHAR(harPath, playwright.BrowserContextRouteFromHAROptions{
+		NotFound: playwright.HarNotFoundAbort,
+	})
+	require.NoError(t, err)
+	page2, err := context2.NewPage()
+	require.NoError(t, err)
+	response, err := page2.Goto(server.PREFIX + "/one-style.html")
+	require.NoError(t, err)
+	body, err := response.Body()
+	require.NoError(t, err)
+	require.Contains(t, string(body), "hello, world!")
+	// TODO  expect to have css
+}
+
+func TestShouldUpdateHarZipForContext(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	harPath := filepath.Join(t.TempDir(), "har.zip")
+	context1, err := browser.NewContext()
+	require.NoError(t, err)
+	require.NoError(t, context1.RouteFromHAR(harPath, playwright.BrowserContextRouteFromHAROptions{
+		Update: playwright.Bool(true),
+	}))
+	page1, err := context1.NewPage()
+	require.NoError(t, err)
+	_, err = page1.Goto(server.PREFIX + "/one-style.html")
+	require.NoError(t, err)
+	require.NoError(t, context1.Close())
+
+	require.FileExists(t, harPath)
+
+	context2, err := browser.NewContext()
+	require.NoError(t, err)
+	err = context2.RouteFromHAR(harPath, playwright.BrowserContextRouteFromHAROptions{
+		NotFound: playwright.HarNotFoundAbort,
+	})
+	require.NoError(t, err)
+	page2, err := context2.NewPage()
+	require.NoError(t, err)
+	response, err := page2.Goto(server.PREFIX + "/one-style.html")
+	require.NoError(t, err)
+	body, err := response.Body()
+	require.NoError(t, err)
+	require.Contains(t, string(body), "hello, world!")
+	// TODO  expect to have css
+}
+
+func TestShouldUpdateHarZipForPage(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	harPath := filepath.Join(t.TempDir(), "har.zip")
+	context1, err := browser.NewContext()
+	require.NoError(t, err)
+	page1, err := context1.NewPage()
+	require.NoError(t, err)
+	require.NoError(t, page1.RouteFromHAR(harPath, playwright.PageRouteFromHAROptions{
+		Update: playwright.Bool(true),
+	}))
+	_, err = page1.Goto(server.PREFIX + "/one-style.html")
+	require.NoError(t, err)
+	require.NoError(t, context1.Close())
+
+	require.FileExists(t, harPath)
+
+	context2, err := browser.NewContext()
+	require.NoError(t, err)
+	page2, err := context2.NewPage()
+	require.NoError(t, err)
+	err = page2.RouteFromHAR(harPath, playwright.PageRouteFromHAROptions{
+		NotFound: playwright.HarNotFoundAbort,
+	})
+	require.NoError(t, err)
+	response, err := page2.Goto(server.PREFIX + "/one-style.html")
+	require.NoError(t, err)
+	body, err := response.Body()
+	require.NoError(t, err)
+	require.Contains(t, string(body), "hello, world!")
+	// TODO  expect to have css
+}
+
+func TestShouldUpdateHarZipForPageWithDifferentOptions(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	harPath := filepath.Join(t.TempDir(), "har.zip")
+	context1, err := browser.NewContext()
+	require.NoError(t, err)
+	page1, err := context1.NewPage()
+	require.NoError(t, err)
+	require.NoError(t, page1.RouteFromHAR(harPath, playwright.PageRouteFromHAROptions{
+		Update: playwright.Bool(true),
+		// UpdateContent: playwright.RouteFromHarUpdateContentPolicyEmbed,
+		// UpdateMode:    playwright.HarModeFull,
+	}))
+	_, err = page1.Goto(server.PREFIX + "/one-style.html")
+	require.NoError(t, err)
+	require.NoError(t, context1.Close())
+
+	require.FileExists(t, harPath)
+
+	context2, err := browser.NewContext()
+	require.NoError(t, err)
+	page2, err := context2.NewPage()
+	require.NoError(t, err)
+	err = page2.RouteFromHAR(harPath, playwright.PageRouteFromHAROptions{
+		NotFound: playwright.HarNotFoundAbort,
+	})
+	require.NoError(t, err)
+	response, err := page2.Goto(server.PREFIX + "/one-style.html")
+	require.NoError(t, err)
+	body, err := response.Body()
+	require.NoError(t, err)
+	require.Contains(t, string(body), "hello, world!")
+	// TODO  expect to have css
+}
+
+func TestShouldUpdateExtractedHarZipForPage(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	harPath := filepath.Join(t.TempDir(), "har.har")
+	context1, err := browser.NewContext()
+	require.NoError(t, err)
+	page1, err := context1.NewPage()
+	require.NoError(t, err)
+	require.NoError(t, page1.RouteFromHAR(harPath, playwright.PageRouteFromHAROptions{
+		Update: playwright.Bool(true),
+	}))
+	_, err = page1.Goto(server.PREFIX + "/one-style.html")
+	require.NoError(t, err)
+	require.NoError(t, context1.Close())
+
+	require.FileExists(t, harPath)
+	content, err := os.ReadFile(harPath)
+	require.NoError(t, err)
+	require.Contains(t, string(content), "log")
+	require.NotContains(t, string(content), "background-color")
+
+	context2, err := browser.NewContext()
+	require.NoError(t, err)
+	page2, err := context2.NewPage()
+	require.NoError(t, err)
+	err = page2.RouteFromHAR(harPath, playwright.PageRouteFromHAROptions{
+		NotFound: playwright.HarNotFoundAbort,
+	})
+	require.NoError(t, err)
+	response, err := page2.Goto(server.PREFIX + "/one-style.html")
+	require.NoError(t, err)
+	body, err := response.Body()
+	require.NoError(t, err)
+	require.Contains(t, string(body), "hello, world!")
+	// TODO  expect to have css
+}

--- a/tests/har_test.go
+++ b/tests/har_test.go
@@ -250,7 +250,9 @@ func TestShouldContextRouteFromHarMatchingTheMethodAndFollowingRedirects(t *test
 	require.NoError(t, err)
 	require.Equal(t, "foo", data)
 	// HAR contains a POST for the css file that should not be used.
-	// TODO add "expect have css" test
+	locator, err := page.Locator("body")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCSS("background-color", "rgb(255, 0, 0)"))
 }
 
 func TestShouldPageRouteFromHarMatchingTheMethodAndFollowingRedirects(t *testing.T) {
@@ -265,7 +267,9 @@ func TestShouldPageRouteFromHarMatchingTheMethodAndFollowingRedirects(t *testing
 	require.NoError(t, err)
 	require.Equal(t, "foo", data)
 	// HAR contains a POST for the css file that should not be used.
-	// TODO add "expect have css" test
+	locator, err := page.Locator("body")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCSS("background-color", "rgb(255, 0, 0)"))
 }
 
 func TestFallbackContinueShouldContinueWhenNotFoundInHar(t *testing.T) {
@@ -277,7 +281,9 @@ func TestFallbackContinueShouldContinueWhenNotFoundInHar(t *testing.T) {
 	require.NoError(t, err)
 	_, err = page.Goto(server.PREFIX + "/one-style.html")
 	require.NoError(t, err)
-	// TODO add "expect have css" test
+	locator, err := page.Locator("body")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCSS("background-color", "rgb(255, 192, 203)"))
 }
 
 func TestByDefaultShouldAbortRequestsNotFoundInHar(t *testing.T) {
@@ -308,7 +314,9 @@ func TestFallbackContinueShouldContinueRequestsOnBadHar(t *testing.T) {
 	require.NoError(t, err)
 	_, err = page.Goto(server.PREFIX + "/one-style.html")
 	require.NoError(t, err)
-	// TODO add "expect have css" test
+	locator, err := page.Locator("body")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCSS("background-color", "rgb(255, 192, 203)"))
 }
 
 func TestShouldOnlyHandleRequestsMatchingUrlFilter(t *testing.T) {
@@ -334,7 +342,9 @@ func TestShouldOnlyHandleRequestsMatchingUrlFilter(t *testing.T) {
 	data, err := page.Evaluate(`window.value`)
 	require.NoError(t, err)
 	require.Equal(t, "foo", data)
-	// TODO add "expect have css" test
+	locator, err := page.Locator("body")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCSS("background-color", "rgba(0, 0, 0, 0)"))
 }
 
 func TestShouldOnlyHandleRequestsMatchingUrlFilterNoFallback(t *testing.T) {
@@ -359,7 +369,9 @@ func TestShouldOnlyHandleRequestsMatchingUrlFilterNoFallback(t *testing.T) {
 	data, err := page.Evaluate(`window.value`)
 	require.NoError(t, err)
 	require.Equal(t, "foo", data)
-	// TODO add "expect have css" test
+	locator, err := page.Locator("body")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCSS("background-color", "rgba(0, 0, 0, 0)"))
 }
 
 func TestShouldOnlyHandleRequestsMatchingUrlFilterNoFallbackPage(t *testing.T) {
@@ -384,7 +396,9 @@ func TestShouldOnlyHandleRequestsMatchingUrlFilterNoFallbackPage(t *testing.T) {
 	data, err := page.Evaluate(`window.value`)
 	require.NoError(t, err)
 	require.Equal(t, "foo", data)
-	// TODO add "expect have css" test
+	locator, err := page.Locator("body")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCSS("background-color", "rgba(0, 0, 0, 0)"))
 }
 
 func TestShouldSupportRegexFilter(t *testing.T) {
@@ -400,7 +414,9 @@ func TestShouldSupportRegexFilter(t *testing.T) {
 	data, err := page.Evaluate(`window.value`)
 	require.NoError(t, err)
 	require.Equal(t, "foo", data)
-	// TODO add "expect have css" test
+	locator, err := page.Locator("body")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCSS("background-color", "rgb(255, 0, 0)"))
 }
 
 func TestShouldGoBackToRedirectedNavigation(t *testing.T) {
@@ -678,7 +694,9 @@ func TestShouldProduceExtractedZip(t *testing.T) {
 	body, err := response.Body()
 	require.NoError(t, err)
 	require.Contains(t, string(body), "hello, world!")
-	// TODO  expect to have css
+	locator, err := page2.Locator("body")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCSS("background-color", "rgb(255, 192, 203)"))
 }
 
 func TestShouldUpdateHarZipForContext(t *testing.T) {
@@ -711,7 +729,9 @@ func TestShouldUpdateHarZipForContext(t *testing.T) {
 	body, err := response.Body()
 	require.NoError(t, err)
 	require.Contains(t, string(body), "hello, world!")
-	// TODO  expect to have css
+	locator, err := page2.Locator("body")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCSS("background-color", "rgb(255, 192, 203)"))
 }
 
 func TestShouldUpdateHarZipForPage(t *testing.T) {
@@ -744,7 +764,9 @@ func TestShouldUpdateHarZipForPage(t *testing.T) {
 	body, err := response.Body()
 	require.NoError(t, err)
 	require.Contains(t, string(body), "hello, world!")
-	// TODO  expect to have css
+	locator, err := page2.Locator("body")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCSS("background-color", "rgb(255, 192, 203)"))
 }
 
 func TestShouldUpdateHarZipForPageWithDifferentOptions(t *testing.T) {
@@ -779,7 +801,9 @@ func TestShouldUpdateHarZipForPageWithDifferentOptions(t *testing.T) {
 	body, err := response.Body()
 	require.NoError(t, err)
 	require.Contains(t, string(body), "hello, world!")
-	// TODO  expect to have css
+	locator, err := page2.Locator("body")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCSS("background-color", "rgb(255, 192, 203)"))
 }
 
 func TestShouldUpdateExtractedHarZipForPage(t *testing.T) {
@@ -816,5 +840,7 @@ func TestShouldUpdateExtractedHarZipForPage(t *testing.T) {
 	body, err := response.Body()
 	require.NoError(t, err)
 	require.Contains(t, string(body), "hello, world!")
-	// TODO  expect to have css
+	locator, err := page2.Locator("body")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCSS("background-color", "rgb(255, 192, 203)"))
 }

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -1,7 +1,9 @@
 package playwright_test
 
 import (
+	"archive/zip"
 	"bytes"
+	"fmt"
 	"io"
 	"log"
 	"mime"
@@ -311,4 +313,32 @@ func getFreePort() (int, error) {
 	}
 	defer l.Close()
 	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+func readFromZip(zipFile string, fileName string) ([]byte, error) {
+	r, err := zip.OpenReader(zipFile)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+
+	for _, f := range r.File {
+		if f.Name == fileName {
+			rc, err := f.Open()
+			if err != nil {
+				return nil, err
+			}
+			defer rc.Close()
+
+			buf := new(bytes.Buffer)
+			_, err = io.Copy(buf, rc)
+			if err != nil {
+				return nil, err
+			}
+
+			return buf.Bytes(), nil
+		}
+	}
+
+	return nil, fmt.Errorf("file %s not found in %s", fileName, zipFile)
 }

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -25,6 +25,7 @@ var pw *playwright.Playwright
 var browser playwright.Browser
 var context playwright.BrowserContext
 var page playwright.Page
+var expect playwright.PlaywrightAssertions
 var isChromium bool
 var isFirefox bool
 var isWebKit bool
@@ -65,6 +66,7 @@ func BeforeAll() {
 	if err != nil {
 		log.Fatalf("could not launch: %v", err)
 	}
+	expect = playwright.NewPlaywrightAssertions(1000)
 	isChromium = browserName == "chromium" || browserName == ""
 	isFirefox = browserName == "firefox"
 	isWebKit = browserName == "webkit"

--- a/tests/input_test.go
+++ b/tests/input_test.go
@@ -2,6 +2,7 @@ package playwright_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/playwright-community/playwright-go"
 	"github.com/stretchr/testify/require"
@@ -81,6 +82,22 @@ func TestMouseDblclick(t *testing.T) {
 	result, err := page.Evaluate("window.clicked")
 	require.NoError(t, err)
 	require.True(t, result.(bool))
+}
+
+func TestMouseWheel(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	require.NoError(t, page.SetContent(`<div style="width: 5000px; height: 5000px;"></div>`))
+
+	require.NoError(t, page.Mouse().Wheel(0, 100))
+	time.Sleep(500 * time.Millisecond)
+	h, err := page.WaitForFunction(`window.scrollY === 100`, nil)
+	require.NoError(t, err)
+	value, err := h.JSONValue()
+	require.NoError(t, err)
+	require.True(t, value.(bool))
 }
 
 func TestKeyboardDown(t *testing.T) {

--- a/tests/locator_assertions_test.go
+++ b/tests/locator_assertions_test.go
@@ -1,0 +1,444 @@
+package playwright_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocatorAssertionsToBeChecked(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<input id='checkbox1' type='checkbox' checked>
+	<input id='checkbox2' type='checkbox'>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("#checkbox1")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToBeChecked())
+	require.Error(t, expect.Locator(locator).NotToBeChecked())
+	require.Error(t, expect.Locator(locator).ToBeChecked(playwright.LocatorAssertionsToBeCheckedOptions{
+		Checked: playwright.Bool(false),
+	}))
+
+	locator, err = page.Locator("#checkbox2")
+	require.NoError(t, err)
+	require.Error(t, expect.Locator(locator).ToBeChecked())
+	require.NoError(t, expect.Locator(locator).NotToBeChecked())
+}
+
+func TestLocatorAssertionsToBeDisabled(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<button disabled>button1</button>
+	<button>button2</button>
+	<div>div</div>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator(":text(\"button1\")")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToBeDisabled())
+	require.Error(t, expect.Locator(locator).NotToBeDisabled())
+
+	locator, err = page.Locator(":text(\"button2\")")
+	require.NoError(t, err)
+	require.Error(t, expect.Locator(locator).ToBeDisabled())
+	require.NoError(t, expect.Locator(locator).NotToBeDisabled())
+
+	locator, err = page.Locator("div")
+	require.NoError(t, err)
+	require.Error(t, expect.Locator(locator).ToBeDisabled())
+	require.NoError(t, expect.Locator(locator).NotToBeDisabled())
+}
+
+func TestLocatorAssertionsToBeEditable(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<input id=input1>
+	<input id=input2 disabled>
+	<textarea></textarea>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("#input1")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToBeEditable())
+	require.Error(t, expect.Locator(locator).NotToBeEditable())
+
+	locator, err = page.Locator("#input2")
+	require.NoError(t, err)
+	require.Error(t, expect.Locator(locator).ToBeEditable())
+	require.NoError(t, expect.Locator(locator).NotToBeEditable())
+
+	locator, err = page.Locator("textarea")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToBeEditable())
+	require.Error(t, expect.Locator(locator).NotToBeEditable())
+}
+
+func TestLocatorAssertionsToBeEmpty(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<textarea id="textarea1"></textarea>
+	<textarea id="textarea2">test</textarea>
+	<div id="div1"></div>
+	<div id="div2">test</div>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("#textarea1")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToBeEmpty())
+	require.Error(t, expect.Locator(locator).NotToBeEmpty())
+
+	locator, err = page.Locator("#textarea2")
+	require.NoError(t, err)
+	require.Error(t, expect.Locator(locator).ToBeEmpty())
+	require.NoError(t, expect.Locator(locator).NotToBeEmpty())
+
+	locator, err = page.Locator("#div1")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToBeEmpty())
+	require.Error(t, expect.Locator(locator).NotToBeEmpty())
+
+	locator, err = page.Locator("#div2")
+	require.NoError(t, err)
+	require.Error(t, expect.Locator(locator).ToBeEmpty())
+	require.NoError(t, expect.Locator(locator).NotToBeEmpty())
+}
+
+func TestLocatorAssertionsToBeEnabled(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<button>button1</button>
+	<button disabled>button2</button>
+	<div>div</div>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator(`:text("button1")`)
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToBeEnabled())
+	require.Error(t, expect.Locator(locator).NotToBeEnabled())
+
+	locator, err = page.Locator(`:text("button2")`)
+	require.NoError(t, err)
+	require.Error(t, expect.Locator(locator).ToBeEnabled())
+	require.NoError(t, expect.Locator(locator).NotToBeEnabled())
+
+	locator, err = page.Locator("div")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToBeEnabled())
+	require.Error(t, expect.Locator(locator).NotToBeEnabled())
+}
+
+func TestLocatorAssertionsToBeFocused(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<input id=input1>
+	<input id=input2>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("#input1")
+	require.NoError(t, err)
+	require.NoError(t, locator.Focus())
+	require.NoError(t, expect.Locator(locator).ToBeFocused())
+	require.Error(t, expect.Locator(locator).NotToBeFocused())
+
+	locator, err = page.Locator("#input2")
+	require.NoError(t, err)
+	require.Error(t, expect.Locator(locator).ToBeFocused())
+	require.NoError(t, expect.Locator(locator).NotToBeFocused())
+}
+
+func TestLocatorAssertionsToBeHidden(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<details>
+		<summary>click to open</summary>
+		<ul>
+			<li>hidden item 1</li>
+			<li>hidden item 2</li>
+			<li>hidden item 3</li>
+		</ul>
+	</details>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("summary")
+	require.NoError(t, err)
+	require.Error(t, expect.Locator(locator).ToBeHidden())
+	require.NoError(t, expect.Locator(locator).NotToBeHidden())
+
+	locator, err = page.Locator("ul")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToBeHidden())
+	require.Error(t, expect.Locator(locator).NotToBeHidden())
+}
+
+func TestLocatorAssertionsToBeVisible(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<details>
+		<summary>click to open</summary>
+		<ul>
+			<li>hidden item 1</li>
+			<li>hidden item 2</li>
+			<li>hidden item 3</li>
+		</ul>
+	</details>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("summary")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToBeVisible())
+	require.Error(t, expect.Locator(locator).NotToBeVisible())
+
+	locator, err = page.Locator("ul")
+	require.NoError(t, err)
+	require.Error(t, expect.Locator(locator).ToBeVisible())
+	require.NoError(t, expect.Locator(locator).NotToBeVisible())
+}
+
+func TestLocatorAssertionsToContainText(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`<div><span style="display: none">foo</span>test1</div>`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("div")
+	require.NoError(t, err)
+
+	require.NoError(t, expect.Locator(locator).ToContainText("foo"))
+	require.NoError(t, expect.Locator(locator).NotToContainText("foo", playwright.LocatorAssertionsToContainTextOptions{
+		UseInnerText: playwright.Bool(true),
+	}))
+	require.NoError(t, expect.Locator(locator).ToContainText([]string{"test"}))
+	require.NoError(t, expect.Locator(locator).ToContainText(regexp.MustCompile(`test\d+`)))
+	require.NoError(t, expect.Locator(locator).ToContainText([]*regexp.Regexp{regexp.MustCompile("test")}))
+	require.Error(t, expect.Locator(locator).ToContainText("invalid"))
+	require.Error(t, expect.Locator(locator).NotToContainText("test"))
+}
+
+func TestLocatorAssertionsToHaveAttribute(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<input id="input1" type="text">
+	<input id="input2" type="number">
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("#input1")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveAttribute("type", "text"))
+	require.NoError(t, expect.Locator(locator).ToHaveAttribute("type", regexp.MustCompile("text")))
+	require.Error(t, expect.Locator(locator).NotToHaveAttribute("type", "text"))
+	require.Error(t, expect.Locator(locator).NotToHaveAttribute("type", regexp.MustCompile("text")))
+
+	locator, err = page.Locator("#input2")
+	require.NoError(t, err)
+	require.Error(t, expect.Locator(locator).ToHaveAttribute("type", "text"))
+	require.Error(t, expect.Locator(locator).ToHaveAttribute("type", regexp.MustCompile("text")))
+	require.NoError(t, expect.Locator(locator).NotToHaveAttribute("type", "text"))
+	require.NoError(t, expect.Locator(locator).NotToHaveAttribute("type", regexp.MustCompile("text")))
+}
+
+func TestLocatorAssertionsToHaveClass(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<div class="test1">test1</div>
+	<div class="test2">test2</div>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator(".test1")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveClass("test1"))
+	require.NoError(t, expect.Locator(locator).ToHaveClass([]string{"test1"}))
+	require.NoError(t, expect.Locator(locator).ToHaveClass(regexp.MustCompile("test.{1}")))
+	require.NoError(t, expect.Locator(locator).ToHaveClass([]*regexp.Regexp{regexp.MustCompile(`test\d+`)}))
+	require.Error(t, expect.Locator(locator).NotToHaveClass("test1"))
+
+	locator, err = page.Locator(".test2")
+	require.NoError(t, err)
+	require.Error(t, expect.Locator(locator).ToHaveClass("test1"))
+	require.Error(t, expect.Locator(locator).ToHaveClass([]string{"test1"}))
+	require.Error(t, expect.Locator(locator).ToHaveClass(regexp.MustCompile(`test\d{2}`)))
+	require.Error(t, expect.Locator(locator).ToHaveClass([]*regexp.Regexp{regexp.MustCompile(`test123`)}))
+	require.NoError(t, expect.Locator(locator).NotToHaveClass("test1"))
+}
+
+func TestLocatorAssertionsToHaveCount(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<button>button1</button>
+	<button disabled>button2</button>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("button")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCount(2))
+	require.Error(t, expect.Locator(locator).NotToHaveCount(2))
+}
+
+func TestLocatorAssertionsToHaveCSS(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<button id="button1" style="display: flex">button1</button>
+	<button id="button2">button2</button>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("#button1")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCSS("display", "flex"))
+	require.Error(t, expect.Locator(locator).NotToHaveCSS("display", "flex"))
+
+	locator, err = page.Locator("#button2")
+	require.NoError(t, err)
+	require.Error(t, expect.Locator(locator).ToHaveCSS("display", "flex"))
+	require.NoError(t, expect.Locator(locator).NotToHaveCSS("display", "flex"))
+}
+
+func TestLocatorAssertionsToHaveId(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`
+	<button id="button1">button1</button>
+	<div>div</div>
+	`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("button")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveId("button1"))
+	require.Error(t, expect.Locator(locator).NotToHaveId("button1"))
+
+	locator, err = page.Locator("div")
+	require.NoError(t, err)
+	require.Error(t, expect.Locator(locator).ToHaveId("button1"))
+	require.NoError(t, expect.Locator(locator).NotToHaveId("button1"))
+}
+
+func TestLocatorAssertionsToHaveJSProperty(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	require.NoError(t, page.SetContent("<div></div>"))
+	_, err = page.EvalOnSelector("div", "e => e.foo = true")
+	require.NoError(t, err)
+
+	locator, err := page.Locator("div")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveJSProperty("foo", true))
+	require.Error(t, expect.Locator(locator).NotToHaveJSProperty("foo", true))
+}
+
+func TestLocatorAssertionsToHaveText(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`<div><span style="display: none">foo</span>test</div>`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("div")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveText("footest"))
+	require.NoError(t, expect.Locator(locator).ToHaveText("Test",
+		playwright.LocatorAssertionsToHaveTextOptions{
+			UseInnerText: playwright.Bool(true),
+			IgnoreCase:   playwright.Bool(true),
+		}))
+	require.NoError(t, expect.Locator(locator).ToHaveText([]string{"footest"}))
+	require.NoError(t, expect.Locator(locator).ToHaveText(regexp.MustCompile("foo.*")))
+	require.NoError(t, expect.Locator(locator).ToHaveText([]*regexp.Regexp{regexp.MustCompile("foo.*")}))
+	require.Error(t, expect.Locator(locator).ToHaveText("invalid"))
+	require.Error(t, expect.Locator(locator).NotToHaveText("footest"))
+}
+
+func TestLocatorAssertionsToHaveValue(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`<input type="text" value="test">`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("input")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveValue("test"))
+	require.NoError(t, expect.Locator(locator).ToHaveValue(regexp.MustCompile("te.*")))
+	require.Error(t, expect.Locator(locator).ToHaveValue("invalid"))
+	require.Error(t, expect.Locator(locator).NotToHaveValue("test"))
+}
+
+func TestLocatorAssertionsToHaveValues(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	err = page.SetContent(`<select multiple>
+	<option value="R">Red</option>
+	<option value="G">Green</option>
+	<option value="B">Blue</option>
+</select>`)
+	require.NoError(t, err)
+
+	locator, err := page.Locator("select")
+	require.NoError(t, err)
+	_, err = locator.SelectOption(playwright.SelectOptionValues{
+		Values: &[]string{"R", "G"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveValues([]interface{}{"R", "G"}))
+	require.NoError(t, expect.Locator(locator).NotToHaveValues([]interface{}{"G", "B"}))
+}

--- a/tests/locator_get_by_test.go
+++ b/tests/locator_get_by_test.go
@@ -44,6 +44,84 @@ func TestGetByTestIdEscapeId(t *testing.T) {
 	require.Equal(t, "Hello world", text)
 }
 
+func TestGetByText(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	require.NoError(t, page.SetContent(`<div><div>yo</div><div>ya</div><div>\nye  </div></div>`))
+	locator, err := page.GetByText("yo")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCount(1))
+	locator, err = page.Locator("div")
+	require.NoError(t, err)
+	locator, err = locator.GetByText("yo")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCount(1))
+}
+
+func TestGetByLabel(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	require.NoError(t, page.SetContent(`<div><label for=target>Name</label><input id=target type=text></div>`))
+	locator, err := page.GetByLabel("Name")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCount(1))
+	locator, err = page.Locator("div")
+	require.NoError(t, err)
+	locator, err = locator.GetByLabel("Name")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCount(1))
+
+	ret, err := locator.Evaluate("e => e.nodeName", nil)
+	require.NoError(t, err)
+	require.Equal(t, "INPUT", ret)
+}
+
+func TestGetByPlaceholder(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	require.NoError(t, page.SetContent(`
+	<div>
+    <input placeholder="Hello">
+    <input placeholder="Hello World">
+  </div>`))
+	locator, err := page.GetByPlaceholder("hello")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCount(2))
+	locator, err = page.Locator("div")
+	require.NoError(t, err)
+	locator, err = locator.GetByPlaceholder("Hello", playwright.LocatorGetByPlaceholderOptions{
+		Exact: playwright.Bool(true),
+	})
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCount(1))
+}
+
+func TestGetByAltText(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	require.NoError(t, page.SetContent(`
+	<div>
+    <input alt="Hello">
+    <input alt="Hello World">
+  </div>`))
+	locator, err := page.GetByAltText("hello")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCount(2))
+}
+
+func TestGetByTitle(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	require.NoError(t, page.SetContent(`
+	<div>
+    <input title="Hello">
+    <input title="Hello World">
+  </div>`))
+	locator, err := page.GetByTitle("hello")
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(locator).ToHaveCount(2))
+}
+
 func TestGetByRole(t *testing.T) {
 	BeforeEach(t)
 	defer AfterEach(t)

--- a/tests/locator_get_by_test.go
+++ b/tests/locator_get_by_test.go
@@ -1,0 +1,87 @@
+package playwright_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetByTestId(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	require.NoError(t, page.SetContent(`<div><div data-testid='Hello'>Hello world</div></div>`))
+	locator, err := page.GetByTestId("Hello")
+	require.NoError(t, err)
+	text, err := locator.TextContent()
+	require.NoError(t, err)
+	require.Equal(t, "Hello world", text)
+
+	locator, err = page.MainFrame().GetByTestId("Hello")
+	require.NoError(t, err)
+	text, err = locator.TextContent()
+	require.NoError(t, err)
+	require.Equal(t, "Hello world", text)
+
+	locator, err = page.Locator("div")
+	require.NoError(t, err)
+	locator, err = locator.GetByTestId("Hello")
+	require.NoError(t, err)
+	text, err = locator.TextContent()
+	require.NoError(t, err)
+	require.Equal(t, "Hello world", text)
+}
+
+func TestGetByTestIdEscapeId(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	require.NoError(t, page.SetContent(`<div><div data-testid='He"llo'>Hello world</div></div>`))
+	locator, err := page.GetByTestId("He\"llo")
+	require.NoError(t, err)
+	text, err := locator.TextContent()
+	require.NoError(t, err)
+	require.Equal(t, "Hello world", text)
+}
+
+func TestGetByRole(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	require.NoError(t, page.SetContent(`
+	<button>Hello</button>
+	<button>Hel"lo</button>
+	<div role="dialog">I am a dialog</div>
+	`))
+	locator, err := page.GetByRole("button", playwright.LocatorGetByRoleOptions{
+		Name: "hello",
+	})
+	require.NoError(t, err)
+	count, err := locator.Count()
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	locator, err = page.GetByRole("button", playwright.LocatorGetByRoleOptions{
+		Name: "Hel\"lo",
+	})
+	require.NoError(t, err)
+	require.NoError(t, err)
+	count, err = locator.Count()
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	locator, err = page.GetByRole("button", playwright.LocatorGetByRoleOptions{
+		Name: regexp.MustCompile(`(?i)he`),
+	})
+	require.NoError(t, err)
+	require.NoError(t, err)
+	count, err = locator.Count()
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+
+	locator, err = page.GetByRole("dialog")
+	require.NoError(t, err)
+	require.NoError(t, err)
+	count, err = locator.Count()
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -1,6 +1,7 @@
 package playwright_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/playwright-community/playwright-go"
@@ -428,4 +429,41 @@ func TestLocatorShouldFocusAndBlurButton(t *testing.T) {
 	require.False(t, ret.(bool))
 	require.True(t, focused)
 	require.True(t, blurred)
+}
+
+func TestLocatorAllShouldWork(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	require.NoError(t, page.SetContent(`<div><p>A</p><p>B</p><p>C</p></div>`))
+	expected := []string{"A", "B", "C"}
+	texts := make([]string, 0)
+	p, err := page.Locator("p")
+	require.NoError(t, err)
+	locators, err := p.All()
+	require.NoError(t, err)
+	for _, locator := range locators {
+		content, err := locator.TextContent()
+		require.NoError(t, err)
+		texts = append(texts, content)
+	}
+	require.ElementsMatch(t, expected, texts)
+}
+
+func TestLocatorsClearShouldWork(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(fmt.Sprintf("%s/input/textarea.html", server.PREFIX))
+	require.NoError(t, err)
+	button, err := page.Locator("input")
+	require.NoError(t, err)
+	require.NoError(t, button.Fill("some value"))
+	ret, err := page.Evaluate(`result`)
+	require.NoError(t, err)
+	require.Equal(t, "some value", ret)
+	require.NoError(t, button.Clear())
+	ret, err = page.Evaluate(`result`)
+	require.NoError(t, err)
+	require.Equal(t, "", ret)
 }

--- a/tests/page_assertions_test.go
+++ b/tests/page_assertions_test.go
@@ -1,0 +1,57 @@
+package playwright_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPageAssertionsToHaveTitle(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	require.NoError(t, page.SetContent(`<title>new title</title>`))
+
+	require.NoError(t, expect.Page(page).ToHaveTitle("new title"))
+	require.NoError(t, expect.Page(page).ToHaveTitle(regexp.MustCompile("(?i)new title")))
+	require.NoError(t, expect.Page(page).NotToHaveTitle("not the current title", playwright.PageAssertionsToHaveTitleOptions{
+		Timeout: playwright.Float(750),
+	}))
+
+	_, err = page.Evaluate(`setTimeout(() => {
+		document.title = 'great title';
+	}, 500);
+	`)
+	require.NoError(t, err)
+	require.NoError(t, expect.Page(page).ToHaveTitle("great title"))
+	require.NoError(t, expect.Page(page).Not().ToHaveTitle("not the current title"))
+}
+
+func TestPageAssertionsToHaveURL(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+
+	require.NoError(t, expect.Page(page).ToHaveURL(server.EMPTY_PAGE))
+	require.NoError(t, expect.Page(page).ToHaveURL(regexp.MustCompile(`.*/empty\.html`)))
+	require.NoError(t, expect.Page(page).NotToHaveURL("https://playwright.dev"))
+}
+
+func TestPageAssertionsToHaveURLWithBaseURL(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	page, err := browser.NewPage(playwright.BrowserNewContextOptions{
+		BaseURL: &server.PREFIX,
+	})
+	require.NoError(t, err)
+	_, err = page.Goto("/empty.html")
+	require.NoError(t, err)
+	require.NoError(t, expect.Page(page).ToHaveURL("/empty.html"))
+	require.NoError(t, expect.Page(page).ToHaveURL(regexp.MustCompile(`.*/empty\.html`)))
+	require.NoError(t, expect.Page(page).Not().ToHaveURL("https://playwright.dev"))
+	require.NoError(t, page.Close())
+}

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -965,31 +965,15 @@ func TestPageSetChecked(t *testing.T) {
 	require.False(t, isChecked.(bool))
 }
 
-func TestPageWaitForRequest(t *testing.T) {
-	t.Run("should work", func(t *testing.T) {
-		BeforeEach(t)
-		defer AfterEach(t)
-
-		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			request, err := page.WaitForRequest("**/one-style.html", playwright.PageWaitForRequestOptions{Timeout: playwright.Float(3 * 1000)})
-			require.NoError(t, err)
-			require.Equal(t, fmt.Sprintf("%s/one-style.html", server.PREFIX), request.URL())
-		}()
-
-		_, err := page.Goto(server.PREFIX + "/one-style.html")
-		require.NoError(t, err)
-		wg.Wait()
-	})
-
+func TestPageExpectRequestTimeout(t *testing.T) {
 	t.Run("should respect timeout", func(t *testing.T) {
 		BeforeEach(t)
 		defer AfterEach(t)
-		_, err := page.Goto(server.EMPTY_PAGE)
-		require.NoError(t, err)
-		request, err := page.WaitForRequest("**/one-style.html", playwright.PageWaitForRequestOptions{Timeout: playwright.Float(1000)})
+
+		request, err := page.ExpectRequest("**/one-style.html", func() error {
+			_, err := page.Goto(server.EMPTY_PAGE)
+			return err
+		}, playwright.PageWaitForRequestOptions{Timeout: playwright.Float(1000)})
 
 		require.Nil(t, request)
 		require.EqualError(t, err, "Timeout 1000.00ms exceeded.")
@@ -998,12 +982,13 @@ func TestPageWaitForRequest(t *testing.T) {
 	t.Run("should use default timeout", func(t *testing.T) {
 		BeforeEach(t)
 		defer AfterEach(t)
-		_, err := page.Goto(server.EMPTY_PAGE)
 		page.SetDefaultTimeout(500)
 		defer page.SetDefaultTimeout(30 * 1000) // reset
 
-		require.NoError(t, err)
-		request, err := page.WaitForRequest("**/one-style.html")
+		request, err := page.ExpectRequest("**/one-style.html", func() error {
+			_, err := page.Goto(server.EMPTY_PAGE)
+			return err
+		})
 
 		require.Nil(t, request)
 		require.EqualError(t, err, "Timeout 500.00ms exceeded.")

--- a/tests/route_test.go
+++ b/tests/route_test.go
@@ -268,11 +268,11 @@ func TestFulfillWithURLOverride(t *testing.T) {
 			URL: playwright.String(server.PREFIX + "/one-style.html"),
 		})
 		require.NoError(t, err)
+		headers := response.Headers() // require for webkit on linux
+		headers["foo"] = "bar"
 		require.NoError(t, route.Fulfill(playwright.RouteFulfillOptions{
 			Response: response,
-			Headers: map[string]string{
-				"Foo": "bar",
-			},
+			Headers:  headers,
 		}))
 	}))
 	response, err := page.Goto(server.EMPTY_PAGE)

--- a/tests/selectors_test.go
+++ b/tests/selectors_test.go
@@ -1,0 +1,73 @@
+package playwright_test
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectorsRegisterShouldWork(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	tagSelector := `
+	{
+		create(root, target) {
+			return target.nodeName;
+		},
+		query(root, selector) {
+			return root.querySelector(selector);
+		},
+		queryAll(root, selector) {
+			return Array.from(root.querySelectorAll(selector));
+		}
+	}
+	`
+	selectorName := "tag_" + browserName
+	selector2Name := "tag2_" + browserName
+
+	// Register one engine before creating context.
+	err := pw.Selectors.Register(selectorName, playwright.SelectorsRegisterOptions{
+		Script: &tagSelector,
+	})
+	require.NoError(t, err)
+
+	context2, err := browser.NewContext()
+	require.NoError(t, err)
+
+	// Register another engine after creating context.
+	err = pw.Selectors.Register(selector2Name, playwright.SelectorsRegisterOptions{
+		Script: &tagSelector,
+	})
+	require.NoError(t, err)
+
+	page, err := context2.NewPage()
+	require.NoError(t, err)
+	require.NoError(t, page.SetContent(`<div><span></span></div><div></div>`))
+
+	ret, err := page.EvalOnSelector(selectorName+"=DIV", `e => e.nodeName`)
+	require.NoError(t, err)
+	require.Equal(t, "DIV", ret)
+	ret, err = page.EvalOnSelector(selectorName+"=SPAN", `e => e.nodeName`)
+	require.NoError(t, err)
+	require.Equal(t, "SPAN", ret)
+	ret, err = page.EvalOnSelectorAll(selectorName+"=DIV", `es => es.length`)
+	require.NoError(t, err)
+	require.Equal(t, 2, ret)
+
+	ret, err = page.EvalOnSelector(selector2Name+"=DIV", `e => e.nodeName`)
+	require.NoError(t, err)
+	require.Equal(t, "DIV", ret)
+	ret, err = page.EvalOnSelector(selector2Name+"=SPAN", `e => e.nodeName`)
+	require.NoError(t, err)
+	require.Equal(t, "SPAN", ret)
+	ret, err = page.EvalOnSelectorAll(selector2Name+"=DIV", `es => es.length`)
+	require.NoError(t, err)
+	require.Equal(t, 2, ret)
+
+	// Selector names are case-sensitive.
+	_, err = page.QuerySelector("tAG=DIV")
+	require.ErrorContains(t, err, `Unknown engine "tAG" while parsing selector tAG=DIV`)
+
+	require.NoError(t, context2.Close())
+}

--- a/tests/video_test.go
+++ b/tests/video_test.go
@@ -28,7 +28,7 @@ func TestVideoShouldWork(t *testing.T) {
 	require.NoError(t, err)
 	_, err = page.Reload()
 	require.NoError(t, err)
-	page.WaitForTimeout(1000) // make sure video has some data
+	page.WaitForTimeout(500) // make sure video has some data
 	require.NoError(t, context.Close())
 
 	path, err := page.Video().Path()
@@ -69,7 +69,7 @@ func TestVideo(t *testing.T) {
 		path, err := video.Path()
 		require.NoError(t, err)
 		require.Contains(t, path, recordVideoDir)
-		page.WaitForTimeout(1000)
+		page.WaitForTimeout(500)
 		require.NoError(t, page.Context().Close())
 	})
 
@@ -87,7 +87,7 @@ func TestVideo(t *testing.T) {
 		defer AfterEach(t)
 		_, err := page.Goto(server.PREFIX + "/grid.html")
 		require.NoError(t, err)
-		page.WaitForTimeout(1000)
+		page.WaitForTimeout(500)
 		require.NoError(t, page.Close())
 		video := page.Video()
 		require.NotNil(t, video)
@@ -113,7 +113,7 @@ func TestVideo(t *testing.T) {
 		require.NoError(t, err)
 		video := page.Video()
 		require.NotNil(t, video)
-		page.WaitForTimeout(1000)
+		page.WaitForTimeout(500)
 		require.NoError(t, page.Close())
 		require.NoError(t, video.Delete())
 		path, err := video.Path()
@@ -162,7 +162,7 @@ func TestVideo(t *testing.T) {
 		path, err := video.Path()
 		require.NoError(t, err)
 		require.Contains(t, path, tmpDir)
-		page.WaitForTimeout(1000)
+		page.WaitForTimeout(500)
 		require.NoError(t, context.Close())
 		require.FileExists(t, path)
 	})
@@ -187,7 +187,7 @@ func TestVideo(t *testing.T) {
 		require.NoError(t, err)
 		_, err = page.Goto(server.PREFIX + "/grid.html")
 		require.NoError(t, err)
-		page.WaitForTimeout(1000)
+		page.WaitForTimeout(500)
 		video := page.Video()
 		_, err = video.Path()
 		require.ErrorContains(t, err, "Path is not available when connecting remotely")

--- a/tests/websocket_test.go
+++ b/tests/websocket_test.go
@@ -107,15 +107,16 @@ func TestWebSocketShouldEmitCloseEvents(t *testing.T) {
 	defer AfterEach(t)
 	wsServer := newWebsocketServer()
 	defer wsServer.Stop()
-	wsEvent, err := page.ExpectEvent("websocket", func() error {
+	ws, err := page.ExpectWebSocket(func() error {
 		_, err := page.Evaluate(`port => {
             const ws = new WebSocket('ws://localhost:' + port + '/ws');
             ws.addEventListener('message', data => { ws.close() });
         }`, wsServer.PORT)
 		return err
+	}, playwright.PageExpectWebSocketOptions{
+		Timeout: playwright.Float(1000),
 	})
 	require.NoError(t, err)
-	ws := wsEvent.(playwright.WebSocket)
 	require.Equal(t, ws.URL(), fmt.Sprintf("ws://localhost:%d/ws", wsServer.PORT))
 	if !ws.IsClosed() {
 		_, err = ws.WaitForEvent("close")
@@ -141,7 +142,7 @@ func TestWebSocketShouldEmitFrameEvents(t *testing.T) {
 			received = append(received, payload)
 		})
 	})
-	wsEvent, err := page.ExpectEvent("websocket", func() error {
+	ws, err := page.ExpectWebSocket(func() error {
 		_, err := page.Evaluate(`port => {
             const ws = new WebSocket('ws://localhost:' + port + '/ws');
             ws.addEventListener('open', () => {
@@ -151,7 +152,6 @@ func TestWebSocketShouldEmitFrameEvents(t *testing.T) {
 		return err
 	})
 	require.NoError(t, err)
-	ws := wsEvent.(playwright.WebSocket)
 	if !ws.IsClosed() {
 		_, err = ws.WaitForEvent("close")
 		require.NoError(t, err)
@@ -178,7 +178,7 @@ func TestWebSocketShouldEmitBinaryFrameEvents(t *testing.T) {
 			received = append(received, payload)
 		})
 	})
-	wsEvent, err := page.ExpectEvent("websocket", func() error {
+	ws, err := page.ExpectWebSocket(func() error {
 		_, err := page.Evaluate(`port => {
             const ws = new WebSocket('ws://localhost:' + port + '/ws');
             ws.addEventListener('open', () => {
@@ -192,7 +192,6 @@ func TestWebSocketShouldEmitBinaryFrameEvents(t *testing.T) {
 		return err
 	})
 	require.NoError(t, err)
-	ws := wsEvent.(playwright.WebSocket)
 	if !ws.IsClosed() {
 		_, err = ws.WaitForEvent("close")
 		require.NoError(t, err)
@@ -200,4 +199,25 @@ func TestWebSocketShouldEmitBinaryFrameEvents(t *testing.T) {
 
 	require.Equal(t, sent, [][]byte{{0, 1, 2, 3, 4}, []byte("echo-bin")})
 	require.Equal(t, received, [][]byte{[]byte("incoming"), {4, 2}})
+}
+
+func TestShouldRejectWaitForEventOnCloseAndError(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	wsServer := newWebsocketServer()
+	defer wsServer.Stop()
+	ws, err := page.ExpectWebSocket(func() error {
+		_, err := page.Evaluate(`port => {
+            ws = new WebSocket('ws://localhost:' + port + '/ws');
+        }`, wsServer.PORT)
+		return err
+	})
+	require.NoError(t, err)
+	_, err = ws.WaitForEvent("framereceived")
+	require.NoError(t, err)
+	_, err = ws.ExpectEvent("framesent", func() error {
+		_, err := page.Evaluate(`window.ws.close()`)
+		return err
+	})
+	require.ErrorContains(t, err, "websocket closed")
 }

--- a/tests/websocket_test.go
+++ b/tests/websocket_test.go
@@ -219,6 +219,11 @@ func TestWebSocketShouldRejectWaitForEventOnCloseAndError(t *testing.T) {
 	_, err = ws.ExpectEvent("framesent", func() error {
 		_, err := page.Evaluate(`window.ws.close()`)
 		return err
+	}, playwright.WebSocketWaitForEventOptions{
+		Timeout: playwright.Float(1000),
+		Predicate: func(ev interface{}) bool {
+			return true
+		},
 	})
 	require.ErrorContains(t, err, "websocket closed")
 }

--- a/tests/websocket_test.go
+++ b/tests/websocket_test.go
@@ -201,7 +201,7 @@ func TestWebSocketShouldEmitBinaryFrameEvents(t *testing.T) {
 	require.Equal(t, received, [][]byte{[]byte("incoming"), {4, 2}})
 }
 
-func TestShouldRejectWaitForEventOnCloseAndError(t *testing.T) {
+func TestWebSocketShouldRejectWaitForEventOnCloseAndError(t *testing.T) {
 	BeforeEach(t)
 	defer AfterEach(t)
 	wsServer := newWebsocketServer()
@@ -213,8 +213,9 @@ func TestShouldRejectWaitForEventOnCloseAndError(t *testing.T) {
 		return err
 	})
 	require.NoError(t, err)
-	_, err = ws.WaitForEvent("framereceived")
-	require.NoError(t, err)
+	// event may have been generated before interception
+	// _, err = ws.WaitForEvent("framereceived")
+	// require.NoError(t, err)
 	_, err = ws.ExpectEvent("framesent", func() error {
 		_, err := page.Evaluate(`window.ws.close()`)
 		return err

--- a/waiter.go
+++ b/waiter.go
@@ -60,7 +60,7 @@ func (w *waiter) WithTimeout(timeout float64) *waiter {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.waitFunc != nil {
-		w.reject(fmt.Errorf("waiter: set timeout before WaitForEvent"))
+		w.reject(fmt.Errorf("waiter: please set timeout before WaitForEvent"))
 		return w
 	}
 	w.timeout = timeout

--- a/waiter.go
+++ b/waiter.go
@@ -151,7 +151,7 @@ func (w *waiter) createHandler(evChan chan<- interface{}, predicate interface{})
 		if w.fulfilled.Load() {
 			return
 		}
-		if predicate == nil {
+		if predicate == nil || reflect.ValueOf(predicate).IsNil() {
 			w.fulfilled.Store(true)
 			if len(ev) == 1 {
 				evChan <- ev[0]

--- a/waiter.go
+++ b/waiter.go
@@ -136,7 +136,8 @@ func (w *waiter) Wait() (interface{}, error) {
 	return w.waitFunc()
 }
 
-func (w *waiter) Expect(cb func() error) (interface{}, error) {
+// RunAndWait waits for the waiter to return after calls func.
+func (w *waiter) RunAndWait(cb func() error) (interface{}, error) {
 	if w.waitFunc == nil {
 		return nil, fmt.Errorf("waiter: call WaitForEvent first")
 	}

--- a/waiter_test.go
+++ b/waiter_test.go
@@ -120,3 +120,25 @@ func TestWaiterRejectOnEventWithPredicate(t *testing.T) {
 	require.Equal(t, 0, emitter.ListenerCount(testEventNameReject))
 	require.Nil(t, result)
 }
+
+func TestWaiterReturnErrorWhenMisuse(t *testing.T) {
+	emitter := &eventEmitter{}
+	emitter.initEventEmitter()
+	waiter := newWaiter()
+	waiter.WaitForEvent(emitter, testEventNameFoobar, nil)
+	waiter.WithTimeout(500)
+	_, err := waiter.Wait()
+	require.ErrorContains(t, err, "please set timeout before WaitForEvent")
+
+	waiter = newWaiter()
+	waiter.WaitForEvent(emitter, testEventNameFoobar, nil)
+	waiter.WaitForEvent(emitter, testEventNameFoo, nil)
+	_, err = waiter.Wait()
+	require.ErrorContains(t, err, "WaitForEvent can only be called once")
+
+	waiter = newWaiter()
+	waiter.WaitForEvent(emitter, testEventNameFoobar, nil)
+	waiter.RejectOnEvent(emitter, testEventNameFoo, nil)
+	_, err = waiter.Wait()
+	require.ErrorContains(t, err, "call RejectOnEvent before WaitForEvent")
+}

--- a/websocket.go
+++ b/websocket.go
@@ -102,7 +102,7 @@ func (ws *webSocketImpl) expectEvent(event string, cb func() error, options ...W
 	if cb == nil {
 		return waiter.WaitForEvent(ws, event, predicate).Wait()
 	} else {
-		return waiter.WaitForEvent(ws, event, predicate).Expect(cb)
+		return waiter.WaitForEvent(ws, event, predicate).RunAndWait(cb)
 	}
 }
 

--- a/worker.go
+++ b/worker.go
@@ -95,7 +95,7 @@ func (w *workerImpl) ExpectEvent(event string, cb func() error, predicates ...in
 	if len(predicates) == 1 {
 		predicate = predicates[0]
 	}
-	return newWaiter().WaitForEvent(w, event, predicate).Expect(cb)
+	return newWaiter().WaitForEvent(w, event, predicate).RunAndWait(cb)
 }
 
 func newWorker(parent *channelOwner, objectType string, guid string, initializer map[string]interface{}) *workerImpl {

--- a/worker.go
+++ b/worker.go
@@ -70,7 +70,7 @@ func (w *workerImpl) onClose() {
 	}
 	if w.context != nil {
 		w.context.Lock()
-		workers := make([]*workerImpl, 0)
+		workers := make([]Worker, 0)
 		for i := 0; i < len(w.context.serviceWorkers); i++ {
 			if w.context.serviceWorkers[i] != w {
 				workers = append(workers, w.context.serviceWorkers[i])

--- a/worker.go
+++ b/worker.go
@@ -12,19 +12,13 @@ func (w *workerImpl) URL() string {
 
 func (w *workerImpl) Evaluate(expression string, options ...interface{}) (interface{}, error) {
 	var arg interface{}
-	forceExpression := false
-	if !isFunctionBody(expression) {
-		forceExpression = true
-	}
 	if len(options) == 1 {
 		arg = options[0]
 	} else if len(options) == 2 {
 		arg = options[0]
-		forceExpression = options[1].(bool)
 	}
 	result, err := w.channel.Send("evaluateExpression", map[string]interface{}{
 		"expression": expression,
-		"isFunction": !forceExpression,
 		"arg":        serializeArgument(arg),
 	})
 	if err != nil {
@@ -35,19 +29,13 @@ func (w *workerImpl) Evaluate(expression string, options ...interface{}) (interf
 
 func (w *workerImpl) EvaluateHandle(expression string, options ...interface{}) (JSHandle, error) {
 	var arg interface{}
-	forceExpression := false
-	if !isFunctionBody(expression) {
-		forceExpression = true
-	}
 	if len(options) == 1 {
 		arg = options[0]
 	} else if len(options) == 2 {
 		arg = options[0]
-		forceExpression = options[1].(bool)
 	}
 	result, err := w.channel.Send("evaluateExpressionHandle", map[string]interface{}{
 		"expression": expression,
-		"isFunction": !forceExpression,
 		"arg":        serializeArgument(arg),
 	})
 	if err != nil {


### PR DESCRIPTION
Since no other contributors have submitted in a while, I've included several features in this PR. 

Mainly include:
* RouteFromHAR
* Missing part of Locator
* Web-first assertions #271 
    * mostly done by @masaushi in #278, thanks to @masaushi

Except for classes and methods explicitly ignored in `validate-interfaces.js`, other methods are aligned with playwright-python v1.30.0. Note, run `./scripts/apply-patch.sh` first, and then validate with `node ./scripts/validate-interfaces.js`.