### PR TITLE
fix(ci): misuse of matrix conditional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
           parallel: true
       continue-on-error: true
   finish:
-    if: matrix.go == 'stable'
+    if: ${{ always() }}
     needs: test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Sorry, I used `matrix.go` in the `finish` job by mistake. This is unnecessary and caused the Action to fail to run. 