### PR TITLE
test: add ExpectDownload regression test for mobile emulation context

### DIFF
--- a/tests/download_test.go
+++ b/tests/download_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/playwright-community/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,6 +47,48 @@ func TestDownloadBasic(t *testing.T) {
 
 	require.NoError(t, download.Delete())
 	require.NoFileExists(t, file)
+}
+
+// Regression test for https://github.com/playwright-community/playwright-go/issues/579
+// Verifies that ExpectDownload works under a mobile emulation context (IsMobile + HasTouch),
+// e.g. when emulating an iPad. The download event must fire on the page channel even when
+// the context has touch + isMobile enabled.
+func TestDownloadInMobileContext(t *testing.T) {
+	BeforeEach(t)
+
+	server.SetRoute("/downloadMobile", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/octet-stream")
+		w.Header().Add("Content-Disposition", "attachment; filename=mobile.txt")
+		if _, err := w.Write([]byte("mobile-payload")); err != nil {
+			log.Printf("could not write: %v", err)
+		}
+	})
+
+	device := pw.Devices["iPad Mini"]
+	mobileCtx, err := browser.NewContext(playwright.BrowserNewContextOptions{
+		Viewport:          device.Viewport,
+		UserAgent:         playwright.String(device.UserAgent),
+		DeviceScaleFactor: playwright.Float(device.DeviceScaleFactor),
+		IsMobile:          playwright.Bool(device.IsMobile),
+		HasTouch:          playwright.Bool(device.HasTouch),
+	})
+	require.NoError(t, err)
+	defer mobileCtx.Close()
+
+	mobilePage, err := mobileCtx.NewPage()
+	require.NoError(t, err)
+
+	require.NoError(t, mobilePage.SetContent(
+		fmt.Sprintf(`<a href="%s/downloadMobile">download</a>`, server.PREFIX),
+	))
+
+	download, err := mobilePage.ExpectDownload(func() error {
+		return mobilePage.Locator("a").Click()
+	})
+	require.NoError(t, err)
+	require.Equal(t, mobilePage, download.Page())
+	require.Equal(t, fmt.Sprintf("%s/downloadMobile", server.PREFIX), download.URL())
+	require.Equal(t, "mobile.txt", download.SuggestedFilename())
 }
 
 func TestDownloadCancel(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a regression test, `TestDownloadInMobileContext`, that exercises `Page.ExpectDownload` under an iPad Mini emulation context (`IsMobile: true`, `HasTouch: true`). The test confirms that the page-level `"download"` channel event still fires correctly under mobile emulation and that `Download.URL()` / `Download.SuggestedFilename()` return the expected values.

Refs #579.

## Notes on #579

I was unable to reproduce a real bug from the report. After investigating, the snippet in the issue clicks `<a href="…some.jpg">` against a server that does not send `Content-Disposition: attachment` and the anchor has no `download` attribute, so the browser navigates to the resource instead of triggering a download — `ExpectDownload` then correctly times out. With the same iPad Mini / `IsMobile` context plus a properly configured download (this PR's test), `ExpectDownload` resolves as expected.

I'm opening this as a draft so a maintainer can decide whether:
1. This regression coverage is worth merging on its own, and/or
2. The issue should be closed with a comment pointing the reporter at the `download` attribute / `Content-Disposition: attachment` requirement.

## Test plan

- [x] `go test ./tests -run TestDownloadInMobileContext -v` — passes
- [x] `go test ./tests -run "TestDownloadBasic|TestDownloadCancel|TestDownloadInMobileContext" -v` — all pass
- [x] `go vet ./...` clean, `gofmt` clean