### PR TITLE
docs: add Dockerfile example

### DIFF
--- a/Dockerfile.example
+++ b/Dockerfile.example
@@ -1,0 +1,25 @@
+# Stage 1: Modules caching
+FROM golang:1.21 as modules
+COPY go.mod go.sum /modules/
+WORKDIR /modules
+RUN go mod download
+
+# Stage 2: Build
+FROM golang:1.21 as builder
+COPY --from=modules /go/pkg /go/pkg
+COPY . /workdir
+WORKDIR /workdir
+# Install playwright cli with right version for later use
+RUN PWGO_VER=$(grep -oE "playwright-go v\S+" /workdir/go.mod | sed 's/playwright-go //g') \
+    && go install github.com/playwright-community/playwright-go/cmd/playwright@${PWGO_VER}
+# Build your app
+RUN GOOS=linux GOARCH=amd64 go build -o /bin/myapp
+
+# Stage 3: Final
+FROM ubuntu:jammy
+COPY --from=builder /go/bin/playwright /bin/myapp /
+RUN apt-get update && apt-get install -y ca-certificates tzdata \
+    # Install dependencies and all browsers (or specify one)
+    && /playwright install --with-deps \
+    && rm -rf /var/lib/apt/lists/*
+CMD ["/myapp"]

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ func main() {
 }
 ```
 
+## Docker
+Refer to the [Dockerfile.example](./Dockerfile.example) to build your own docker image.
+
 ## More examples
 
 * Refer to [helper_test.go](./tests/helper_test.go) for End-To-End testing 


### PR DESCRIPTION
This example Dockerfile ensures that the playwright driver version matches `go.mod`