### PR TITLE
fix: prevent panic in Sizes()

### DIFF
--- a/request.go
+++ b/request.go
@@ -193,6 +193,9 @@ func (r *requestImpl) Sizes() (*RequestSizesResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	if response == nil {
+		return nil, fmt.Errorf("sizes could not be retrieved because request has no response")
+	}
 	sizes, err := response.(*responseImpl).channel.Send("sizes")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I don't know why we need a full response object to get request sizes, but this panics for me several times per page load as I attempt to log size information