### PR TITLE
fix: Panics caused by BoundingBox API returning nil

### DIFF
--- a/element_handle.go
+++ b/element_handle.go
@@ -189,6 +189,11 @@ func (e *elementHandleImpl) BoundingBox() (*Rect, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if boundingBox == nil {
+		return nil, nil
+	}
+
 	out := &Rect{}
 	remapMapToStruct(boundingBox, out)
 	return out, nil

--- a/helpers.go
+++ b/helpers.go
@@ -133,11 +133,6 @@ func transformOptions(options ...interface{}) map[string]interface{} {
 }
 
 func remapValue(inMapValue reflect.Value, outStructValue reflect.Value) {
-	if !inMapValue.IsValid() {
-		outStructValue.Set(reflect.Zero(outStructValue.Type()))
-		return
-	}
-
 	switch outStructValue.Type().Kind() {
 	case reflect.Bool:
 		outStructValue.SetBool(inMapValue.Bool())

--- a/helpers.go
+++ b/helpers.go
@@ -133,6 +133,11 @@ func transformOptions(options ...interface{}) map[string]interface{} {
 }
 
 func remapValue(inMapValue reflect.Value, outStructValue reflect.Value) {
+	if !inMapValue.IsValid() {
+		outStructValue.Set(reflect.Zero(outStructValue.Type()))
+		return
+	}
+
 	switch outStructValue.Type().Kind() {
 	case reflect.Bool:
 		outStructValue.SetBool(inMapValue.Bool())


### PR DESCRIPTION
The `boundingBox` playwright API may return `nil` for the bounding box without setting an error.
The Go implementation doesn't support this case, causing null dereference and panics when trying to remap the nil to the matching struct.

We handle this by checking if the value is `nil` before remapping values.

This PR fixes this bug by checking for `nil` value before remapping.

We can also change the implementation of the remapping but it will require passing pointer to a pointer (`**`) in order to set `nil` values for variables.

Reference - https://github.com/microsoft/playwright/blob/59a50cf59603850c645830a17ccb05178eb96f50/packages/playwright-core/src/client/elementHandle.ts#L185

# Panic Trace
```
	/usr/local/go/src/runtime/panic.go:785 +0x124
reflect.flag.mustBe(...)
	/usr/local/go/src/reflect/value.go:218
reflect.Value.MapKeys({0x0?, 0x0?, 0x27f7f58?})
	/usr/local/go/src/reflect/value.go:1828 +0x1f4
github.com/playwright-community/playwright-go.remapValue({0x0?, 0x0?, 0x4003bd3c18?}, {0x209e2c0?, 0x4004203240?, 0x0?})
	/go/pkg/mod/github.com/playwright-community/playwright-go@v0.4700.0/helpers.go:161 +0x5c8
github.com/playwright-community/playwright-go.remapMapToStruct({0x0?, 0x0?}, {0x1b21b60?, 0x4004203240?})
	/go/pkg/mod/github.com/playwright-community/playwright-go@v0.4700.0/helpers.go:174 +0x100
github.com/playwright-community/playwright-go.(*elementHandleImpl).BoundingBox(0x1b61a60?)
	/go/pkg/mod/github.com/playwright-community/playwright-go@v0.4700.0/element_handle.go:193 +0x84
github.com/playwright-community/playwright-go.(*locatorImpl).BoundingBox.func1({0x28f0108?, 0x4002b940a0?})
	/go/pkg/mod/github.com/playwright-community/playwright-go@v0.4700.0/locator.go:143 +0x2c
github.com/playwright-community/playwright-go.(*locatorImpl).withElement(0x4003bd3d18?, 0x24ba0d0, {0x4006773d40?, 0x1c3c3c0?, 0x1?})
	/go/pkg/mod/github.com/playwright-community/playwright-go@v0.4700.0/locator.go:846 +0x5c
github.com/playwright-community/playwright-go.(*locatorImpl).BoundingBox(0x40039ab230, {0x40066ccfb0?, 0x1?, 0x0?})
	/go/pkg/mod/github.com/playwright-community/playwright-go@v0.4700.0/locator.go:142 +0x8c
...
reflect: call of reflect.Value.MapKeys on zero Value
```