### PR TITLE
Fix serializeValue to properly handle slices

### DIFF
--- a/js_handle.go
+++ b/js_handle.go
@@ -216,11 +216,14 @@ func serializeValue(value interface{}, handles *[]*channel, depth int) interface
 		}
 	}
 	if refV.Kind() == reflect.Slice {
-		aV := value.([]interface{})
-		for i := range aV {
-			aV[i] = serializeValue(aV[i], handles, depth+1)
+		out := []interface{}{}
+		sV := value.([]interface{})
+		for i := range sV {
+			out = append(out, serializeValue(sV[i], handles, depth+1))
 		}
-		return aV
+		return map[string]interface{} {
+			"a": out,
+		}
 	}
 	if refV.Kind() == reflect.Map {
 		out := []interface{}{}

--- a/js_handle.go
+++ b/js_handle.go
@@ -221,7 +221,7 @@ func serializeValue(value interface{}, handles *[]*channel, depth int) interface
 		for i := range sV {
 			out = append(out, serializeValue(sV[i], handles, depth+1))
 		}
-		return map[string]interface{} {
+		return map[string]interface{}{
 			"a": out,
 		}
 	}

--- a/tests/js_handle_test.go
+++ b/tests/js_handle_test.go
@@ -156,11 +156,11 @@ func TestJSHandleTypeSerializing(t *testing.T) {
 		require.Equal(t, v, value)
 	}
 	// The following cases seem to fail due to playwright
-	//floatV, err := page.Evaluate(`a => a`, 42.42)
-	//require.NoError(t, err)
-	//require.Equal(t, 42.42, floatV)
-	//now := time.Now()
-	//timeV, err := page.Evaluate(`a => a`, now)
-	//require.NoError(t, err)
-	//require.Equal(t, now, timeV)
+	// floatV, err := page.Evaluate(`a => a`, 42.42)
+	// require.NoError(t, err)
+	// require.Equal(t, 42.42, floatV)
+	// now := time.Now()
+	// timeV, err := page.Evaluate(`a => a`, now)
+	// require.NoError(t, err)
+	// require.Equal(t, now, timeV)
 }

--- a/tests/js_handle_test.go
+++ b/tests/js_handle_test.go
@@ -120,3 +120,47 @@ func TestJSHandleTypeParsing(t *testing.T) {
 	_, ok = stringV.(int)
 	require.False(t, ok)
 }
+
+func TestJSHandleTypeSerializing(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	nilV, err := page.Evaluate(`a => a`, nil)
+	require.NoError(t, err)
+	require.Equal(t, nil, nilV)
+	boolV, err := page.Evaluate(`a => a`, true)
+	require.NoError(t, err)
+	require.Equal(t, true, boolV)
+	intV, err := page.Evaluate(`a => a`, 42)
+	require.NoError(t, err)
+	require.Equal(t, 42, intV)
+	sliceArgs := []interface{}{"test1", "test2", "test3"}
+	res, err := page.Evaluate(`a => a`, sliceArgs)
+	require.NoError(t, err)
+	sliceV, ok := res.([]interface{})
+	require.True(t, ok)
+	for i, v := range sliceArgs {
+		require.Equal(t, v, sliceV[i])
+	}
+	mapArgs := map[string]interface{}{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+	}
+	res, err = page.Evaluate(`a => a`, mapArgs)
+	require.NoError(t, err)
+	mapV, ok := res.(map[string]interface{})
+	require.True(t, ok)
+	for k, v := range mapArgs {
+		value, ok := mapV[k]
+		require.True(t, ok)
+		require.Equal(t, v, value)
+	}
+	// The following cases seem to fail due to playwright
+	//floatV, err := page.Evaluate(`a => a`, 42.42)
+	//require.NoError(t, err)
+	//require.Equal(t, 42.42, floatV)
+	//now := time.Now()
+	//timeV, err := page.Evaluate(`a => a`, now)
+	//require.NoError(t, err)
+	//require.Equal(t, now, timeV)
+}


### PR DESCRIPTION
This change fixes serialization of slices when passed as argument to Evaluate().
I found two issues with how slices are serialized:
- The original argument was directly modified (passed as a reference) to become a map. We now create a separate map.
- Once serialized, we returned a slice of map which I believe is not expected. We now returned {"a": [..]}, which is what the python library does [here](https://github.com/microsoft/playwright-python/blob/a45f6adcd6c622e4036adb0449b4d6ee772392a5/playwright/_impl/_js_handle.py#L149).

I also added a few tests.

I discovered that passing floats and time will not work.
We do not correctly serialize valid floats but when I tried fixing it I got the following error:
```playwright: arg.value.v: expected one of (null|undefined|NaN|Infinity|-Infinity|-0)```

Unfortunately, I wasn't able to fix this.