### PR TITLE
Use `PLAYWRIGHT_DRIVER_PATH` environment variable as driver cache directory

### DIFF
--- a/run.go
+++ b/run.go
@@ -38,7 +38,7 @@ type PlaywrightDriver struct {
 func NewDriver(options *RunOptions) (*PlaywrightDriver, error) {
 	baseDriverDirectory := options.DriverDirectory
 	if baseDriverDirectory == "" {
-		baseDriverDirectory := os.Getenv("PLAYWRIGHT_DRIVER_PATH")
+		baseDriverDirectory = os.Getenv("PLAYWRIGHT_DRIVER_PATH")
 	}
 	if baseDriverDirectory == "" {
 		var err error

--- a/run.go
+++ b/run.go
@@ -53,7 +53,7 @@ func NewDriver(options *RunOptions) (*PlaywrightDriver, error) {
 
 func getDefaultCacheDirectory() (string, error) {
 	if cachePath := os.Getenv("PLAYWRIGHT_BROWSERS_PATH"); cachePath != "" {
-		return cachePath
+		return cachePath, nil
 	}
 
 	userHomeDir, err := os.UserHomeDir()

--- a/run.go
+++ b/run.go
@@ -38,6 +38,9 @@ type PlaywrightDriver struct {
 func NewDriver(options *RunOptions) (*PlaywrightDriver, error) {
 	baseDriverDirectory := options.DriverDirectory
 	if baseDriverDirectory == "" {
+		baseDriverDirectory := os.Getenv("PLAYWRIGHT_DRIVER_PATH")
+	}
+	if baseDriverDirectory == "" {
 		var err error
 		baseDriverDirectory, err = getDefaultCacheDirectory()
 		if err != nil {
@@ -52,10 +55,6 @@ func NewDriver(options *RunOptions) (*PlaywrightDriver, error) {
 }
 
 func getDefaultCacheDirectory() (string, error) {
-	if cachePath := os.Getenv("PLAYWRIGHT_BROWSERS_PATH"); cachePath != "" {
-		return cachePath, nil
-	}
-
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("could not get user home directory: %w", err)

--- a/run.go
+++ b/run.go
@@ -52,6 +52,10 @@ func NewDriver(options *RunOptions) (*PlaywrightDriver, error) {
 }
 
 func getDefaultCacheDirectory() (string, error) {
+	if cachePath := os.Getenv("PLAYWRIGHT_BROWSERS_PATH"); cachePath != "" {
+		return cachePath
+	}
+
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("could not get user home directory: %w", err)


### PR DESCRIPTION
Playwright uses `PLAYWRIGHT_BROWSERS_PATH` to define the cache directory used to install the browsers.
See playwright implementation - [link](https://github.com/microsoft/playwright/blob/470b1b4922a665d2b4230dacde16be6593b5e80c/packages/playwright-core/src/server/registry/index.ts#L275)

```go
  const envDefined = getFromENV('PLAYWRIGHT_BROWSERS_PATH');
  if (envDefined === '0') {
    result = path.join(__dirname, '..', '..', '..', '.local-browsers');
  } else if (envDefined) {
    result = envDefined;
  } else {
    let cacheDirectory: string;
    if (process.platform === 'linux')
      cacheDirectory = process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache');
    else if (process.platform === 'darwin')
      cacheDirectory = path.join(os.homedir(), 'Library', 'Caches');
    else if (process.platform === 'win32')
      cacheDirectory = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
    else
      throw new Error('Unsupported platform: ' + process.platform);
    result = path.join(cacheDirectory, 'ms-playwright');
  }
```