### PR TITLE
Add run option to install browsers with dependencies

### DIFF
--- a/run.go
+++ b/run.go
@@ -204,6 +204,9 @@ func (d *PlaywrightDriver) installBrowsers(driverPath string) error {
 	if d.options.Browsers != nil {
 		additionalArgs = append(additionalArgs, d.options.Browsers...)
 	}
+	if d.options.WithDependencies {
+		additionalArgs = append(additionalArgs, "--with-deps")
+	}
 	cmd := exec.Command(driverPath, additionalArgs...)
 	cmd.SysProcAttr = defaultSysProcAttr
 	cmd.Stdout = os.Stdout
@@ -225,6 +228,7 @@ type RunOptions struct {
 	SkipInstallBrowsers bool
 	Browsers            []string
 	Verbose             bool
+	WithDependencies    bool
 }
 
 // Install does download the driver and the browsers. If not called manually


### PR DESCRIPTION
Currently, it is possible to install Playwright with its dependencies from Golang by using this syntax:
```go
err := playwright.Install(&playwright.RunOptions{Browsers: []string{"--with-deps"}})
```

This PR introduces a more elegant solution:
```go
err := playwright.Install(&playwright.RunOptions{WithDependencies: true})
```