### PR TITLE
Get PLAYWRIGHT_NODEJS_PATH env var when looking for node executable

### DIFF
--- a/run.go
+++ b/run.go
@@ -284,6 +284,11 @@ func transformRunOptions(options []*RunOptions) *RunOptions {
 }
 
 func getNodeExecutable(driverDirectory string) string {
+	envPath := os.Getenv("PLAYWRIGHT_NODEJS_PATH")
+	if envPath != "" {
+		return envPath
+	}
+
 	node := "node"
 	if runtime.GOOS == "windows" {
 		node = "node.exe"

--- a/run_test.go
+++ b/run_test.go
@@ -2,6 +2,7 @@ package playwright
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -86,6 +87,21 @@ func TestShouldNotHangWhenPlaywrightUnexpectedExit(t *testing.T) {
 
 	_, err = context.NewPage()
 	require.Error(t, err)
+}
+
+func TestGetNodeExecutable(t *testing.T) {
+	// When PLAYWRIGHT_NODEJS_PATH is set, use that path.
+	err := os.Setenv("PLAYWRIGHT_NODEJS_PATH", "/envDir")
+	require.NoError(t, err)
+
+	executable := getNodeExecutable("/testDirectory")
+	assert.Equal(t, "/envDir", executable)
+
+	err = os.Unsetenv("PLAYWRIGHT_NODEJS_PATH")
+	require.NoError(t, err)
+
+	executable = getNodeExecutable("/testDirectory")
+	assert.Contains(t, executable, "/testDirectory")
 }
 
 // find and kill playwright process


### PR DESCRIPTION
In playwright-go [v0.4400.0](https://github.com/playwright-community/playwright-go/releases/tag/v0.4400.0) some functionality was regressed with the PLAYWRIGHT_NODEJS_PATH env var as playwright.Run command no longer respects it. I have a fix for it but any suggestions to my changes are welcome. Thanks!