### PR TITLE
feat: StorageState can convert to OptionalStorageState (close #414)

### DIFF
--- a/tests/browser_context_storage_state_test.go
+++ b/tests/browser_context_storage_state_test.go
@@ -144,3 +144,52 @@ func TestBrowserContextStorageStateRoundTripThroughTheFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, map[string]interface{}{"name1": "value1"}, localStorage)
 }
+
+func TestBrowserContextStorageStateRoundTripThroughConvert(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	page1, err := context.NewPage()
+	require.NoError(t, err)
+	defer page1.Close()
+	require.NoError(t, page1.Route("**/*", func(route playwright.Route) {
+		require.NoError(t, route.Fulfill(playwright.RouteFulfillOptions{
+			Body: "<html></html>",
+		}))
+	}))
+	_, err = page1.Goto("https://www.example.com")
+	require.NoError(t, err)
+	_, err = page1.Evaluate(`
+	() => {
+		localStorage["name1"] = "value1"
+		document.cookie = "username=John Doe"
+		return document.cookie
+	}
+	`)
+	require.NoError(t, err)
+
+	storageState, err := context.StorageState()
+	require.NoError(t, err)
+
+	context2, err := browser.NewContext(
+		playwright.BrowserNewContextOptions{
+			StorageState: storageState.ToOptionalStorageState(),
+		})
+	require.NoError(t, err)
+	defer context2.Close()
+	page2, err := context2.NewPage()
+	require.NoError(t, err)
+	defer page2.Close()
+	require.NoError(t, page2.Route("**/*", func(route playwright.Route) {
+		require.NoError(t, route.Fulfill(playwright.RouteFulfillOptions{
+			Body: "<html></html>",
+		}))
+	}))
+	_, err = page2.Goto("https://www.example.com")
+	require.NoError(t, err)
+	cookie, err := page2.Evaluate("document.cookie")
+	require.NoError(t, err)
+	require.Equal(t, "username=John Doe", cookie)
+	localStorage, err := page2.Evaluate("window.localStorage")
+	require.NoError(t, err)
+	require.Equal(t, map[string]interface{}{"name1": "value1"}, localStorage)
+}

--- a/type_helpers.go
+++ b/type_helpers.go
@@ -45,3 +45,28 @@ func IntSlice(v ...int) *[]int {
 	o = append(o, v...)
 	return &o
 }
+
+// ToOptionalStorageState converts StorageState to OptionalStorageState for use directly in [Browser.NewContext]
+func (s StorageState) ToOptionalStorageState() *OptionalStorageState {
+	cookies := make([]OptionalCookie, len(s.Cookies))
+	for i, c := range s.Cookies {
+		cookies[i] = c.ToOptionalCookie()
+	}
+	return &OptionalStorageState{
+		Origins: s.Origins,
+		Cookies: cookies,
+	}
+}
+
+func (c Cookie) ToOptionalCookie() OptionalCookie {
+	return OptionalCookie{
+		Name:     c.Name,
+		Value:    c.Value,
+		Domain:   String(c.Domain),
+		Path:     String(c.Path),
+		Expires:  Float(c.Expires),
+		HttpOnly: Bool(c.HttpOnly),
+		Secure:   Bool(c.Secure),
+		SameSite: c.SameSite,
+	}
+}


### PR DESCRIPTION
This PR avoids manual conversion when there is no need to store StorageState as a file (solve #414)

```go
storageState, _ = context1.StorageState()

context2, _ := browser.NewContext(
	playwright.BrowserNewContextOptions{
		StorageState: storageState.ToOptionalStorageState(),
	})

```