### PR TITLE
fix: prevent misuse of transformOptions

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -76,7 +76,7 @@ func (b *browserImpl) NewContext(options ...BrowserNewContextOptions) (BrowserCo
 		options[0].RecordHarContent = nil
 		options[0].RecordHarOmitContent = nil
 	}
-	channel, err := b.channel.Send("newContext", overrides, options)
+	channel, err := b.channel.Send("newContext", options, overrides)
 	if err != nil {
 		return nil, fmt.Errorf("could not send message: %w", err)
 	}

--- a/browser_type.go
+++ b/browser_type.go
@@ -23,7 +23,7 @@ func (b *browserTypeImpl) Launch(options ...BrowserTypeLaunchOptions) (Browser, 
 		overrides["env"] = serializeMapToNameAndValue(options[0].Env)
 		options[0].Env = nil
 	}
-	channel, err := b.channel.Send("launch", overrides, options)
+	channel, err := b.channel.Send("launch", options, overrides)
 	if err != nil {
 		return nil, fmt.Errorf("could not send message: %w", err)
 	}
@@ -79,7 +79,7 @@ func (b *browserTypeImpl) LaunchPersistentContext(userDataDir string, options ..
 			options[0].RecordHarOmitContent = nil
 		}
 	}
-	channel, err := b.channel.Send("launchPersistentContext", overrides, options)
+	channel, err := b.channel.Send("launchPersistentContext", options, overrides)
 	if err != nil {
 		return nil, fmt.Errorf("could not send message: %w", err)
 	}
@@ -92,7 +92,7 @@ func (b *browserTypeImpl) Connect(wsEndpoint string, options ...BrowserTypeConne
 		"wsEndpoint": wsEndpoint,
 	}
 	localUtils := b.connection.LocalUtils()
-	pipe, err := localUtils.channel.SendReturnAsDict("connect", overrides, options)
+	pipe, err := localUtils.channel.SendReturnAsDict("connect", options, overrides)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func (b *browserTypeImpl) ConnectOverCDP(endpointURL string, options ...BrowserT
 			options[0].Headers = nil
 		}
 	}
-	response, err := b.channel.SendReturnAsDict("connectOverCDP", overrides, options)
+	response, err := b.channel.SendReturnAsDict("connectOverCDP", options, overrides)
 	if err != nil {
 		return nil, err
 	}

--- a/fetch.go
+++ b/fetch.go
@@ -35,7 +35,7 @@ func (r *apiRequestImpl) NewContext(options ...APIRequestNewContextOptions) (API
 		}
 	}
 
-	channel, err := r.channel.Send("newRequest", overrides, options)
+	channel, err := r.channel.Send("newRequest", options, overrides)
 	if err != nil {
 		return nil, fmt.Errorf("could not send message: %w", err)
 	}
@@ -178,7 +178,7 @@ func (r *apiRequestContextImpl) innerFetch(url string, request Request, options 
 		}
 	}
 
-	response, err := r.channel.Send("fetch", overrides, options)
+	response, err := r.channel.Send("fetch", options, overrides)
 	if err != nil {
 		return nil, err
 	}

--- a/page.go
+++ b/page.go
@@ -337,7 +337,6 @@ func (p *pageImpl) Screenshot(options ...PageScreenshotOptions) ([]byte, error) 
 				}
 			}
 			overrides["mask"] = masks
-			options[0].Mask = nil
 		}
 	}
 	data, err := p.channel.Send("screenshot", options, overrides)
@@ -358,7 +357,7 @@ func (p *pageImpl) Screenshot(options ...PageScreenshotOptions) ([]byte, error) 
 
 func (p *pageImpl) PDF(options ...PagePdfOptions) ([]byte, error) {
 	var path *string
-	if len(options) > 0 {
+	if len(options) == 1 {
 		path = options[0].Path
 	}
 	data, err := p.channel.Send("pdf", options)

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -97,6 +97,7 @@ func TestPageScreenshotWithMask(t *testing.T) {
 		Mask: []playwright.Locator{
 			sensElem,
 		},
+		MaskColor: playwright.String("red"),
 	})
 	require.NoError(t, err)
 	require.True(t, filetype.IsImage(screenshot2))


### PR DESCRIPTION
`transformOptions` was previously restricted and does not report misuse. 

Now no longer restricted, and it is more intuitive to take `overrides` as the second argument when calling it. 