### PR TITLE
chore: require go v1.22

### DIFF
--- a/browser_context.go
+++ b/browser_context.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 
 	"github.com/playwright-community/playwright-go/internal/safe"
-	"golang.org/x/exp/slices"
 )
 
 type browserContextImpl struct {

--- a/channel.go
+++ b/channel.go
@@ -1,11 +1,19 @@
 package playwright
 
+import "encoding/json"
+
 type channel struct {
 	eventEmitter
 	guid       string
 	connection *connection
 	owner      *channelOwner // to avoid type conversion
 	object     interface{}   // retain type info (for fromChannel needed)
+}
+
+func (c *channel) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]string{
+		"guid": c.guid,
+	})
 }
 
 func (c *channel) Send(method string, options ...interface{}) (interface{}, error) {

--- a/connection.go
+++ b/connection.go
@@ -217,7 +217,7 @@ func (c *connection) sendMessageToServer(object *channelOwner, method string, pa
 		"id":       id,
 		"guid":     object.guid,
 		"method":   method,
-		"params":   params, // MarshalJSON will replace channel with guid
+		"params":   params, // channel.MarshalJSON will replace channel with guid
 		"metadata": metadata,
 	}
 	if c.tracingCount.Load() > 0 && len(stack) > 0 && object.guid != "localUtils" {

--- a/connection.go
+++ b/connection.go
@@ -164,33 +164,6 @@ func (c *connection) WrapAPICall(cb func() (interface{}, error), isInternal bool
 	return cb()
 }
 
-func (c *connection) replaceChannelsWithGuids(payload interface{}) interface{} {
-	if payload == nil {
-		return nil
-	}
-	if channel, isChannel := payload.(*channel); isChannel {
-		return map[string]string{
-			"guid": channel.guid,
-		}
-	}
-	v := reflect.ValueOf(payload)
-	if v.Kind() == reflect.Slice {
-		listV := make([]interface{}, 0)
-		for i := 0; i < v.Len(); i++ {
-			listV = append(listV, c.replaceChannelsWithGuids(v.Index(i).Interface()))
-		}
-		return listV
-	}
-	if v.Kind() == reflect.Map {
-		mapV := make(map[string]interface{})
-		for _, key := range v.MapKeys() {
-			mapV[key.String()] = c.replaceChannelsWithGuids(v.MapIndex(key).Interface())
-		}
-		return mapV
-	}
-	return payload
-}
-
 func (c *connection) replaceGuidsWithChannels(payload interface{}) interface{} {
 	if payload == nil {
 		return nil
@@ -244,7 +217,7 @@ func (c *connection) sendMessageToServer(object *channelOwner, method string, pa
 		"id":       id,
 		"guid":     object.guid,
 		"method":   method,
-		"params":   c.replaceChannelsWithGuids(params),
+		"params":   params, // MarshalJSON will replace channel with guid
 		"metadata": metadata,
 	}
 	if c.tracingCount.Load() > 0 && len(stack) > 0 && object.guid != "localUtils" {

--- a/event_emitter.go
+++ b/event_emitter.go
@@ -3,9 +3,8 @@ package playwright
 import (
 	"math"
 	"reflect"
+	"slices"
 	"sync"
-
-	"golang.org/x/exp/slices"
 )
 
 type EventEmitter interface {
@@ -119,10 +118,10 @@ func (er *eventRegister) count() int {
 	return len(er.listeners)
 }
 
-func (e *eventRegister) removeHandler(handler interface{}) {
+func (er *eventRegister) removeHandler(handler interface{}) {
 	handlerPtr := reflect.ValueOf(handler).Pointer()
 
-	e.listeners = slices.DeleteFunc(e.listeners, func(l listener) bool {
+	er.listeners = slices.DeleteFunc(er.listeners, func(l listener) bool {
 		return reflect.ValueOf(l.handler).Pointer() == handlerPtr
 	})
 }

--- a/frame_locator.go
+++ b/frame_locator.go
@@ -1,10 +1,9 @@
 package playwright
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
-
-	"github.com/playwright-community/playwright-go/internal/multierror"
 )
 
 type frameLocatorImpl struct {
@@ -102,7 +101,7 @@ func (fl *frameLocatorImpl) Locator(selectorOrLocator interface{}, options ...Fr
 	locator, ok := selectorOrLocator.(*locatorImpl)
 	if ok {
 		if fl.frame != locator.frame {
-			locator.err = multierror.Join(locator.err, ErrLocatorNotSameFrame)
+			locator.err = errors.Join(locator.err, ErrLocatorNotSameFrame)
 			return locator
 		}
 		return newLocator(locator.frame,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/playwright-community/playwright-go
 
-go 1.19
+go 1.22
 
 require (
 	github.com/deckarep/golang-set/v2 v2.6.0
@@ -12,8 +12,6 @@ require (
 	github.com/orisano/pixelmatch v0.0.0-20230914042517-fa304d1dc785
 	github.com/stretchr/testify v1.8.4
 	github.com/tidwall/gjson v1.17.0
-	go.uber.org/multierr v1.11.0
-	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -42,13 +42,9 @@ github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhso
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
-go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
-golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJkTFJCVUX+S/ZT6wYzM=
-golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/internal/multierror/multierror_g0120.go
+++ b/internal/multierror/multierror_g0120.go
@@ -1,8 +1,0 @@
-//go:build go1.20
-// +build go1.20
-
-package multierror
-
-import "errors"
-
-var Join = errors.Join

--- a/internal/multierror/multierror_go119.go
+++ b/internal/multierror/multierror_go119.go
@@ -1,8 +1,0 @@
-//go:build !go1.20
-// +build !go1.20
-
-package multierror
-
-import "go.uber.org/multierr"
-
-var Join = multierr.Combine

--- a/internal/safe/map.go
+++ b/internal/safe/map.go
@@ -1,9 +1,8 @@
 package safe
 
 import (
+	"maps"
 	"sync"
-
-	"golang.org/x/exp/maps"
 )
 
 // SyncMap is a thread-safe map
@@ -64,7 +63,7 @@ func (m *SyncMap[K, V]) Delete(k K) {
 func (m *SyncMap[K, V]) Clear() {
 	m.Lock()
 	defer m.Unlock()
-	maps.Clear(m.m)
+	clear(m.m)
 }
 
 func (m *SyncMap[K, V]) Len() int {

--- a/locator.go
+++ b/locator.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-
-	"github.com/playwright-community/playwright-go/internal/multierror"
 )
 
 var (
@@ -35,7 +33,7 @@ func newLocator(frame *frameImpl, selector string, options ...LocatorLocatorOpti
 	if option.Has != nil {
 		has := option.Has.(*locatorImpl)
 		if frame != has.frame {
-			locator.err = multierror.Join(locator.err, ErrLocatorNotSameFrame)
+			locator.err = errors.Join(locator.err, ErrLocatorNotSameFrame)
 		} else {
 			selector += fmt.Sprintf(` >> internal:has=%s`, escapeText(has.selector))
 		}
@@ -43,7 +41,7 @@ func newLocator(frame *frameImpl, selector string, options ...LocatorLocatorOpti
 	if option.HasNot != nil {
 		hasNot := option.HasNot.(*locatorImpl)
 		if frame != hasNot.frame {
-			locator.err = multierror.Join(locator.err, ErrLocatorNotSameFrame)
+			locator.err = errors.Join(locator.err, ErrLocatorNotSameFrame)
 		} else {
 			selector += fmt.Sprintf(` >> internal:has-not=%s`, escapeText(hasNot.selector))
 		}
@@ -598,7 +596,7 @@ func (l *locatorImpl) Locator(selectorOrLocator interface{}, options ...LocatorL
 	locator, ok := selectorOrLocator.(*locatorImpl)
 	if ok {
 		if l.frame != locator.frame {
-			l.err = multierror.Join(l.err, ErrLocatorNotSameFrame)
+			l.err = errors.Join(l.err, ErrLocatorNotSameFrame)
 			return l
 		}
 		return newLocator(l.frame,
@@ -606,7 +604,7 @@ func (l *locatorImpl) Locator(selectorOrLocator interface{}, options ...LocatorL
 			options...,
 		)
 	}
-	l.err = multierror.Join(l.err, fmt.Errorf("invalid locator parameter: %v", selectorOrLocator))
+	l.err = errors.Join(l.err, fmt.Errorf("invalid locator parameter: %v", selectorOrLocator))
 	return l
 }
 

--- a/page.go
+++ b/page.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"sync"
 
 	"github.com/playwright-community/playwright-go/internal/safe"
-	"golang.org/x/exp/slices"
 )
 
 type pageImpl struct {

--- a/run.go
+++ b/run.go
@@ -13,8 +13,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-
-	"github.com/playwright-community/playwright-go/internal/multierror"
 )
 
 const (
@@ -372,17 +370,17 @@ func downloadDriver(driverURLs []string) (body []byte, e error) {
 	for _, driverURL := range driverURLs {
 		resp, err := http.Get(driverURL)
 		if err != nil {
-			e = multierror.Join(e, fmt.Errorf("could not download driver from %s: %w", driverURL, err))
+			e = errors.Join(e, fmt.Errorf("could not download driver from %s: %w", driverURL, err))
 			continue
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			e = multierror.Join(e, fmt.Errorf("error: got non 200 status code: %d (%s) from %s", resp.StatusCode, resp.Status, driverURL))
+			e = errors.Join(e, fmt.Errorf("error: got non 200 status code: %d (%s) from %s", resp.StatusCode, resp.Status, driverURL))
 			continue
 		}
 		body, err = io.ReadAll(resp.Body)
 		if err != nil {
-			e = multierror.Join(e, fmt.Errorf("could not read response body: %w", err))
+			e = errors.Join(e, fmt.Errorf("could not read response body: %w", err))
 			continue
 		}
 		return body, nil

--- a/tests/browser_type_test.go
+++ b/tests/browser_type_test.go
@@ -6,13 +6,13 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/playwright-community/playwright-go"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 func TestBrowserTypeBrowserName(t *testing.T) {

--- a/tests/input_test.go
+++ b/tests/input_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/playwright-community/playwright-go"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 func TestMouseMove(t *testing.T) {


### PR DESCRIPTION
Will require go v1.22+ starting with version `v0.4800.0`. The benefit is the functionality of the new standard library, especially `errors` support for wrapping multiple errors.