### PR TITLE
fix(cdp): handle missing timing fields in the response from CDP

### DIFF
--- a/response.go
+++ b/response.go
@@ -147,14 +147,14 @@ func newResponse(parent *channelOwner, objectType string, guid string, initializ
 	timing := resp.initializer["timing"].(map[string]interface{})
 	resp.request = fromChannel(resp.initializer["request"]).(*requestImpl)
 	resp.request.timing = &RequestTiming{
-		StartTime:             timing["startTime"].(float64),
-		DomainLookupStart:     timing["domainLookupStart"].(float64),
-		DomainLookupEnd:       timing["domainLookupEnd"].(float64),
-		ConnectStart:          timing["connectStart"].(float64),
-		SecureConnectionStart: timing["secureConnectionStart"].(float64),
-		ConnectEnd:            timing["connectEnd"].(float64),
-		RequestStart:          timing["requestStart"].(float64),
-		ResponseStart:         timing["responseStart"].(float64),
+		StartTime:             getFloatOrDefault(timing, "startTime", 0.0),
+		DomainLookupStart:     getFloatOrDefault(timing, "domainLookupStart", 0.0),
+		DomainLookupEnd:       getFloatOrDefault(timing, "domainLookupEnd", 0.0),
+		ConnectStart:          getFloatOrDefault(timing, "connectStart", 0.0),
+		SecureConnectionStart: getFloatOrDefault(timing, "secureConnectionStart", 0.0),
+		ConnectEnd:            getFloatOrDefault(timing, "connectEnd", 0.0),
+		RequestStart:          getFloatOrDefault(timing, "requestStart", 0.0),
+		ResponseStart:         getFloatOrDefault(timing, "responseStart", 0.0),
 	}
 	resp.provisionalHeaders = newRawHeaders(resp.initializer["headers"])
 	resp.finished = make(chan error, 1)

--- a/response.go
+++ b/response.go
@@ -154,14 +154,14 @@ func newResponse(parent *channelOwner, objectType string, guid string, initializ
 	resp.request = fromChannel(resp.initializer["request"]).(*requestImpl)
 	resp.request.response = resp
 	resp.request.timing = &RequestTiming{
-		StartTime:             timing["startTime"].(float64),
-		DomainLookupStart:     timing["domainLookupStart"].(float64),
-		DomainLookupEnd:       timing["domainLookupEnd"].(float64),
-		ConnectStart:          timing["connectStart"].(float64),
-		SecureConnectionStart: timing["secureConnectionStart"].(float64),
-		ConnectEnd:            timing["connectEnd"].(float64),
-		RequestStart:          timing["requestStart"].(float64),
-		ResponseStart:         timing["responseStart"].(float64),
+		StartTime:             getFloatOrDefault(timing, "startTime", 0.0),
+		DomainLookupStart:     getFloatOrDefault(timing, "domainLookupStart", 0.0),
+		DomainLookupEnd:       getFloatOrDefault(timing, "domainLookupEnd", 0.0),
+		ConnectStart:          getFloatOrDefault(timing, "connectStart", 0.0),
+		SecureConnectionStart: getFloatOrDefault(timing, "secureConnectionStart", 0.0),
+		ConnectEnd:            getFloatOrDefault(timing, "connectEnd", 0.0),
+		RequestStart:          getFloatOrDefault(timing, "requestStart", 0.0),
+		ResponseStart:         getFloatOrDefault(timing, "responseStart", 0.0),
 	}
 	resp.provisionalHeaders = newRawHeaders(resp.initializer["headers"])
 	resp.finished = make(chan error, 1)

--- a/response.go
+++ b/response.go
@@ -150,18 +150,22 @@ func (r *responseImpl) ServerAddr() (*ResponseServerAddrResult, error) {
 func newResponse(parent *channelOwner, objectType string, guid string, initializer map[string]any) *responseImpl {
 	resp := &responseImpl{}
 	resp.createChannelOwner(resp, parent, objectType, guid, initializer)
-	timing := resp.initializer["timing"].(map[string]any)
 	resp.request = fromChannel(resp.initializer["request"]).(*requestImpl)
 	resp.request.response = resp
-	resp.request.timing = &RequestTiming{
-		StartTime:             getFloatOrDefault(timing, "startTime", 0.0),
-		DomainLookupStart:     getFloatOrDefault(timing, "domainLookupStart", 0.0),
-		DomainLookupEnd:       getFloatOrDefault(timing, "domainLookupEnd", 0.0),
-		ConnectStart:          getFloatOrDefault(timing, "connectStart", 0.0),
-		SecureConnectionStart: getFloatOrDefault(timing, "secureConnectionStart", 0.0),
-		ConnectEnd:            getFloatOrDefault(timing, "connectEnd", 0.0),
-		RequestStart:          getFloatOrDefault(timing, "requestStart", 0.0),
-		ResponseStart:         getFloatOrDefault(timing, "responseStart", 0.0),
+	// The request timing is pre-seeded with the upstream defaults in newRequest.
+	// Mirror upstream's Object.assign(request._timing, initializer.timing) by only
+	// overriding the fields that are actually present in the timing initializer.
+	// Some CDP implementations (e.g. non-Chromium browsers) omit the timing object
+	// entirely or only return a subset of its fields.
+	if timing, ok := resp.initializer["timing"].(map[string]any); ok {
+		assignFloatIfPresent(timing, "startTime", &resp.request.timing.StartTime)
+		assignFloatIfPresent(timing, "domainLookupStart", &resp.request.timing.DomainLookupStart)
+		assignFloatIfPresent(timing, "domainLookupEnd", &resp.request.timing.DomainLookupEnd)
+		assignFloatIfPresent(timing, "connectStart", &resp.request.timing.ConnectStart)
+		assignFloatIfPresent(timing, "secureConnectionStart", &resp.request.timing.SecureConnectionStart)
+		assignFloatIfPresent(timing, "connectEnd", &resp.request.timing.ConnectEnd)
+		assignFloatIfPresent(timing, "requestStart", &resp.request.timing.RequestStart)
+		assignFloatIfPresent(timing, "responseStart", &resp.request.timing.ResponseStart)
 	}
 	resp.provisionalHeaders = newRawHeaders(resp.initializer["headers"])
 	resp.finished = make(chan error, 1)

--- a/tests/network_test.go
+++ b/tests/network_test.go
@@ -279,3 +279,17 @@ func TestRequestExistingResponse(t *testing.T) {
 	require.NotNil(t, existing)
 	require.Equal(t, response, existing)
 }
+
+func TestResponseTimingShouldPopulateTimingFromInitializer(t *testing.T) {
+	BeforeEach(t)
+
+	response, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	require.NoError(t, response.Finished())
+	timing := response.Request().Timing()
+	require.NotNil(t, timing)
+	// StartTime defaults to 0 and is populated for real responses, while fields
+	// the server does not report retain their -1 default (mirroring upstream).
+	require.GreaterOrEqual(t, timing.StartTime, 0.0)
+	require.GreaterOrEqual(t, timing.ResponseStart, timing.RequestStart)
+}

--- a/type_helpers.go
+++ b/type_helpers.go
@@ -83,3 +83,15 @@ func (c Cookie) ToOptionalCookie() OptionalCookie {
 		SameSite: c.SameSite,
 	}
 }
+
+func getFloatOrDefault(m map[string]interface{}, key string, defaultValue float64) float64 {
+	if val, ok := m[key]; !ok {
+		return defaultValue
+	} else {
+		if f, isFloat := val.(float64); !isFloat {
+			return defaultValue
+		} else {
+			return f
+		}
+	}
+}

--- a/type_helpers.go
+++ b/type_helpers.go
@@ -71,14 +71,14 @@ func (c Cookie) ToOptionalCookie() OptionalCookie {
 	}
 }
 
-func getFloatOrDefault(m map[string]interface{}, key string, defaultValue float64) float64 {
-	if val, ok := m[key]; !ok {
-		return defaultValue
-	} else {
-		if f, isFloat := val.(float64); !isFloat {
-			return defaultValue
-		} else {
-			return f
+// assignFloatIfPresent overrides *target with m[key] when that key holds a
+// float64 value, leaving *target untouched otherwise. It is used to merge the
+// timing fields returned by the server over their pre-seeded defaults without
+// panicking when a field is missing or has an unexpected type.
+func assignFloatIfPresent(m map[string]any, key string, target *float64) {
+	if val, ok := m[key]; ok {
+		if f, isFloat := val.(float64); isFloat {
+			*target = f
 		}
 	}
 }

--- a/type_helpers.go
+++ b/type_helpers.go
@@ -70,3 +70,15 @@ func (c Cookie) ToOptionalCookie() OptionalCookie {
 		SameSite: c.SameSite,
 	}
 }
+
+func getFloatOrDefault(m map[string]interface{}, key string, defaultValue float64) float64 {
+	if val, ok := m[key]; !ok {
+		return defaultValue
+	} else {
+		if f, isFloat := val.(float64); !isFloat {
+			return defaultValue
+		} else {
+			return f
+		}
+	}
+}

--- a/type_helpers_test.go
+++ b/type_helpers_test.go
@@ -1,0 +1,33 @@
+package playwright
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_assignFloatIfPresent(t *testing.T) {
+	t.Run("overrides target when key holds a float64", func(t *testing.T) {
+		target := -1.0
+		assignFloatIfPresent(map[string]any{"startTime": 123.0}, "startTime", &target)
+		require.Equal(t, 123.0, target)
+	})
+
+	t.Run("leaves target untouched when key is missing", func(t *testing.T) {
+		target := -1.0
+		assignFloatIfPresent(map[string]any{}, "startTime", &target)
+		require.Equal(t, -1.0, target)
+	})
+
+	t.Run("leaves target untouched when value is nil", func(t *testing.T) {
+		target := -1.0
+		assignFloatIfPresent(map[string]any{"startTime": nil}, "startTime", &target)
+		require.Equal(t, -1.0, target)
+	})
+
+	t.Run("leaves target untouched when value is not a float64", func(t *testing.T) {
+		target := -1.0
+		assignFloatIfPresent(map[string]any{"startTime": "not-a-float"}, "startTime", &target)
+		require.Equal(t, -1.0, target)
+	})
+}


### PR DESCRIPTION

Fixed handling of float values from the CDP timing response. To handle situation where an implementation of the CDP doesn't return appropriate timings or is missing some fields.

Go: 1.25
Playwright-go: v0.5200.1
Browser: Chromium-ish -> LightPanda via CDP

## Reproduce

I was trying to use LightPanda's Browser which has support for CDP to use as an alternative to Chromium.

Follow the steps in order to reproduce.

1. Download [LightPanda Browser](https://github.com/lightpanda-io/browser/releases)
2. Run LightPanda Browser's CDP server
```sh
$ lightpanda-x86_64-linux serve --port 9226 --log_level debug
```

3. Create the following Go program

```go
package main

import (
	"fmt"
	"log"

	playwrightgo "github.com/playwright-community/playwright-go"
)

func main() {
	err := run()
	if err != nil {
		log.Fatal(err)
	}
}
func run() error {

	err := playwrightgo.Install(&playwrightgo.RunOptions{
		Browsers: []string{"chromium"},
		DryRun:   true,
	})
	if err != nil {
		return fmt.Errorf("could not launch playwright: %w", err)
	}

	pw, err := playwrightgo.Run()
	if err != nil {
		return fmt.Errorf("could not launch playwright: %w", err)
	}

	browser, err := pw.Chromium.ConnectOverCDP("ws://localhost:9226")
	if err != nil {
		return fmt.Errorf("could not launch LightPanda via CDP: %w", err)
	}
	context, err := browser.NewContext()
	if err != nil {
		return fmt.Errorf("could not create context: %w", err)
	}
	page, err := context.NewPage()
	if err != nil {
		return fmt.Errorf("could not create page: %w", err)
	}

	_, err = page.Goto("https://playwright.dev/")
	if err != nil {
		return fmt.Errorf("could not goto: %w", err)
	}

	loc := page.Locator(`a[href="/community/welcome"]`)
	assertions := playwrightgo.NewPlaywrightAssertions()
	assert := assertions.Locator(loc)

	err = assert.ToHaveText("Community")
	if err != nil {
		return fmt.Errorf("could assert community link: %w", err)
	}

	err = browser.Close()
	if err != nil {
		return fmt.Errorf("could not close browser: %w", err)
	}
	err = pw.Stop()
	if err != nil {
		return fmt.Errorf("could not stop Playwright: %w", err)
	}

	return nil

}

```

4. Run the program `go run main.go`

5. Observe that there's a panic with the following in the error trace:

```
panic: interface conversion: interface {} is nil, not float64

goroutine 50 [running]:
github.com/playwright-community/playwright-go.newResponse(0xc0001b4000, {0xc000114cf0, 0x8}, {0xc00014aff0, 0x29}, 0xc0001a2db0)
```
