### PR TITLE
Roll to Playwright v1.38.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/playwright-community/playwright-go)](https://pkg.go.dev/github.com/playwright-community/playwright-go)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](http://opensource.org/licenses/MIT)
 [![Go Report Card](https://goreportcard.com/badge/github.com/playwright-community/playwright-go)](https://goreportcard.com/report/github.com/playwright-community/playwright-go) ![Build Status](https://github.com/playwright-community/playwright-go/workflows/Go/badge.svg)
-[![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://aka.ms/playwright-slack) [![Coverage Status](https://coveralls.io/repos/github/playwright-community/playwright-go/badge.svg?branch=main)](https://coveralls.io/github/playwright-community/playwright-go?branch=main) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-116.0.5845.82-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-115.0-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> <!-- GEN:webkit-version-badge -->[![WebKit version](https://img.shields.io/badge/webkit-17.0-blue.svg?logo=safari)](https://webkit.org/)<!-- GEN:stop -->
+[![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://aka.ms/playwright-slack) [![Coverage Status](https://coveralls.io/repos/github/playwright-community/playwright-go/badge.svg?branch=main)](https://coveralls.io/github/playwright-community/playwright-go?branch=main) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-117.0.5938.62-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-117.0-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> <!-- GEN:webkit-version-badge -->[![WebKit version](https://img.shields.io/badge/webkit-17.0-blue.svg?logo=safari)](https://webkit.org/)<!-- GEN:stop -->
 
 [API reference](https://playwright.dev/docs/api/class-playwright) | [Example recipes](https://github.com/playwright-community/playwright-go/tree/main/examples)
 
@@ -13,9 +13,9 @@ Playwright is a Go library to automate [Chromium](https://www.chromium.org/Home)
 
 |          | Linux | macOS | Windows |
 |   :---   | :---: | :---: | :---:   |
-| Chromium <!-- GEN:chromium-version -->116.0.5845.82<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| Chromium <!-- GEN:chromium-version -->117.0.5938.62<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 | WebKit <!-- GEN:webkit-version -->17.0<!-- GEN:stop --> | ✅ | ✅ | ✅ |
-| Firefox <!-- GEN:firefox-version -->115.0<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| Firefox <!-- GEN:firefox-version -->117.0<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 
 Headless execution is supported for all the browsers on all platforms.
 

--- a/browser.go
+++ b/browser.go
@@ -33,6 +33,14 @@ func (b *browserImpl) NewContext(options ...BrowserNewContextOptions) (BrowserCo
 	if len(options) == 1 {
 		option = options[0]
 	}
+	if option.AcceptDownloads != nil {
+		if *option.AcceptDownloads {
+			overrides["acceptDownloads"] = "accept"
+		} else {
+			overrides["acceptDownloads"] = "deny"
+		}
+		options[0].AcceptDownloads = nil
+	}
 	if option.ExtraHttpHeaders != nil {
 		overrides["extraHTTPHeaders"] = serializeMapToNameAndValue(options[0].ExtraHttpHeaders)
 		options[0].ExtraHttpHeaders = nil

--- a/browser_context.go
+++ b/browser_context.go
@@ -439,7 +439,7 @@ func (b *browserContextImpl) onClose() {
 	b.Emit("close", b)
 }
 
-func (b *browserContextImpl) onPage(page *pageImpl) {
+func (b *browserContextImpl) onPage(page Page) {
 	b.Lock()
 	b.pages = append(b.pages, page)
 	b.Unlock()
@@ -587,6 +587,7 @@ func newBrowserContext(parent *channelOwner, objectType string, guid string, ini
 	bt := &browserContextImpl{
 		timeoutSettings: newTimeoutSettings(nil),
 		pages:           make([]Page, 0),
+		backgroundPages: make([]Page, 0),
 		routes:          make([]*routeHandlerEntry, 0),
 		bindings:        make(map[string]BindingCallFunction),
 		harRecorders:    make(map[string]harRecordingMetadata),

--- a/browser_type.go
+++ b/browser_type.go
@@ -44,6 +44,14 @@ func (b *browserTypeImpl) LaunchPersistentContext(userDataDir string, options ..
 		if err != nil {
 			return nil, fmt.Errorf("can not convert options: %w", err)
 		}
+		if options[0].AcceptDownloads != nil {
+			if *options[0].AcceptDownloads {
+				overrides["acceptDownloads"] = "accept"
+			} else {
+				overrides["acceptDownloads"] = "deny"
+			}
+			options[0].AcceptDownloads = nil
+		}
 		if options[0].ExtraHttpHeaders != nil {
 			overrides["extraHTTPHeaders"] = serializeMapToNameAndValue(options[0].ExtraHttpHeaders)
 			options[0].ExtraHttpHeaders = nil

--- a/examples/end-to-end-testing/main.go
+++ b/examples/end-to-end-testing/main.go
@@ -51,7 +51,7 @@ func main() {
 
 	// Adding a todo entry (click in the input, enter the todo title and press the Enter key)
 	assertErrorToNilf("could not click: %v", page.Locator("input.new-todo").Click())
-	assertErrorToNilf("could not type: %v", page.Locator("input.new-todo").Type(todoName))
+	assertErrorToNilf("could not type: %v", page.Locator("input.new-todo").Fill(todoName))
 	assertErrorToNilf("could not press: %v", page.Locator("input.new-todo").Press("Enter"))
 
 	// After adding 1 there should be 1 entry in the list

--- a/frame.go
+++ b/frame.go
@@ -275,11 +275,10 @@ func (f *frameImpl) onLoadState(ev map[string]interface{}) {
 		add := ev["add"].(string)
 		f.loadStates.Add(add)
 		f.Emit("loadstate", add)
-		if f.parentFrame == nil && add == "load" && f.page != nil {
-			f.page.Emit("load", f.page)
-		}
-		if f.parentFrame == nil && add == "domcontentloaded" && f.page != nil {
-			f.page.Emit("domcontentloaded", f.page)
+		if f.parentFrame == nil && f.page != nil {
+			if add == "load" || add == "domcontentloaded" {
+				f.Page().Emit(add, f.page)
+			}
 		}
 	} else if ev["remove"] != nil {
 		remove := ev["remove"].(string)

--- a/frame.go
+++ b/frame.go
@@ -1,6 +1,7 @@
 package playwright
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -138,7 +139,10 @@ func (f *frameImpl) waitForLoadStateImpl(state string, timeout *float64, cb func
 	if f.loadStates.Has(state) {
 		return nil
 	}
-	waiter := f.setNavigationWaiter(timeout)
+	waiter, err := f.setNavigationWaiter(timeout)
+	if err != nil {
+		return err
+	}
 	waiter.WaitForEvent(f, "loadstate", func(payload interface{}) bool {
 		gotState := payload.(string)
 		return gotState == state
@@ -153,6 +157,9 @@ func (f *frameImpl) waitForLoadStateImpl(state string, timeout *float64, cb func
 }
 
 func (f *frameImpl) WaitForURL(url interface{}, options ...FrameWaitForURLOptions) error {
+	if f.page == nil {
+		return errors.New("frame is detached")
+	}
 	matcher := newURLMatcher(url, f.page.browserContext.options.BaseURL)
 	if matcher.Matches(f.URL()) {
 		state := "load"
@@ -179,6 +186,9 @@ func (f *frameImpl) WaitForURL(url interface{}, options ...FrameWaitForURLOption
 }
 
 func (f *frameImpl) ExpectNavigation(cb func() error, options ...FrameExpectNavigationOptions) (Response, error) {
+	if f.page == nil {
+		return nil, errors.New("frame is detached")
+	}
 	option := FrameExpectNavigationOptions{}
 	if len(options) == 1 {
 		option = options[0]
@@ -201,7 +211,10 @@ func (f *frameImpl) ExpectNavigation(cb func() error, options ...FrameExpectNavi
 		}
 		return matcher == nil || matcher.Matches(ev["url"].(string))
 	}
-	waiter := f.setNavigationWaiter(option.Timeout)
+	waiter, err := f.setNavigationWaiter(option.Timeout)
+	if err != nil {
+		return nil, err
+	}
 
 	eventData, err := waiter.WaitForEvent(f, "navigated", predicate).RunAndWait(cb)
 	if err != nil || eventData == nil {
@@ -223,7 +236,10 @@ func (f *frameImpl) ExpectNavigation(cb func() error, options ...FrameExpectNavi
 	return nil, nil
 }
 
-func (f *frameImpl) setNavigationWaiter(timeout *float64) *waiter {
+func (f *frameImpl) setNavigationWaiter(timeout *float64) (*waiter, error) {
+	if f.page == nil {
+		return nil, errors.New("page does not exist")
+	}
 	waiter := newWaiter()
 	if timeout != nil {
 		waiter.WithTimeout(*timeout)
@@ -239,7 +255,7 @@ func (f *frameImpl) setNavigationWaiter(timeout *float64) *waiter {
 		}
 		return false
 	})
-	return waiter
+	return waiter, nil
 }
 
 func (f *frameImpl) onFrameNavigated(ev map[string]interface{}) {
@@ -248,7 +264,8 @@ func (f *frameImpl) onFrameNavigated(ev map[string]interface{}) {
 	f.name = ev["name"].(string)
 	f.Unlock()
 	f.Emit("navigated", ev)
-	if f.page != nil {
+	_, ok := ev["error"]
+	if !ok && f.page != nil {
 		f.page.Emit("framenavigated", f)
 	}
 }
@@ -258,6 +275,12 @@ func (f *frameImpl) onLoadState(ev map[string]interface{}) {
 		add := ev["add"].(string)
 		f.loadStates.Add(add)
 		f.Emit("loadstate", add)
+		if f.parentFrame == nil && add == "load" && f.page != nil {
+			f.page.Emit("load", f.page)
+		}
+		if f.parentFrame == nil && add == "domcontentloaded" && f.page != nil {
+			f.page.Emit("domcontentloaded", f.page)
+		}
 	} else if ev["remove"] != nil {
 		remove := ev["remove"].(string)
 		f.loadStates.Remove(remove)

--- a/generated-structs.go
+++ b/generated-structs.go
@@ -1083,6 +1083,9 @@ type ElementHandleScreenshotOptions struct {
 	// When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be
 	// changed.  Defaults to `"hide"`.
 	Caret *ScreenshotCaret `json:"caret"`
+	// Specify locators that should be masked when the screenshot is taken. Masked elements will be overlaid with a pink
+	// box `#FF00FF` (customized by “maskColor”) that completely covers its bounding box.
+	Mask []Locator `json:"mask"`
 	// Specify the color of the overlay box for masked elements, in
 	// [CSS color format]. Default color is pink `#FF00FF`.
 	//
@@ -2331,6 +2334,17 @@ type LocatorPressOptions struct {
 	// be changed by using the [BrowserContext.SetDefaultTimeout] or [Page.SetDefaultTimeout] methods.
 	Timeout *float64 `json:"timeout"`
 }
+type LocatorPressSequentiallyOptions struct {
+	// Time to wait between key presses in milliseconds. Defaults to 0.
+	Delay *float64 `json:"delay"`
+	// Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
+	// can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
+	// navigating to inaccessible pages. Defaults to `false`.
+	NoWaitAfter *bool `json:"noWaitAfter"`
+	// Maximum time in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can
+	// be changed by using the [BrowserContext.SetDefaultTimeout] or [Page.SetDefaultTimeout] methods.
+	Timeout *float64 `json:"timeout"`
+}
 type LocatorScreenshotOptions struct {
 	// When set to `"disabled"`, stops CSS animations, CSS transitions and Web Animations. Animations get different
 	// treatment depending on their duration:
@@ -2341,6 +2355,9 @@ type LocatorScreenshotOptions struct {
 	// When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be
 	// changed.  Defaults to `"hide"`.
 	Caret *ScreenshotCaret `json:"caret"`
+	// Specify locators that should be masked when the screenshot is taken. Masked elements will be overlaid with a pink
+	// box `#FF00FF` (customized by “maskColor”) that completely covers its bounding box.
+	Mask []Locator `json:"mask"`
 	// Specify the color of the overlay box for masked elements, in
 	// [CSS color format]. Default color is pink `#FF00FF`.
 	//
@@ -3172,6 +3189,9 @@ type PageScreenshotOptions struct {
 	// When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Defaults to
 	// `false`.
 	FullPage *bool `json:"fullPage"`
+	// Specify locators that should be masked when the screenshot is taken. Masked elements will be overlaid with a pink
+	// box `#FF00FF` (customized by “maskColor”) that completely covers its bounding box.
+	Mask []Locator `json:"mask"`
 	// Specify the color of the overlay box for masked elements, in
 	// [CSS color format]. Default color is pink `#FF00FF`.
 	//

--- a/locator.go
+++ b/locator.go
@@ -630,6 +630,17 @@ func (l *locatorImpl) Press(key string, options ...LocatorPressOptions) error {
 	return l.frame.Press(l.selector, key, opt)
 }
 
+func (l *locatorImpl) PressSequentially(text string, options ...LocatorPressSequentiallyOptions) error {
+	if l.err != nil {
+		return l.err
+	}
+	var option LocatorTypeOptions
+	if len(options) == 1 {
+		option = LocatorTypeOptions(options[0])
+	}
+	return l.Type(text, option)
+}
+
 func (l *locatorImpl) Screenshot(options ...LocatorScreenshotOptions) ([]byte, error) {
 	if l.err != nil {
 		return nil, l.err

--- a/patches/main.patch
+++ b/patches/main.patch
@@ -342,10 +342,10 @@ index ee6d29b00..c60c92fb8 100644
  
  :::note
 diff --git a/docs/src/api/class-browsercontext.md b/docs/src/api/class-browsercontext.md
-index 322c3a507..76ef29115 100644
+index ad5f7e7af..9b34b1e5e 100644
 --- a/docs/src/api/class-browsercontext.md
 +++ b/docs/src/api/class-browsercontext.md
-@@ -387,7 +387,7 @@ The order of evaluation of multiple scripts installed via [`method: BrowserConte
+@@ -394,7 +394,7 @@ The order of evaluation of multiple scripts installed via [`method: BrowserConte
  
  ### param: BrowserContext.addInitScript.script
  * since: v1.8
@@ -354,7 +354,7 @@ index 322c3a507..76ef29115 100644
  - `script` <[function]|[string]|[Object]>
    - `path` ?<[path]> Path to the JavaScript file. If `path` is a relative path, then it is resolved relative to the
      current working directory. Optional.
-@@ -425,7 +425,7 @@ Script to be evaluated in all pages in the browser context. Optional.
+@@ -432,7 +432,7 @@ Script to be evaluated in all pages in the browser context. Optional.
  
  ## method: BrowserContext.backgroundPages
  * since: v1.11
@@ -363,7 +363,7 @@ index 322c3a507..76ef29115 100644
  - returns: <[Array]<[Page]>>
  
  :::note
-@@ -1178,7 +1178,7 @@ handler function to route the request.
+@@ -1185,7 +1185,7 @@ handler function to route the request.
  
  ### param: BrowserContext.route.handler
  * since: v1.8
@@ -372,7 +372,7 @@ index 322c3a507..76ef29115 100644
  - `handler` <[function]\([Route]\)>
  
  handler function to route the request.
-@@ -1236,7 +1236,7 @@ Optional setting to control resource content management. If `attach` is specifie
+@@ -1243,7 +1243,7 @@ Optional setting to control resource content management. If `attach` is specifie
  
  ## method: BrowserContext.serviceWorkers
  * since: v1.11
@@ -381,7 +381,7 @@ index 322c3a507..76ef29115 100644
  - returns: <[Array]<[Worker]>>
  
  :::note
-@@ -1415,6 +1415,13 @@ A glob pattern, regex pattern or predicate receiving [URL] used to register a ro
+@@ -1422,6 +1422,13 @@ A glob pattern, regex pattern or predicate receiving [URL] used to register a ro
  
  Optional handler function used to register a routing with [`method: BrowserContext.route`].
  
@@ -395,7 +395,7 @@ index 322c3a507..76ef29115 100644
  ### param: BrowserContext.unroute.handler
  * since: v1.8
  * langs: csharp, java
-@@ -1456,7 +1463,8 @@ Condition to wait for.
+@@ -1463,7 +1470,8 @@ Condition to wait for.
  
  ## async method: BrowserContext.waitForConsoleMessage
  * since: v1.34
@@ -405,7 +405,7 @@ index 322c3a507..76ef29115 100644
    - alias-python: expect_console_message
    - alias-csharp: RunAndWaitForConsoleMessage
  - returns: <[ConsoleMessage]>
-@@ -1487,7 +1495,8 @@ Receives the [ConsoleMessage] object and resolves to truthy value when the waiti
+@@ -1494,7 +1502,8 @@ Receives the [ConsoleMessage] object and resolves to truthy value when the waiti
  
  ## async method: BrowserContext.waitForEvent
  * since: v1.8
@@ -415,7 +415,7 @@ index 322c3a507..76ef29115 100644
    - alias-python: expect_event
  - returns: <[any]>
  
-@@ -1553,7 +1562,8 @@ Either a predicate that receives an event or an options object. Optional.
+@@ -1560,7 +1569,8 @@ Either a predicate that receives an event or an options object. Optional.
  
  ## async method: BrowserContext.waitForPage
  * since: v1.9
@@ -425,7 +425,7 @@ index 322c3a507..76ef29115 100644
    - alias-python: expect_page
    - alias-csharp: RunAndWaitForPage
  - returns: <[Page]>
-@@ -1572,7 +1582,7 @@ Will throw an error if the context closes before new [Page] is created.
+@@ -1579,7 +1589,7 @@ Will throw an error if the context closes before new [Page] is created.
  
  ### option: BrowserContext.waitForPage.predicate
  * since: v1.9
@@ -434,7 +434,7 @@ index 322c3a507..76ef29115 100644
  - `predicate` <[function]\([Page]\):[boolean]>
  
  Receives the [Page] object and resolves to truthy value when the waiting should resolve.
-@@ -1585,7 +1595,8 @@ Receives the [Page] object and resolves to truthy value when the waiting should
+@@ -1592,7 +1602,8 @@ Receives the [Page] object and resolves to truthy value when the waiting should
  
  ## async method: BrowserContext.waitForEvent2
  * since: v1.8
@@ -485,10 +485,10 @@ index 06776c8e7..36624d703 100644
  * since: v1.8
  - returns: <[string]>
 diff --git a/docs/src/api/class-frame.md b/docs/src/api/class-frame.md
-index 77abb712c..c38b64f6e 100644
+index c607b4adc..3e76ea588 100644
 --- a/docs/src/api/class-frame.md
 +++ b/docs/src/api/class-frame.md
-@@ -1974,7 +1974,7 @@ await page.MainFrame.WaitForFunctionAsync("selector => !!document.querySelector(
+@@ -1947,7 +1947,7 @@ await page.MainFrame.WaitForFunctionAsync("selector => !!document.querySelector(
  
  Optional argument to pass to [`param: expression`].
  
@@ -497,7 +497,7 @@ index 77abb712c..c38b64f6e 100644
  * since: v1.8
  
  ### option: Frame.waitForFunction.polling = %%-csharp-java-wait-for-function-polling-%%
-@@ -2022,6 +2022,11 @@ await frame.WaitForLoadStateAsync(); // Defaults to LoadState.Load
+@@ -1995,6 +1995,11 @@ await frame.WaitForLoadStateAsync(); // Defaults to LoadState.Load
  ```
  
  ### param: Frame.waitForLoadState.state = %%-wait-for-load-state-state-%%
@@ -509,7 +509,7 @@ index 77abb712c..c38b64f6e 100644
  * since: v1.8
  
  ### option: Frame.waitForLoadState.timeout = %%-navigation-timeout-%%
-@@ -2034,6 +2039,7 @@ await frame.WaitForLoadStateAsync(); // Defaults to LoadState.Load
+@@ -2007,6 +2012,7 @@ await frame.WaitForLoadStateAsync(); // Defaults to LoadState.Load
  * since: v1.8
  * deprecated: This method is inherently racy, please use [`method: Frame.waitForURL`] instead.
  * langs:
@@ -567,7 +567,7 @@ index 4b79cd121..81a3ff7e1 100644
  
  Expected options currently selected.
 diff --git a/docs/src/api/class-page.md b/docs/src/api/class-page.md
-index df9f15459..d8289a3fd 100644
+index 7c0e532d1..b5f8a33e3 100644
 --- a/docs/src/api/class-page.md
 +++ b/docs/src/api/class-page.md
 @@ -618,7 +618,7 @@ The order of evaluation of multiple scripts installed via [`method: BrowserConte
@@ -708,7 +708,7 @@ index df9f15459..d8289a3fd 100644
  - `height` <[int]> page height in pixels.
  
  ## async method: Page.tap
-@@ -3897,6 +3904,13 @@ A glob pattern, regex pattern or predicate receiving [URL] to match while routin
+@@ -3870,6 +3877,13 @@ A glob pattern, regex pattern or predicate receiving [URL] to match while routin
  
  Optional handler function to route the request.
  
@@ -722,7 +722,7 @@ index df9f15459..d8289a3fd 100644
  ### param: Page.unroute.handler
  * since: v1.8
  * langs: csharp, java
-@@ -3935,7 +3949,8 @@ Performs action and waits for the Page to close.
+@@ -3908,7 +3922,8 @@ Performs action and waits for the Page to close.
  
  ## async method: Page.waitForConsoleMessage
  * since: v1.9
@@ -732,7 +732,7 @@ index df9f15459..d8289a3fd 100644
    - alias-python: expect_console_message
    - alias-csharp: RunAndWaitForConsoleMessage
  - returns: <[ConsoleMessage]>
-@@ -3966,7 +3981,8 @@ Receives the [ConsoleMessage] object and resolves to truthy value when the waiti
+@@ -3939,7 +3954,8 @@ Receives the [ConsoleMessage] object and resolves to truthy value when the waiti
  
  ## async method: Page.waitForDownload
  * since: v1.9
@@ -742,7 +742,7 @@ index df9f15459..d8289a3fd 100644
    - alias-python: expect_download
    - alias-csharp: RunAndWaitForDownload
  - returns: <[Download]>
-@@ -3997,7 +4013,8 @@ Receives the [Download] object and resolves to truthy value when the waiting sho
+@@ -3970,7 +3986,8 @@ Receives the [Download] object and resolves to truthy value when the waiting sho
  
  ## async method: Page.waitForEvent
  * since: v1.8
@@ -752,7 +752,7 @@ index df9f15459..d8289a3fd 100644
    - alias-python: expect_event
  - returns: <[any]>
  
-@@ -4050,7 +4067,8 @@ Either a predicate that receives an event or an options object. Optional.
+@@ -4023,7 +4040,8 @@ Either a predicate that receives an event or an options object. Optional.
  
  ## async method: Page.waitForFileChooser
  * since: v1.9
@@ -762,7 +762,7 @@ index df9f15459..d8289a3fd 100644
    - alias-python: expect_file_chooser
    - alias-csharp: RunAndWaitForFileChooser
  - returns: <[FileChooser]>
-@@ -4208,7 +4226,7 @@ await page.WaitForFunctionAsync("selector => !!document.querySelector(selector)"
+@@ -4181,7 +4199,7 @@ await page.WaitForFunctionAsync("selector => !!document.querySelector(selector)"
  
  Optional argument to pass to [`param: expression`].
  
@@ -771,7 +771,7 @@ index df9f15459..d8289a3fd 100644
  * since: v1.8
  
  ### option: Page.waitForFunction.polling = %%-csharp-java-wait-for-function-polling-%%
-@@ -4301,6 +4319,11 @@ Console.WriteLine(await popup.TitleAsync()); // popup is ready to use.
+@@ -4274,6 +4292,11 @@ Console.WriteLine(await popup.TitleAsync()); // popup is ready to use.
  ```
  
  ### param: Page.waitForLoadState.state = %%-wait-for-load-state-state-%%
@@ -783,7 +783,7 @@ index df9f15459..d8289a3fd 100644
  * since: v1.8
  
  ### option: Page.waitForLoadState.timeout = %%-navigation-timeout-%%
-@@ -4313,6 +4336,7 @@ Console.WriteLine(await popup.TitleAsync()); // popup is ready to use.
+@@ -4286,6 +4309,7 @@ Console.WriteLine(await popup.TitleAsync()); // popup is ready to use.
  * since: v1.8
  * deprecated: This method is inherently racy, please use [`method: Page.waitForURL`] instead.
  * langs:
@@ -791,7 +791,7 @@ index df9f15459..d8289a3fd 100644
    * alias-python: expect_navigation
    * alias-csharp: RunAndWaitForNavigation
  - returns: <[null]|[Response]>
-@@ -4397,7 +4421,8 @@ a navigation.
+@@ -4370,7 +4394,8 @@ a navigation.
  
  ## async method: Page.waitForPopup
  * since: v1.9
@@ -801,7 +801,7 @@ index df9f15459..d8289a3fd 100644
    - alias-python: expect_popup
    - alias-csharp: RunAndWaitForPopup
  - returns: <[Page]>
-@@ -4429,6 +4454,7 @@ Receives the [Page] object and resolves to truthy value when the waiting should
+@@ -4402,6 +4427,7 @@ Receives the [Page] object and resolves to truthy value when the waiting should
  ## async method: Page.waitForRequest
  * since: v1.8
  * langs:
@@ -809,7 +809,7 @@ index df9f15459..d8289a3fd 100644
    * alias-python: expect_request
    * alias-csharp: RunAndWaitForRequest
  - returns: <[Request]>
-@@ -4536,7 +4562,8 @@ changed by using the [`method: Page.setDefaultTimeout`] method.
+@@ -4509,7 +4535,8 @@ changed by using the [`method: Page.setDefaultTimeout`] method.
  
  ## async method: Page.waitForRequestFinished
  * since: v1.12
@@ -819,7 +819,7 @@ index df9f15459..d8289a3fd 100644
    - alias-python: expect_request_finished
    - alias-csharp: RunAndWaitForRequestFinished
  - returns: <[Request]>
-@@ -4568,6 +4595,7 @@ Receives the [Request] object and resolves to truthy value when the waiting shou
+@@ -4541,6 +4568,7 @@ Receives the [Request] object and resolves to truthy value when the waiting shou
  ## async method: Page.waitForResponse
  * since: v1.8
  * langs:
@@ -827,7 +827,7 @@ index df9f15459..d8289a3fd 100644
    * alias-python: expect_response
    * alias-csharp: RunAndWaitForResponse
  - returns: <[Response]>
-@@ -4930,7 +4958,8 @@ await page.WaitForURLAsync("**/target.html");
+@@ -4903,7 +4931,8 @@ await page.WaitForURLAsync("**/target.html");
  
  ## async method: Page.waitForWebSocket
  * since: v1.9
@@ -837,7 +837,7 @@ index df9f15459..d8289a3fd 100644
    - alias-python: expect_websocket
    - alias-csharp: RunAndWaitForWebSocket
  - returns: <[WebSocket]>
-@@ -4961,7 +4990,8 @@ Receives the [WebSocket] object and resolves to truthy value when the waiting sh
+@@ -4934,7 +4963,8 @@ Receives the [WebSocket] object and resolves to truthy value when the waiting sh
  
  ## async method: Page.waitForWorker
  * since: v1.9
@@ -847,7 +847,7 @@ index df9f15459..d8289a3fd 100644
    - alias-python: expect_worker
    - alias-csharp: RunAndWaitForWorker
  - returns: <[Worker]>
-@@ -5003,7 +5033,8 @@ This does not contain ServiceWorkers
+@@ -4976,7 +5006,8 @@ This does not contain ServiceWorkers
  
  ## async method: Page.waitForEvent2
  * since: v1.8
@@ -906,10 +906,10 @@ index bb5bb305a..064d4567e 100644
  
  Creates a [PageAssertions] object for the given [Page].
 diff --git a/docs/src/api/class-request.md b/docs/src/api/class-request.md
-index 15b566bd0..581bb3cc4 100644
+index fcf231f75..f14d3f914 100644
 --- a/docs/src/api/class-request.md
 +++ b/docs/src/api/class-request.md
-@@ -91,6 +91,13 @@ Headers with multiple entries, such as `Set-Cookie`, appear in the array multipl
+@@ -126,6 +126,13 @@ Headers with multiple entries, such as `Set-Cookie`, appear in the array multipl
  
  Returns the value of the header matching the name. The name is case insensitive.
  
@@ -923,7 +923,7 @@ index 15b566bd0..581bb3cc4 100644
  ### param: Request.headerValue.name
  * since: v1.15
  - `name` <[string]>
-@@ -123,7 +130,7 @@ Request's post body in a binary form, if any.
+@@ -161,7 +168,7 @@ Request's post body in a binary form, if any.
  
  ## method: Request.postDataJSON
  * since: v1.8
@@ -1088,7 +1088,7 @@ index 3b3308b88..e21ea93ef 100644
  - returns: <[any]>
  
 diff --git a/docs/src/api/params.md b/docs/src/api/params.md
-index 81fa010ae..c2ef3259d 100644
+index 81fa010ae..de0b05cc3 100644
 --- a/docs/src/api/params.md
 +++ b/docs/src/api/params.md
 @@ -8,7 +8,7 @@ When to consider operation succeeded, defaults to `load`. Events can be either:
@@ -1415,17 +1415,9 @@ index 81fa010ae..c2ef3259d 100644
  - `firefoxUserPrefs` <[Object]<[string], [any]>>
  
  Firefox user preferences. Learn more about the Firefox user preferences at
-@@ -1087,6 +1112,7 @@ saved to the disk.
- Specify screenshot type, defaults to `png`.
- 
- ## screenshot-option-mask
-+* langs: js, python, csharp
- - `mask` <[Array]<[Locator]>>
- 
- Specify locators that should be masked when the screenshot is taken. Masked elements will be overlaid with
 diff --git a/utils/doclint/generateGoApi.js b/utils/doclint/generateGoApi.js
 new file mode 100644
-index 000000000..3e90a1c8d
+index 000000000..b16989445
 --- /dev/null
 +++ b/utils/doclint/generateGoApi.js
 @@ -0,0 +1,851 @@
@@ -1875,7 +1867,7 @@ index 000000000..3e90a1c8d
 +  if (additionalTypes.has(resultType))
 +    resultType = `${resultType}`.replace(/^\*?/, '*');
 +  // HACK: special cases for returns
-+  if (resultType !== 'void' && name !== 'Failure') // [Download|Request].Failure() error
++  if (resultType !== 'void' && resultType !== '*Error' && name !== 'Failure') // [Download|Request].Failure() error
 +    returns.push(resultType);
 +  // return error, and exclude some methods that don't
 +  if (!resultType.endsWith('Locator') && !methodNoErr.has(name))
@@ -2280,4 +2272,3 @@ index 000000000..3e90a1c8d
 +  }
 +  return false;
 +};
-\ No newline at end of file

--- a/run.go
+++ b/run.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	playwrightCliVersion = "1.37.1"
+	playwrightCliVersion = "1.38.1"
 	baseURL              = "https://playwright.azureedge.net/builds/driver"
 )
 
@@ -107,7 +107,9 @@ func (d *PlaywrightDriver) DownloadDriver() error {
 		return nil
 	}
 
-	log.Printf("Downloading driver to %s", d.DriverDirectory)
+	if d.options.Verbose {
+		log.Printf("Downloading driver to %s", d.DriverDirectory)
+	}
 	driverURL := d.getDriverURL()
 	resp, err := http.Get(driverURL)
 	if err != nil {
@@ -160,7 +162,9 @@ func (d *PlaywrightDriver) DownloadDriver() error {
 		}
 	}
 
-	log.Println("Downloaded driver successfully")
+	if d.options.Verbose {
+		log.Println("Downloaded driver successfully")
+	}
 	return nil
 }
 

--- a/run.go
+++ b/run.go
@@ -80,7 +80,8 @@ func (d *PlaywrightDriver) isUpToDateDriver() (bool, error) {
 	return false, nil
 }
 
-func (d *PlaywrightDriver) install() error {
+// Install downloads the driver and the browsers depending on [RunOptions].
+func (d *PlaywrightDriver) Install() error {
 	if err := d.DownloadDriver(); err != nil {
 		return fmt.Errorf("could not install driver: %w", err)
 	}
@@ -98,6 +99,28 @@ func (d *PlaywrightDriver) install() error {
 	}
 	return nil
 }
+
+// Uninstall removes the driver and the browsers.
+func (d *PlaywrightDriver) Uninstall() error {
+	if d.options.Verbose {
+		log.Println("Removing browsers...")
+	}
+	if err := d.uninstallBrowsers(d.DriverBinaryLocation); err != nil {
+		return fmt.Errorf("could not uninstall browsers: %w", err)
+	}
+	if d.options.Verbose {
+		log.Println("Removing driver...")
+	}
+	if err := os.RemoveAll(d.DriverDirectory); err != nil {
+		return fmt.Errorf("could not remove driver directory: %w", err)
+	}
+	if d.options.Verbose {
+		log.Println("Uninstall driver successfully")
+	}
+	return nil
+}
+
+// DownloadDriver downloads the driver only
 func (d *PlaywrightDriver) DownloadDriver() error {
 	up2Date, err := d.isUpToDateDriver()
 	if err != nil {
@@ -216,10 +239,14 @@ func (d *PlaywrightDriver) installBrowsers(driverPath string) error {
 	cmd := exec.Command(driverPath, additionalArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("could not install browsers: %w", err)
-	}
-	return nil
+	return cmd.Run()
+}
+
+func (d *PlaywrightDriver) uninstallBrowsers(driverPath string) error {
+	cmd := exec.Command(driverPath, "uninstall")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 // RunOptions are custom options to run the driver
@@ -238,7 +265,7 @@ func Install(options ...*RunOptions) error {
 	if err != nil {
 		return fmt.Errorf("could not get driver instance: %w", err)
 	}
-	if err := driver.install(); err != nil {
+	if err := driver.Install(); err != nil {
 		return fmt.Errorf("could not install driver: %w", err)
 	}
 	return nil

--- a/run_test.go
+++ b/run_test.go
@@ -1,0 +1,31 @@
+package playwright
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDriverInstall(t *testing.T) {
+	driverPath := t.TempDir()
+	driver, err := NewDriver(&RunOptions{
+		DriverDirectory: driverPath,
+		Browsers:        []string{"firefox"},
+		Verbose:         true})
+	if err != nil {
+		t.Fatalf("could not start driver: %v", err)
+	}
+	browserPath := t.TempDir()
+	err = os.Setenv("PLAYWRIGHT_BROWSERS_PATH", browserPath)
+	if err != nil {
+		t.Fatalf("could not set PLAYWRIGHT_BROWSERS_PATH: %v", err)
+	}
+	defer os.Unsetenv("PLAYWRIGHT_BROWSERS_PATH")
+	err = driver.Install()
+	if err != nil {
+		t.Fatalf("could not install driver: %v", err)
+	}
+	err = driver.Uninstall()
+	if err != nil {
+		t.Fatalf("could not uninstall driver: %v", err)
+	}
+}

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -495,3 +495,17 @@ func TestBrowserContextCloseShouldBeCallableTwice(t *testing.T) {
 	require.NoError(t, context.Close())
 	require.NoError(t, context.Close())
 }
+
+func TestPageErrorEventShouldWork(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	ret, err := page.Context().ExpectEvent("weberror", func() error {
+		return page.SetContent(`<script>throw new Error("boom")</script>`)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, ret)
+	weberror, ok := ret.(playwright.WebError)
+	require.True(t, ok)
+	require.Equal(t, page, weberror.Page())
+	require.Contains(t, weberror.Error().(*playwright.Error).Stack, "boom")
+}

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -298,7 +298,9 @@ func TestBrowserContextShouldReturnBackgroundPage(t *testing.T) {
 	if len(context.BackgroundPages()) == 1 {
 		page = context.BackgroundPages()[0]
 	} else {
-		ret, err := context.WaitForEvent("backgroundPage")
+		ret, err := context.WaitForEvent("backgroundPage", playwright.BrowserContextWaitForEventOptions{
+			Timeout: playwright.Float(1000),
+		})
 		if err != nil {
 			// probably missing event
 			if len(context.BackgroundPages()) == 1 {
@@ -311,8 +313,16 @@ func TestBrowserContextShouldReturnBackgroundPage(t *testing.T) {
 		}
 	}
 	require.NotNil(t, page)
-	require.NotContains(t, context.Pages(), page)
-	require.Contains(t, context.BackgroundPages(), page)
+	contains := func(pages []playwright.Page, page playwright.Page) bool {
+		for _, p := range pages {
+			if p == page {
+				return true
+			}
+		}
+		return false
+	}
+	require.False(t, contains(context.Pages(), page))
+	require.True(t, contains(context.BackgroundPages(), page))
 	context.Close()
 	require.Len(t, context.BackgroundPages(), 0)
 	require.Len(t, context.Pages(), 0)

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -305,6 +305,12 @@ func (tu *testUtils) AssertEval(t *testing.T, page playwright.Page, script strin
 	require.Equal(t, expected, result)
 }
 
+func (tu *testUtils) AssertResult(t *testing.T, fn func() (interface{}, error), expected interface{}) {
+	result, err := fn()
+	require.NoError(t, err)
+	require.Equal(t, expected, result)
+}
+
 func getBrowserName() string {
 	browserName, hasEnv := os.LookupEnv("BROWSER")
 	if hasEnv {

--- a/tests/input_test.go
+++ b/tests/input_test.go
@@ -162,6 +162,7 @@ func TestElementHandleType(t *testing.T) {
 	//nolint:staticcheck
 	inputElement, err := page.QuerySelector("input")
 	require.NoError(t, err)
+	//nolint:staticcheck
 	require.NoError(t, inputElement.Type("abc123"))
 	result, err := page.Evaluate("window.clicked")
 	require.NoError(t, err)

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -627,3 +627,26 @@ func TestLocatorHighlightShoudWork(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, yes)
 }
+
+func TestLocatorShouldType(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	require.NoError(t, page.SetContent(`<input type='text' />`))
+	//nolint:staticcheck
+	require.NoError(t, page.Locator("input").Type("hello"))
+	utils.AssertResult(t, func() (interface{}, error) {
+		//nolint:staticcheck
+		return page.EvalOnSelector("input", "e => e.value", nil)
+	}, "hello")
+}
+
+func TestLocatorShouldPressSequentially(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	require.NoError(t, page.SetContent(`<input type='text' />`))
+	require.NoError(t, page.Locator("input").PressSequentially("hello"))
+	utils.AssertResult(t, func() (interface{}, error) {
+		//nolint:staticcheck
+		return page.EvalOnSelector("input", "e => e.value", nil)
+	}, "hello")
+}

--- a/tests/selectors_get_by_test.go
+++ b/tests/selectors_get_by_test.go
@@ -1,0 +1,175 @@
+//nolint:staticcheck
+package playwright_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectorsGetByEscaping(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+
+	require.NoError(t, page.SetContent(`
+	<label id=label for=control>Hello my
+wo"rld</label><input id=control />`))
+	_, err := page.EvalOnSelector("input", `input => {
+		input.setAttribute('placeholder', 'hello my\nwo"rld');
+		input.setAttribute('title', 'hello my\nwo"rld');
+		input.setAttribute('alt', 'hello my\nwo"rld');
+	}`, nil)
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(page.GetByText("hello my\nwo\"rld")).ToHaveAttribute("id", "label"))
+	require.NoError(t, expect.Locator(page.GetByText("hello       my     wo\"rld")).ToHaveAttribute("id", "label"))
+	require.NoError(t, expect.Locator(page.GetByLabel("hello my\nwo\"rld")).ToHaveAttribute("id", "control"))
+	require.NoError(t, expect.Locator(page.GetByPlaceholder("hello my\nwo\"rld")).ToHaveAttribute("id", "control"))
+	require.NoError(t, expect.Locator(page.GetByAltText("hello my\nwo\"rld")).ToHaveAttribute("id", "control"))
+	require.NoError(t, expect.Locator(page.GetByTitle("hello my\nwo\"rld")).ToHaveAttribute("id", "control"))
+
+	require.NoError(t, page.SetContent(`
+	<label id=label for=control>Hello my
+world</label><input id=control />`))
+	_, err = page.EvalOnSelector("input", `input => {
+		input.setAttribute('placeholder', 'hello my\nworld');
+		input.setAttribute('title', 'hello my\nworld');
+		input.setAttribute('alt', 'hello my\nworld');
+	}`, nil)
+	require.NoError(t, err)
+	require.NoError(t, expect.Locator(page.GetByText("hello my\nworld")).ToHaveAttribute("id", "label"))
+	require.NoError(t, expect.Locator(page.GetByText("hello       my     world")).ToHaveAttribute("id", "label"))
+	require.NoError(t, expect.Locator(page.GetByLabel("hello my\nworld")).ToHaveAttribute("id", "control"))
+	require.NoError(t, expect.Locator(page.GetByPlaceholder("hello my\nworld")).ToHaveAttribute("id", "control"))
+	require.NoError(t, expect.Locator(page.GetByAltText("hello my\nworld")).ToHaveAttribute("id", "control"))
+	require.NoError(t, expect.Locator(page.GetByTitle("hello my\nworld")).ToHaveAttribute("id", "control"))
+
+	require.NoError(t, page.SetContent(`<div id=target title="my title">Text here</div>`))
+	require.NoError(t, expect.Locator(page.GetByTitle("my title", playwright.PageGetByTitleOptions{
+		Exact: playwright.Bool(true),
+	})).ToHaveCount(1, playwright.LocatorAssertionsToHaveCountOptions{
+		Timeout: playwright.Float(500),
+	}))
+	require.NoError(t, expect.Locator(page.GetByTitle("my t\\itle", playwright.PageGetByTitleOptions{
+		Exact: playwright.Bool(true),
+	})).ToHaveCount(0, playwright.LocatorAssertionsToHaveCountOptions{
+		Timeout: playwright.Float(500),
+	}))
+	require.NoError(t, expect.Locator(page.GetByTitle("my t\\\\itle", playwright.PageGetByTitleOptions{
+		Exact: playwright.Bool(true),
+	})).ToHaveCount(0, playwright.LocatorAssertionsToHaveCountOptions{
+		Timeout: playwright.Float(500),
+	}))
+
+	require.NoError(t, page.SetContent(`<label for=target>foo &gt;&gt; bar</label><input id=target>`))
+	_, err = page.EvalOnSelector("input", `input => {
+		input.setAttribute('placeholder', 'foo >> bar');
+		input.setAttribute('title', 'foo >> bar');
+		input.setAttribute('alt', 'foo >> bar');
+	}`, nil)
+	require.NoError(t, err)
+
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByText("foo >> bar").TextContent()
+	}, "foo >> bar")
+	require.NoError(t, expect.Locator(page.Locator("label")).ToHaveText("foo >> bar"))
+	require.NoError(t, expect.Locator(page.GetByText("foo >> bar")).ToHaveText("foo >> bar"))
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByText(regexp.MustCompile("foo >> bar")).TextContent()
+	}, "foo >> bar")
+	require.NoError(t, expect.Locator(page.GetByLabel("foo >> bar")).ToHaveAttribute("id", "target"))
+	require.NoError(t, expect.Locator(page.GetByLabel(regexp.MustCompile("foo >> bar"))).ToHaveAttribute("id", "target"))
+	require.NoError(t, expect.Locator(page.GetByPlaceholder("foo >> bar")).ToHaveAttribute("id", "target"))
+
+	require.NoError(t, expect.Locator(page.GetByAltText("foo >> bar")).ToHaveAttribute("id", "target"))
+	require.NoError(t, expect.Locator(page.GetByTitle("foo >> bar")).ToHaveAttribute("id", "target"))
+	require.NoError(t, expect.Locator(page.GetByPlaceholder(regexp.MustCompile("foo >> bar"))).ToHaveAttribute("id", "target"))
+	require.NoError(t, expect.Locator(page.GetByAltText(regexp.MustCompile("foo >> bar"))).ToHaveAttribute("id", "target"))
+	require.NoError(t, expect.Locator(page.GetByTitle(regexp.MustCompile("foo >> bar"))).ToHaveAttribute("id", "target"))
+}
+
+func TestSelectorsGetByRoleEscaping(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	require.NoError(t, page.SetContent(`
+		<a href="https://playwright.dev">issues 123</a>
+		<a href="https://playwright.dev">he llo 56</a>
+		<button>Click me</button>
+	`))
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByRole("button").EvaluateAll("els => els.map(e => e.outerHTML)")
+	}, []interface{}{"<button>Click me</button>"})
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByRole("link").EvaluateAll("els => els.map(e => e.outerHTML)")
+	}, []interface{}{
+		`<a href="https://playwright.dev">issues 123</a>`,
+		`<a href="https://playwright.dev">he llo 56</a>`})
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByRole("link", playwright.PageGetByRoleOptions{
+			Name: "issues 123",
+		}).EvaluateAll("els => els.map(e => e.outerHTML)")
+	}, []interface{}{`<a href="https://playwright.dev">issues 123</a>`})
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByRole("link", playwright.PageGetByRoleOptions{
+			Name: "sues",
+		}).EvaluateAll("els => els.map(e => e.outerHTML)")
+	}, []interface{}{`<a href="https://playwright.dev">issues 123</a>`})
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByRole("link", playwright.PageGetByRoleOptions{
+			Name: "  he    \n  llo ",
+		}).EvaluateAll("els => els.map(e => e.outerHTML)")
+	}, []interface{}{`<a href="https://playwright.dev">he llo 56</a>`})
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByRole("button", playwright.PageGetByRoleOptions{
+			Name: "issues",
+		}).EvaluateAll("els => els.map(e => e.outerHTML)")
+	}, []interface{}{})
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByRole("link", playwright.PageGetByRoleOptions{
+			Name:  "sues",
+			Exact: playwright.Bool(true),
+		}).EvaluateAll("els => els.map(e => e.outerHTML)")
+	}, []interface{}{})
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByRole("link", playwright.PageGetByRoleOptions{
+			Name:  "   he \n llo 56 ",
+			Exact: playwright.Bool(true),
+		}).EvaluateAll("els => els.map(e => e.outerHTML)")
+	}, []interface{}{`<a href="https://playwright.dev">he llo 56</a>`})
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByRole("button", playwright.PageGetByRoleOptions{
+			Name:  "Click me",
+			Exact: playwright.Bool(true),
+		}).EvaluateAll("els => els.map(e => e.outerHTML)")
+	}, []interface{}{`<button>Click me</button>`})
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByRole("button", playwright.PageGetByRoleOptions{
+			Name:  "Click \\me",
+			Exact: playwright.Bool(true),
+		}).EvaluateAll("els => els.map(e => e.outerHTML)")
+	}, []interface{}{})
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByRole("button", playwright.PageGetByRoleOptions{
+			Name:  "Click \\\\me",
+			Exact: playwright.Bool(true),
+		}).EvaluateAll("els => els.map(e => e.outerHTML)")
+	}, []interface{}{})
+}
+
+func TestSelectorsIncludeHiddenShouldWork(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	require.NoError(t, page.SetContent(`<button style="display: none">Hidden</button>`))
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByRole("button", playwright.PageGetByRoleOptions{
+			Name: "Hidden",
+		}).EvaluateAll(`els => els.map(e => e.outerHTML)`)
+	}, []interface{}{})
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByRole("button", playwright.PageGetByRoleOptions{
+			Name:          "Hidden",
+			IncludeHidden: playwright.Bool(true),
+		}).EvaluateAll(`els => els.map(e => e.outerHTML)`)
+	}, []interface{}{`<button style="display: none">Hidden</button>`})
+}

--- a/tests/selectors_text_test.go
+++ b/tests/selectors_text_test.go
@@ -1,0 +1,273 @@
+//nolint:staticcheck
+package playwright_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasTextAndInternalTextShouldMatchFullNodeInStrictMode(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	require.NoError(t, page.SetContent(`<div id=div1>hello<span>world</span></div>
+		<div id=div2>hello</div>`))
+
+	require.NoError(t, expect.Locator(page.GetByText("helloworld", playwright.PageGetByTextOptions{
+		Exact: playwright.Bool(true),
+	})).ToHaveId("div1"))
+	require.NoError(t, expect.Locator(page.GetByText("hello", playwright.PageGetByTextOptions{
+		Exact: playwright.Bool(true),
+	})).ToHaveId("div2"))
+	require.NoError(t, expect.Locator(page.Locator("div", playwright.PageLocatorOptions{
+		HasText: regexp.MustCompile(`^helloworld$`),
+	})).ToHaveId("div1"))
+	require.NoError(t, expect.Locator(page.Locator("div", playwright.PageLocatorOptions{
+		HasText: regexp.MustCompile(`^hello$`),
+	})).ToHaveId("div2"))
+
+	require.NoError(t, page.SetContent(`<div id=div1><span id=span1>hello</span>world</div>
+		<div id=div2><span id=span2>hello</span></div>`))
+
+	require.NoError(t, expect.Locator(page.GetByText("helloworld", playwright.PageGetByTextOptions{
+		Exact: playwright.Bool(true),
+	})).ToHaveId("div1"))
+
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByText("hello", playwright.PageGetByTextOptions{
+			Exact: playwright.Bool(true),
+		}).EvaluateAll(`els => els.map(e => e.id)`)
+	}, []interface{}{"span1", "span2"})
+
+	require.NoError(t, expect.Locator(page.Locator("div", playwright.PageLocatorOptions{
+		HasText: regexp.MustCompile(`^helloworld$`),
+	})).ToHaveId("div1"))
+	require.NoError(t, expect.Locator(page.Locator("div", playwright.PageLocatorOptions{
+		HasText: regexp.MustCompile(`^hello$`),
+	})).ToHaveId("div2"))
+}
+
+func TestSelectorsTextShouldWork(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	require.NoError(t, page.SetContent("<div>yo</div><div>ya</div><div>\nye  </div>"))
+
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text=ya", "e => e.outerHTML", nil)
+	}, "<div>ya</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector(`text="ya"`, "e => e.outerHTML", nil)
+	}, "<div>ya</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector(`text=/^[ay]+$/`, "e => e.outerHTML", nil)
+	}, "<div>ya</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector(`text=/Ya/i`, "e => e.outerHTML", nil)
+	}, "<div>ya</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text=ye", "e => e.outerHTML", nil)
+	}, "<div>\nye  </div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByText("ye").Evaluate("e => e.outerHTML", nil)
+	}, "<div>\nye  </div>")
+
+	require.NoError(t, page.SetContent("<div> ye </div><div>ye</div>"))
+
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector(`text="ye"`, "e => e.outerHTML", nil)
+	}, "<div> ye </div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByText("ye", playwright.PageGetByTextOptions{Exact: playwright.Bool(true)}).First().Evaluate("e => e.outerHTML", nil)
+	}, "<div> ye </div>")
+
+	require.NoError(t, page.SetContent(`<div>yo</div><div>"ya</div><div> hello world! </div>`))
+
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text=\"\\\"ya\"", "e => e.outerHTML", nil)
+	}, "<div>\"ya</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector(`text=/hello/`, "e => e.outerHTML", nil)
+	}, "<div> hello world! </div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text=/^\\s*heLLo/i", "e => e.outerHTML", nil)
+	}, "<div> hello world! </div>")
+
+	require.NoError(t, page.SetContent(`<div>yo<div>ya</div>hey<div>hey</div></div>`))
+
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text=hey", "e => e.outerHTML", nil)
+	}, "<div>hey</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector(`text=yo>>text="ya"`, "e => e.outerHTML", nil)
+	}, "<div>ya</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector(`text=yo>> text="ya"`, "e => e.outerHTML", nil)
+	}, "<div>ya</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector(`text=yo >>text='ya'`, "e => e.outerHTML", nil)
+	}, "<div>ya</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector(`text=yo >> text='ya'`, "e => e.outerHTML", nil)
+	}, "<div>ya</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("'yo'>>\"ya\"", "e => e.outerHTML", nil)
+	}, "<div>ya</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("\"yo\" >> 'ya'", "e => e.outerHTML", nil)
+	}, "<div>ya</div>")
+
+	require.NoError(t, page.SetContent(`<div>yo<span id="s1"></span></div><div>yo<span id="s2"></span><span id="s3"></span></div>`))
+
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelectorAll("text=yo", "es => es.map(e => e.outerHTML).join('\\n')", nil)
+	}, "<div>yo<span id=\"s1\"></span></div>\n<div>yo<span id=\"s2\"></span><span id=\"s3\"></span></div>")
+
+	require.NoError(t, page.SetContent("<div>'</div><div>\"</div><div>\\</div><div>x</div>"))
+
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text='\\''", "e => e.outerHTML", nil)
+	}, "<div>'</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text='\"'", "e => e.outerHTML", nil)
+	}, "<div>\"</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector(`text="\""`, "e => e.outerHTML", nil)
+	}, "<div>\"</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector(`text="'"`, "e => e.outerHTML", nil)
+	}, "<div>'</div>")
+
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector(`text="\x"`, "e => e.outerHTML", nil)
+	}, "<div>x</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text='\\x'", "e => e.outerHTML", nil)
+	}, "<div>x</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text='\\\\'", "e => e.outerHTML", nil)
+	}, "<div>\\</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector(`text="\\"`, "e => e.outerHTML", nil)
+	}, "<div>\\</div>")
+
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector(`text="`, "e => e.outerHTML", nil)
+	}, "<div>\"</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text='", "e => e.outerHTML", nil)
+	}, "<div>'</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector(`"x"`, "e => e.outerHTML", nil)
+	}, "<div>x</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("'x'", "e => e.outerHTML", nil)
+	}, "<div>x</div>")
+
+	_, err := page.QuerySelectorAll(`"`)
+	require.Error(t, err)
+	_, err = page.QuerySelectorAll("'")
+	require.Error(t, err)
+
+	require.NoError(t, page.SetContent("<div> ' </div><div> \" </div>"))
+
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector(`text="`, "e => e.outerHTML", nil)
+	}, `<div> " </div>`)
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text='", "e => e.outerHTML", nil)
+	}, `<div> ' </div>`)
+
+	require.NoError(t, page.SetContent("<div>Hi'\"&gt;&gt;foo=bar</div>"))
+
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector(`text="Hi'\">>foo=bar"`, "e => e.outerHTML", nil)
+	}, "<div>Hi'\"&gt;&gt;foo=bar</div>")
+
+	require.NoError(t, page.SetContent("<div>Hi&gt;&gt;<span></span></div>"))
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector(`text="Hi>>">>span`, "e => e.outerHTML", nil)
+	}, "<span></span>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text=/Hi\\>\\>/ >> span", "e => e.outerHTML", nil)
+	}, "<span></span>")
+
+	require.NoError(t, page.SetContent("<div>a<br>b</div><div>a</div>"))
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text=a", "e => e.outerHTML", nil)
+	}, "<div>a<br>b</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text=b", "e => e.outerHTML", nil)
+	}, "<div>a<br>b</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text=ab", "e => e.outerHTML", nil)
+	}, "<div>a<br>b</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.QuerySelector("text=abc")
+	}, nil)
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelectorAll("text=a", "els => els.length")
+	}, 2)
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelectorAll("text=b", "els => els.length")
+	}, 1)
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelectorAll("text=ab", "els => els.length")
+	}, 1)
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelectorAll("text=abc", "els => els.length")
+	}, 0)
+
+	require.NoError(t, page.SetContent("<div></div><span></span>"))
+	_, err = page.EvalOnSelector("div", `div => {
+		div.appendChild(document.createTextNode('hello'))
+		div.appendChild(document.createTextNode('world'))
+	}`, nil)
+	require.NoError(t, err)
+	_, err = page.EvalOnSelector("span", `span => {
+		span.appendChild(document.createTextNode('hello'))
+		span.appendChild(document.createTextNode('world'))
+	}`, nil)
+	require.NoError(t, err)
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text=lowo", "e => e.outerHTML", nil)
+	}, "<div>helloworld</div>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelectorAll("text=lowo", "els => els.map(e => e.outerHTML).join('')")
+	}, "<div>helloworld</div><span>helloworld</span>")
+
+	require.NoError(t, page.SetContent("<span>Sign&nbsp;in</span><span>Hello\n \nworld</span>"))
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text=Sign in", "e => e.outerHTML", nil)
+	}, "<span>Sign&nbsp;in</span>")
+	ret, err := page.QuerySelectorAll("text=Sign \tin")
+	require.NoError(t, err)
+	require.Len(t, ret, 1)
+	ret, err = page.QuerySelectorAll(`text="Sign in"`)
+	require.NoError(t, err)
+	require.Len(t, ret, 1)
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text=lo wo", "e => e.outerHTML", nil)
+	}, "<span>Hello\n \nworld</span>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector(`text="Hello world"`, "e => e.outerHTML", nil)
+	}, "<span>Hello\n \nworld</span>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.QuerySelector(`text="lo wo"`)
+	}, nil)
+	ret, err = page.QuerySelectorAll("text=lo \nwo")
+	require.NoError(t, err)
+	require.Len(t, ret, 1)
+	ret, err = page.QuerySelectorAll("text=\"lo \nwo\"")
+	require.NoError(t, err)
+	require.Len(t, ret, 0)
+
+	require.NoError(t, page.SetContent("<div>let's<span>hello</span></div>"))
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text=/let's/i >> span", "e => e.outerHTML", nil)
+	}, "<span>hello</span>")
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.EvalOnSelector("text=/let\\'s/i >> span", "e => e.outerHTML", nil)
+	}, "<span>hello</span>")
+}

--- a/web_error.go
+++ b/web_error.go
@@ -1,0 +1,21 @@
+package playwright
+
+type webErrorImpl struct {
+	err  *Error
+	page Page
+}
+
+func (e *webErrorImpl) Page() Page {
+	return e.page
+}
+
+func (e *webErrorImpl) Error() error {
+	return e.err
+}
+
+func newWebError(page Page, err *Error) WebError {
+	return &webErrorImpl{
+		err:  err,
+		page: page,
+	}
+}


### PR DESCRIPTION
- roll to v1.38.1
- add some tests, and `escapeRegexForSelector` without "insert a backslash to even number of backslashes followed by the quote", it seems no error
- `PlaywrightDriver.Uninstall` for user case #372