### PR TITLE
ci: xvfb-run occasionally fails when test examples

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,6 +108,6 @@ jobs:
       run: |
         for dir in examples/*; do
           echo "::group::go run $dir/main.go"
-          xvfb-run go run $dir/main.go
+          xvfb-run -a go run $dir/main.go
           echo "::endgroup::"
         done


### PR DESCRIPTION
Most likely the X server has not been released by the previous test, so add `-a`, aka `--auto-servernum`