### PR TITLE
fix: selector option.HasNotText

### DIFF
--- a/locator.go
+++ b/locator.go
@@ -30,7 +30,7 @@ func newLocator(frame *frameImpl, selector string, options ...LocatorLocatorOpti
 		selector += fmt.Sprintf(` >> internal:has-text=%s`, escapeForTextSelector(option.HasText, false))
 	}
 	if option.HasNotText != nil {
-		selector += fmt.Sprintf(` >> internal:has-not-text=%s`, escapeForTextSelector(option.HasText, false))
+		selector += fmt.Sprintf(` >> internal:has-not-text=%s`, escapeForTextSelector(option.HasNotText, false))
 	}
 	if option.Has != nil {
 		has := option.Has.(*locatorImpl)


### PR DESCRIPTION
When I use the code below, an error will be thrown
painc: interface conversion: interface {} is nil, not string
```
locator = locator.Filter(playwright.LocatorFilterOptions{
	HasNotText: "test",
})
```
I checked the source code and the value obtained here is wrong
```
	if option.HasNotText != nil {
		selector += fmt.Sprintf(` >> internal:has-not-text=%s`, escapeForTextSelector(option.HasText, false))
	}
```