### PR TITLE
Add only-shell option to run options

### DIFF
--- a/run.go
+++ b/run.go
@@ -205,6 +205,11 @@ func (d *PlaywrightDriver) installBrowsers() error {
 	if d.options.Browsers != nil {
 		additionalArgs = append(additionalArgs, d.options.Browsers...)
 	}
+
+	if d.options.OnlyInstallShell {
+		additionalArgs = append(additionalArgs, "--only-shell")
+	}
+
 	cmd := d.Command(additionalArgs...)
 	cmd.Stdout = d.options.Stdout
 	cmd.Stderr = d.options.Stderr
@@ -228,7 +233,9 @@ type RunOptions struct {
 	//  - Windows: %USERPROFILE%\AppData\Local
 	//  - macOS: ~/Library/Caches
 	//  - Linux: ~/.cache
-	DriverDirectory     string
+	DriverDirectory string
+	// OnlyInstallShell only downloads the headless shell. (For chromium browsers only)
+	OnlyInstallShell    bool
 	SkipInstallBrowsers bool
 	// if not set and SkipInstallBrowsers is false, will download all browsers (chromium, firefox, webkit)
 	Browsers []string

--- a/run.go
+++ b/run.go
@@ -210,6 +210,10 @@ func (d *PlaywrightDriver) installBrowsers() error {
 		additionalArgs = append(additionalArgs, "--only-shell")
 	}
 
+	if d.options.DryRun {
+		additionalArgs = append(additionalArgs, "--dry-run")
+	}
+
 	cmd := d.Command(additionalArgs...)
 	cmd.Stdout = d.options.Stdout
 	cmd.Stderr = d.options.Stderr
@@ -243,6 +247,8 @@ type RunOptions struct {
 	Stdout   io.Writer
 	Stderr   io.Writer
 	Logger   *slog.Logger
+	// DryRun does not install browser/dependencies. It will only print information.
+	DryRun bool
 }
 
 // Install does download the driver and the browsers.

--- a/run_test.go
+++ b/run_test.go
@@ -41,6 +41,7 @@ func TestRunOptionsRedirectStderr(t *testing.T) {
 	err = driver.Install()
 	require.Error(t, err)
 	require.NoError(t, w.Close())
+	wg.Wait()
 
 	assert.Contains(t, output, "Downloading driver")
 	require.Contains(t, output, fmt.Sprintf("path=%s", driverPath))

--- a/run_test.go
+++ b/run_test.go
@@ -59,6 +59,33 @@ func TestRunOptionsRedirectStderr(t *testing.T) {
 	require.Contains(t, output, fmt.Sprintf("path=%s", driverPath))
 }
 
+func TestRunOptions_OnlyInstallShell(t *testing.T) {
+	if getBrowserName() != "chromium" {
+		t.Skip("chromium only")
+		return
+	}
+
+	driverPath := t.TempDir()
+	driver, err := NewDriver(&RunOptions{
+		DriverDirectory:  driverPath,
+		Browsers:         []string{getBrowserName()},
+		Verbose:          true,
+		OnlyInstallShell: true,
+	})
+	require.NoError(t, err)
+	browserPath := t.TempDir()
+
+	err = os.Setenv("PLAYWRIGHT_BROWSERS_PATH", browserPath)
+	require.NoError(t, err)
+	defer os.Unsetenv("PLAYWRIGHT_BROWSERS_PATH")
+
+	err = driver.Install()
+	require.NoError(t, err)
+
+	err = driver.Uninstall()
+	require.NoError(t, err)
+}
+
 func TestDriverInstall(t *testing.T) {
 	driverPath := t.TempDir()
 	driver, err := NewDriver(&RunOptions{


### PR DESCRIPTION
I am looking to add the feature defined in the docs here: https://playwright.dev/docs/browsers#optimize-download-size-on-ci so that I can reduce the amount of space used by downloading browsers. I only need to use the shell. 