### PR TITLE
test: wait for workerFunction to be defined in worker test

### DIFF
--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -258,6 +258,14 @@ func TestPageExpectWorker(t *testing.T) {
 	require.Equal(t, worker, page.Workers()[0])
 	worker = page.Workers()[0]
 	require.Contains(t, worker.URL(), "worker.js")
+	require.Eventually(t,
+		func() bool {
+			v, err := worker.Evaluate(`() => self["workerFunction"] ? true : false`)
+			require.NoError(t, err)
+			return v == true
+		},
+		500*time.Millisecond, 10*time.Millisecond,
+	)
 	res, err := worker.Evaluate(`() => self["workerFunction"]()`)
 	require.NoError(t, err)
 	require.Equal(t, "worker function result", res)


### PR DESCRIPTION
has received a worker event does not mean worker  is loaded over.
it is the fail reason in many tests.