### PR TITLE
fix: waiter#RunAndWait maybe cause deadlock.

### DIFF
--- a/waiter.go
+++ b/waiter.go
@@ -175,7 +175,9 @@ func (w *waiter) reject(err error) {
 
 func newWaiter() *waiter {
 	w := &waiter{
-		errChan: make(chan error, 1),
+		// receive both event timeout err and callback err
+		// but just return event timeout err
+		errChan: make(chan error, 2),
 	}
 	return w
 }


### PR DESCRIPTION
for errChan cap is 1 and receive both event timeout err and callback err( block on the err for errChan handle receiving(wait#waitFunc) after callback send err(waiter#RunAndWait) ).



# my solution of old code fix ( ExpectFileChooser )

## code which maybe cause deadlock
```go
	uploadFileTimeout := 30 * 1000.0
	fileChooser, err := page.ExpectFileChooser(func() error {
		err = page.Locator(".fileChooser-trigger").Click(playwright.LocatorClickOptions{
			Timeout: playwright.Float(40 * 1000),
		})
		if err != nil {
			return fmt.Errorf("trigger fileChooser: %w", err)
		}
		return nil
	}, playwright.PageExpectFileChooserOptions{
		Timeout: playwright.Float(uploadFileTimeout),
	})
	if err := fileChooser.SetFiles(filepaths); err != nil {
		return "", fmt.Errorf("set files: %w", err)
	}
```
## solution
```go
	stopped := false
	defer func() {
		stopped = true
	}()
	topContext := context.Background()
	uploadFileTimeout := 30 * time.Second
	ctx, cancel := context.WithTimeout(topContext, uploadFileTimeout)
	defer cancel()
	var once sync.Once
	fileChooserCh := make(chan playwright.FileChooser)
	page.OnFileChooser(func(chooser playwright.FileChooser) {
		once.Do(func() {
			if stopped {
				return
			}
			fileChooserCh <- chooser
		})
	})
	err = page.Locator(".fileChooser-trigger").Click(playwright.LocatorClickOptions{
		Timeout: playwright.Float(40 * 1000),
	})
	if err != nil {
		stopped = true
		return "", fmt.Errorf("trigger fileChooser: %w", err)
	}
	select {
	case <-ctx.Done():
		stopped = true
		return "", fmt.Errorf("wait file chooser: %w", playwright.ErrTimeout)
	case fileChooser := <-fileChooserCh:
		if err := fileChooser.SetFiles(filepaths); err != nil {
			return "", fmt.Errorf("set files: %w", err)
		}
	}
```