### PR TITLE
chore: roll to Playwright v1.59.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/playwright-community/playwright-go)](https://pkg.go.dev/github.com/playwright-community/playwright-go)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](http://opensource.org/licenses/MIT)
 [![Go Report Card](https://goreportcard.com/badge/github.com/playwright-community/playwright-go)](https://goreportcard.com/report/github.com/playwright-community/playwright-go) ![Build Status](https://github.com/playwright-community/playwright-go/workflows/Go/badge.svg)
-[![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://aka.ms/playwright-slack) [![Coverage Status](https://coveralls.io/repos/github/playwright-community/playwright-go/badge.svg?branch=main)](https://coveralls.io/github/playwright-community/playwright-go?branch=main) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-143.0.7499.4-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-144.0.2-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> <!-- GEN:webkit-version-badge -->[![WebKit version](https://img.shields.io/badge/webkit-26.0-blue.svg?logo=safari)](https://webkit.org/)<!-- GEN:stop -->
+[![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://aka.ms/playwright-slack) [![Coverage Status](https://coveralls.io/repos/github/playwright-community/playwright-go/badge.svg?branch=main)](https://coveralls.io/github/playwright-community/playwright-go?branch=main) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-147.0.7727.15-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-148.0.2-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> <!-- GEN:webkit-version-badge -->[![WebKit version](https://img.shields.io/badge/webkit-26.4-blue.svg?logo=safari)](https://webkit.org/)<!-- GEN:stop -->
 
 [API reference](https://playwright.dev/docs/api/class-playwright) | [Example recipes](https://github.com/playwright-community/playwright-go/tree/main/examples)
 
@@ -13,9 +13,9 @@ Playwright is a Go library to automate [Chromium](https://www.chromium.org/Home)
 
 |          | Linux | macOS | Windows |
 |   :---   | :---: | :---: | :---:   |
-| Chromium <!-- GEN:chromium-version -->143.0.7499.4<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| WebKit <!-- GEN:webkit-version -->26.0<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Firefox <!-- GEN:firefox-version -->144.0.2<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Chromium <!-- GEN:chromium-version -->147.0.7727.15<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| WebKit <!-- GEN:webkit-version -->26.4<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Firefox <!-- GEN:firefox-version -->148.0.2<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 Headless execution is supported for all the browsers on all platforms.
 

--- a/browser.go
+++ b/browser.go
@@ -134,6 +134,20 @@ func (b *browserImpl) Contexts() []BrowserContext {
 	return b.contexts
 }
 
+func (b *browserImpl) Bind(title string, options ...BrowserBindOptions) (*Bind, error) {
+	overrides := map[string]any{"title": title}
+	result, err := b.channel.SendReturnAsDict("startServer", options, overrides)
+	if err != nil {
+		return nil, err
+	}
+	return &Bind{Endpoint: result["endpoint"].(string)}, nil
+}
+
+func (b *browserImpl) Unbind() error {
+	_, err := b.channel.Send("stopServer")
+	return err
+}
+
 func (b *browserImpl) Close(options ...BrowserCloseOptions) (err error) {
 	if len(options) == 1 {
 		b.closeReason = options[0].Reason

--- a/browser_context.go
+++ b/browser_context.go
@@ -28,6 +28,8 @@ type browserContextImpl struct {
 	backgroundPages []Page
 	bindings        *safe.SyncMap[string, BindingCallFunction]
 	tracing         *tracingImpl
+	debugger        *debuggerImpl
+	isClosedFlag    bool
 	request         *apiRequestContextImpl
 	harRecorders    map[string]harRecordingMetadata
 	closed          chan struct{}
@@ -70,6 +72,10 @@ func (b *browserContextImpl) Pages() []Page {
 
 func (b *browserContextImpl) Browser() Browser {
 	return b.browser
+}
+
+func (b *browserContextImpl) Debugger() (Debugger, error) {
+	return b.debugger, nil
 }
 
 func (b *browserContextImpl) Tracing() Tracing {
@@ -547,6 +553,7 @@ func (b *browserContextImpl) onBinding(binding *bindingCallImpl) {
 }
 
 func (b *browserContextImpl) onClose() {
+	b.isClosedFlag = true
 	if b.browser != nil {
 		contexts := make([]BrowserContext, 0)
 		b.browser.Lock()
@@ -813,6 +820,11 @@ func newBrowserContext(parent *channelOwner, objectType string, guid string, ini
 		bt.browser.contexts = append(bt.browser.contexts, bt)
 	}
 	bt.tracing = fromChannel(initializer["tracing"]).(*tracingImpl)
+	if dbg := fromNullableChannel(initializer["debugger"]); dbg != nil {
+		if d, ok := dbg.(*debuggerImpl); ok {
+			bt.debugger = d
+		}
+	}
 	bt.request = fromChannel(initializer["requestContext"]).(*apiRequestContextImpl)
 	bt.clock = newClock(bt)
 
@@ -952,4 +964,21 @@ func newBrowserContext(parent *channelOwner, objectType string, guid string, ini
 		"responsefailed":  "responseFailed",
 	})
 	return bt
+}
+
+func (b *browserContextImpl) IsClosed() bool {
+	return b.isClosedFlag || b.closeReason != nil
+}
+
+func (b *browserContextImpl) SetStorageState(storageStatePath string) error {
+	storageString, err := os.ReadFile(storageStatePath)
+	if err != nil {
+		return err
+	}
+	var storageState map[string]any
+	if err := json.Unmarshal(storageString, &storageState); err != nil {
+		return err
+	}
+	_, err = b.channel.Send("setStorageState", map[string]any{"storageState": storageState})
+	return err
 }

--- a/browser_type.go
+++ b/browser_type.go
@@ -109,7 +109,7 @@ func (b *browserTypeImpl) LaunchPersistentContext(userDataDir string, options ..
 
 func (b *browserTypeImpl) Connect(wsEndpoint string, options ...BrowserTypeConnectOptions) (Browser, error) {
 	overrides := map[string]any{
-		"wsEndpoint": wsEndpoint,
+		"endpoint": wsEndpoint,
 		"headers": map[string]string{
 			"x-playwright-browser":        b.Name(),
 			"x-playwright-launch-options": "{}",

--- a/cdp_session.go
+++ b/cdp_session.go
@@ -9,6 +9,10 @@ func (c *cdpSessionImpl) Detach() error {
 	return err
 }
 
+func (c *cdpSessionImpl) OnClose(fn func(CDPSession)) {
+	c.On("close", fn)
+}
+
 func (c *cdpSessionImpl) Send(method string, params map[string]any) (any, error) {
 	result, err := c.channel.Send("send", map[string]any{
 		"method": method,

--- a/console_message.go
+++ b/console_message.go
@@ -54,3 +54,11 @@ func newConsoleMessage(event map[string]any) *consoleMessageImpl {
 	}
 	return bt
 }
+
+func (c *consoleMessageImpl) Timestamp() (float64, error) {
+	v, ok := c.event["timestamp"]
+	if !ok {
+		return 0, nil
+	}
+	return v.(float64), nil
+}

--- a/debugger.go
+++ b/debugger.go
@@ -1,0 +1,68 @@
+package playwright
+
+import "sync"
+
+type debuggerImpl struct {
+	channelOwner
+	mu            sync.RWMutex
+	pausedDetails *PausedDetail
+}
+
+func (d *debuggerImpl) OnPausedStateChanged(fn func()) {
+	d.On("pausedStateChanged", fn)
+}
+
+func (d *debuggerImpl) PausedDetails() (*PausedDetail, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.pausedDetails, nil
+}
+
+func (d *debuggerImpl) RequestPause() error {
+	_, err := d.channel.Send("requestPause")
+	return err
+}
+
+func (d *debuggerImpl) Resume() error {
+	_, err := d.channel.Send("resume")
+	return err
+}
+
+func (d *debuggerImpl) Next() error {
+	_, err := d.channel.Send("next")
+	return err
+}
+
+func (d *debuggerImpl) RunTo(location DebuggerLocation) error {
+	_, err := d.channel.Send("runTo", map[string]any{"location": location})
+	return err
+}
+
+func newDebugger(parent *channelOwner, objectType string, guid string, initializer map[string]any) *debuggerImpl {
+	bt := &debuggerImpl{}
+	bt.createChannelOwner(bt, parent, objectType, guid, initializer)
+	bt.channel.On("pausedStateChanged", func(params map[string]any) {
+		bt.mu.Lock()
+		if pd, ok := params["pausedDetails"]; ok && pd != nil {
+			data := pd.(map[string]any)
+			detail := &PausedDetail{Title: data["title"].(string)}
+			if loc, ok := data["location"].(map[string]any); ok {
+				detail.Location = &PausedDetailLocation{File: loc["file"].(string)}
+				if line, ok := loc["line"]; ok && line != nil {
+					v := int(line.(float64))
+					detail.Location.Line = &v
+				}
+				if col, ok := loc["column"]; ok && col != nil {
+					v := int(col.(float64))
+					detail.Location.Column = &v
+				}
+			}
+			bt.pausedDetails = detail
+		} else {
+			bt.pausedDetails = nil
+		}
+		bt.mu.Unlock()
+		bt.Emit("pausedStateChanged")
+	})
+	return bt
+}

--- a/disposable.go
+++ b/disposable.go
@@ -1,0 +1,16 @@
+package playwright
+
+type disposableImpl struct {
+	channelOwner
+}
+
+func (d *disposableImpl) Dispose() error {
+	_, err := d.channel.Send("dispose")
+	return err
+}
+
+func newDisposable(parent *channelOwner, objectType string, guid string, initializer map[string]any) *disposableImpl {
+	bt := &disposableImpl{}
+	bt.createChannelOwner(bt, parent, objectType, guid, initializer)
+	return bt
+}

--- a/examples/video/main.go
+++ b/examples/video/main.go
@@ -21,7 +21,7 @@ func main() {
 	}
 	page, err := browser.NewPage(playwright.BrowserNewPageOptions{
 		RecordVideo: &playwright.RecordVideo{
-			Dir: "videos/",
+			Dir: playwright.String("videos/"),
 		},
 	})
 	if err != nil {

--- a/fetch.go
+++ b/fetch.go
@@ -463,3 +463,18 @@ func serializeMapToNameValue(data map[string]any) []map[string]string {
 	}
 	return serialized
 }
+
+func (r *requestImpl) ExistingResponse() (Response, error) {
+	if !r.hasResponse {
+		return nil, nil
+	}
+	return r.Response()
+}
+
+func (r *responseImpl) HttpVersion() (string, error) {
+	result, err := r.channel.Send("httpVersion")
+	if err != nil {
+		return "", err
+	}
+	return result.(string), nil
+}

--- a/frame_locator.go
+++ b/frame_locator.go
@@ -109,7 +109,8 @@ func (fl *frameLocatorImpl) Locator(selectorOrLocator any, options ...FrameLocat
 			locator.err = errors.Join(locator.err, ErrLocatorNotSameFrame)
 			return locator
 		}
-		return newLocator(locator.frame,
+		return newLocator(
+			locator.frame,
 			fmt.Sprintf("%s >> internal:control=enter-frame >> %s", fl.frameSelector, locator.selector),
 			option,
 		)

--- a/generated-enums.go
+++ b/generated-enums.go
@@ -365,6 +365,18 @@ var (
 	LoadStateNetworkidle                 = getLoadState("networkidle")
 )
 
+func getAriaSnapshotMode(in string) *AriaSnapshotMode {
+	v := AriaSnapshotMode(in)
+	return &v
+}
+
+type AriaSnapshotMode string
+
+var (
+	AriaSnapshotModeAi      *AriaSnapshotMode = getAriaSnapshotMode("ai")
+	AriaSnapshotModeDefault                   = getAriaSnapshotMode("default")
+)
+
 func getContrast(in string) *Contrast {
 	v := Contrast(in)
 	return &v
@@ -389,6 +401,34 @@ var (
 	MediaScreen     *Media = getMedia("screen")
 	MediaPrint             = getMedia("print")
 	MediaNoOverride        = getMedia("no-override")
+)
+
+func getConsoleMessagesFilter(in string) *ConsoleMessagesFilter {
+	v := ConsoleMessagesFilter(in)
+	return &v
+}
+
+type ConsoleMessagesFilter string
+
+var (
+	ConsoleMessagesFilterAll             *ConsoleMessagesFilter = getConsoleMessagesFilter("all")
+	ConsoleMessagesFilterSinceNavigation                        = getConsoleMessagesFilter("since-navigation")
+)
+
+func getAnnotatePosition(in string) *AnnotatePosition {
+	v := AnnotatePosition(in)
+	return &v
+}
+
+type AnnotatePosition string
+
+var (
+	AnnotatePositionTopLeft     *AnnotatePosition = getAnnotatePosition("top-left")
+	AnnotatePositionTop                           = getAnnotatePosition("top")
+	AnnotatePositionTopRight                      = getAnnotatePosition("top-right")
+	AnnotatePositionBottomLeft                    = getAnnotatePosition("bottom-left")
+	AnnotatePositionBottom                        = getAnnotatePosition("bottom")
+	AnnotatePositionBottomRight                   = getAnnotatePosition("bottom-right")
 )
 
 func getHttpCredentialsSend(in string) *HttpCredentialsSend {

--- a/generated-interfaces.go
+++ b/generated-interfaces.go
@@ -130,8 +130,7 @@ type APIResponse interface {
 // The [APIResponseAssertions] class provides assertion methods that can be used to make assertions about the
 // [APIResponse] in the tests.
 type APIResponseAssertions interface {
-	// Makes the assertion check for the opposite condition. For example, this code tests that the response status is not
-	// successful:
+	// Makes the assertion check for the opposite condition.
 	Not() APIResponseAssertions
 
 	// Ensures the response status code is within `200..299` range.
@@ -183,6 +182,11 @@ type Browser interface {
 	// to control their exact life times.
 	NewPage(options ...BrowserNewPageOptions) (Page, error)
 
+	// Binds the browser to a named pipe or web socket, making it available for other clients to connect to.
+	//
+	//  title: Title of the browser server, used for identification.
+	Bind(title string, options ...BrowserBindOptions) (*Bind, error)
+
 	// **NOTE** This API controls
 	// [Chromium Tracing] which is a low-level
 	// chromium-specific debugging tool. API to control [Playwright Tracing] could be found
@@ -206,6 +210,9 @@ type Browser interface {
 	// [here]: ./class-tracing
 	StopTracing() ([]byte, error)
 
+	// Unbinds the browser server previously bound with [Browser.Bind].
+	Unbind() error
+
 	// Returns the browser version.
 	Version() string
 }
@@ -224,6 +231,9 @@ type BrowserContext interface {
 
 	// Playwright has ability to mock clock and passage of time.
 	Clock() Clock
+
+	// Debugger allows to pause and resume the execution.
+	Debugger() (Debugger, error)
 
 	// Emitted when Browser context gets closed. This might happen because of one of the following:
 	//  - Browser context is closed.
@@ -363,7 +373,11 @@ type BrowserContext interface {
 	//    - `'notifications'`
 	//    - `'payment-handler'`
 	//    - `'storage-access'`
+	//    - `'screen-wake-lock'`
 	GrantPermissions(permissions []string, options ...BrowserContextGrantPermissionsOptions) error
+
+	// Indicates that the browser context is in the process of closing or has already been closed.
+	IsClosed() bool
 
 	// **NOTE** CDP sessions are only supported on Chromium-based browsers.
 	// Returns the newly created session.
@@ -460,6 +474,12 @@ type BrowserContext interface {
 	// snapshot.
 	StorageState(path ...string) (*StorageState, error)
 
+	// Clears the existing cookies, local storage and IndexedDB entries for all origins and sets the new storage state.
+	//
+	//  storageStatePath: Populates context with given storage state. This option can be used to initialize context with logged-in
+	//    information obtained via [BrowserContext.StorageState]. Path to the file with saved storage state.
+	SetStorageState(storageStatePath string) error
+
 	Tracing() Tracing
 
 	// Removes all routes created with [BrowserContext.Route] and [BrowserContext.RouteFromHAR].
@@ -468,7 +488,7 @@ type BrowserContext interface {
 	// Removes a route created with [BrowserContext.Route]. When “[object Object]” is not specified, removes all routes
 	// for the “[object Object]”.
 	//
-	// 1. url: A glob pattern, regex pattern or predicate receiving [URL] used to register a routing with [BrowserContext.Route].
+	// 1. url: A glob pattern, regex pattern, or predicate receiving [URL] used to register a routing with [BrowserContext.Route].
 	// 2. handler: Optional handler function used to register a routing with [BrowserContext.Route].
 	Unroute(url any, handler ...routeHandler) error
 
@@ -505,8 +525,8 @@ type BrowserType interface {
 	// **NOTE** The major and minor version of the Playwright instance that connects needs to match the version of
 	// Playwright that launches the browser (1.2.3 → is compatible with 1.2.x).
 	//
-	//  wsEndpoint: A Playwright browser websocket endpoint to connect to. You obtain this endpoint via `BrowserServer.wsEndpoint`.
-	Connect(wsEndpoint string, options ...BrowserTypeConnectOptions) (Browser, error)
+	//  endpoint: A Playwright browser websocket endpoint to connect to. You obtain this endpoint via `BrowserServer.wsEndpoint`.
+	Connect(endpoint string, options ...BrowserTypeConnectOptions) (Browser, error)
 
 	// This method attaches Playwright to an existing browser instance using the Chrome DevTools Protocol.
 	// The default browser context is accessible via [Browser.Contexts].
@@ -568,6 +588,9 @@ type BrowserType interface {
 // [DevTools Protocol Viewer]: https://chromedevtools.github.io/devtools-protocol/
 type CDPSession interface {
 	EventEmitter
+	// Emitted when the session is closed, either because the target was closed or `session.detach()` was called.
+	OnClose(fn func(CDPSession))
+
 	// Detaches the CDPSession from the target. Once detached, the CDPSession object won't emit any events and can't be
 	// used to send messages.
 	Detach() error
@@ -658,6 +681,9 @@ type ConsoleMessage interface {
 	// The text of the console message.
 	String() string
 
+	// The timestamp of the console message in milliseconds since the Unix epoch.
+	Timestamp() (float64, error)
+
 	// One of the following values: `log`, `debug`, `info`, `error`, `warning`, `dir`, `dirxml`, `table`,
 	// `trace`, `clear`, `startGroup`, `startGroupCollapsed`, `endGroup`, `assert`, `profile`,
 	// `profileEnd`, `count`, `timeEnd`.
@@ -666,6 +692,35 @@ type ConsoleMessage interface {
 	// The web worker or service worker that produced this console message, if any. Note that console messages from web
 	// workers also have non-null [ConsoleMessage.Page].
 	Worker() (Worker, error)
+}
+
+// API for controlling the Playwright debugger. The debugger allows pausing script execution and inspecting the page.
+// Obtain the debugger instance via [BrowserContext.Debugger].
+type Debugger interface {
+	// Emitted when the debugger pauses or resumes.
+	OnPausedStateChanged(fn func())
+
+	// Returns details about the currently paused call. Returns `null` if the debugger is not paused.
+	PausedDetails() (*PausedDetail, error)
+
+	// Configures the debugger to pause before the next action is executed.
+	// Throws if the debugger is already paused. Use [Debugger.Next] or [Debugger.RunTo] to step while paused.
+	// Note that [Page.Pause] is equivalent to a "debugger" statement — it pauses execution at the call site immediately.
+	// On the contrary, [Debugger.RequestPause] is equivalent to "pause on next statement" — it configures the debugger to
+	// pause before the next action is executed.
+	RequestPause() error
+
+	// Resumes script execution. Throws if the debugger is not paused.
+	Resume() error
+
+	// Resumes script execution and pauses again before the next action. Throws if the debugger is not paused.
+	Next() error
+
+	// Resumes script execution and pauses when an action originates from the given source location. Throws if the
+	// debugger is not paused.
+	//
+	//  location: The source location to pause at.
+	RunTo(location DebuggerLocation) error
 }
 
 // [Dialog] objects are dispatched by page via the [Page.OnDialog] event.
@@ -1927,7 +1982,7 @@ type Frame interface {
 
 	// Waits for the frame to navigate to the given URL.
 	//
-	//  url: A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if
+	//  url: A glob pattern, regex pattern, or predicate receiving [URL] to match while waiting for the navigation. Note that if
 	//    the parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly
 	//    equal to the string.
 	WaitForURL(url any, options ...FrameWaitForURLOptions) error
@@ -2238,6 +2293,9 @@ type Locator interface {
 	//   - listitem:
 	//     - link "About"
 	// ```
+	// An AI-optimized snapshot, controlled by “[object Object]”, is different from a default snapshot:
+	//  1. Includes element references `[ref=e2]`. 2. Does not wait for an element matching the locator, and throws when
+	//    no elements match. 3. Includes snapshots of `<iframe>`s inside the target.
 	//
 	// [aria snapshots]: https://playwright.dev/docs/aria-snapshots
 	// [YAML]: https://yaml.org/spec/1.2.2/
@@ -2345,8 +2403,7 @@ type Locator interface {
 	Describe(description string) Locator
 
 	// Returns locator description previously set with [Locator.Describe]. Returns `null` if no custom description has
-	// been set. Prefer `Locator.toString()` for a human-readable representation, as it uses the description when
-	// available.
+	// been set.
 	Description() (string, error)
 
 	// Programmatically dispatch an event on the matching element.
@@ -2682,6 +2739,11 @@ type Locator interface {
 	// [Learn more about locators]: https://playwright.dev/docs/locators
 	Locator(selectorOrLocator any, options ...LocatorLocatorOptions) Locator
 
+	// Returns a new locator that uses best practices for referencing the matched element, prioritizing test ids, aria
+	// roles, and other user-facing attributes over CSS selectors. This is useful for converting implementation-detail
+	// selectors into more resilient, human-readable locators.
+	Normalize() Locator
+
 	// Returns locator to the n-th matching element. It's zero based, `nth(0)` selects the first element.
 	Nth(index int) Locator
 
@@ -2884,8 +2946,7 @@ type Locator interface {
 // The [LocatorAssertions] class provides assertion methods that can be used to make assertions about the [Locator]
 // state in the tests.
 type LocatorAssertions interface {
-	// Makes the assertion check for the opposite condition. For example, this code tests that the Locator doesn't contain
-	// text `"error"`:
+	// Makes the assertion check for the opposite condition.
 	Not() LocatorAssertions
 
 	// Ensures that [Locator] points to an element that is
@@ -3701,8 +3762,19 @@ type Page interface {
 
 	Keyboard() Keyboard
 
+	// Clears all stored console messages from this page. Subsequent calls to [Page.ConsoleMessages] will only return
+	// messages logged after the clear.
+	ClearConsoleMessages() error
+
+	// Clears all stored page errors from this page. Subsequent calls to [Page.PageErrors] will only return errors thrown
+	// after the clear.
+	ClearPageErrors() error
+
 	// Returns up to (currently) 200 last console messages from this page. See [Page.OnConsole] for more details.
-	ConsoleMessages() ([]ConsoleMessage, error)
+	ConsoleMessages(options ...PageConsoleMessagesOptions) ([]ConsoleMessage, error)
+
+	// Returns up to (currently) 200 last page errors from this page. See [Page.OnPageError] for more details.
+	PageErrors() ([]string, error)
 
 	// The method returns an element locator that can be used to perform actions on this page / frame. Locator is resolved
 	// to the element immediately before performing an action, so a series of actions on the same locator can in fact be
@@ -3883,6 +3955,9 @@ type Page interface {
 	// 2. handler: Handler function to route the WebSocket.
 	RouteWebSocket(url any, handler func(WebSocketRoute)) error
 
+	// [Screencast] object associated with this page.
+	Screencast() (Screencast, error)
+
 	// Returns the buffer with the captured screenshot.
 	Screenshot(options ...PageScreenshotOptions) ([]byte, error)
 
@@ -3990,6 +4065,11 @@ type Page interface {
 	// 2. height: Page height in pixels.
 	SetViewportSize(width int, height int) error
 
+	// Captures the aria snapshot of the page. Read more about [aria snapshots].
+	//
+	// [aria snapshots]: https://playwright.dev/docs/aria-snapshots
+	AriaSnapshot(options ...PageAriaSnapshotOptions) (string, error)
+
 	// This method taps an element matching “[object Object]” by performing the following steps:
 	//  1. Find an element matching “[object Object]”. If there is none, wait until a matching element is attached to
 	//    the DOM.
@@ -4064,13 +4144,14 @@ type Page interface {
 	// Removes a route created with [Page.Route]. When “[object Object]” is not specified, removes all routes for the
 	// “[object Object]”.
 	//
-	// 1. url: A glob pattern, regex pattern or predicate receiving [URL] to match while routing.
+	// 1. url: A glob pattern, regex pattern, or predicate receiving [URL] to match while routing.
 	// 2. handler: Optional handler function to route the request.
 	Unroute(url any, handler ...routeHandler) error
 
 	URL() string
 
-	// Video object associated with this page.
+	// Video object associated with this page. Can be used to access the video file when using the `recordVideo` context
+	// option.
 	Video() Video
 
 	ViewportSize() *Size
@@ -4179,7 +4260,7 @@ type Page interface {
 
 	// Waits for the main frame to navigate to the given URL.
 	//
-	//  url: A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if
+	//  url: A glob pattern, regex pattern, or predicate receiving [URL] to match while waiting for the navigation. Note that if
 	//    the parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly
 	//    equal to the string.
 	WaitForURL(url any, options ...PageWaitForURLOptions) error
@@ -4213,8 +4294,7 @@ type Page interface {
 // The [PageAssertions] class provides assertion methods that can be used to make assertions about the [Page] state in
 // the tests.
 type PageAssertions interface {
-	// Makes the assertion check for the opposite condition. For example, this code tests that the page URL doesn't
-	// contain `"error"`:
+	// Makes the assertion check for the opposite condition.
 	Not() PageAssertions
 
 	// Ensures the page has the given title.
@@ -4331,6 +4411,11 @@ type Request interface {
 	// Returns the matching [Response] object, or `null` if the response was not received due to error.
 	Response() (Response, error)
 
+	// Returns the [Response] object if the response has already been received, `null` otherwise.
+	// Unlike [Request.Response], this method does not wait for the response to arrive. It returns immediately with the
+	// response object if the response has been received, or `null` if the response has not been received yet.
+	ExistingResponse() (Response, error)
+
 	// Returns resource size information for given request.
 	Sizes() (*RequestSizesResult, error)
 
@@ -4386,6 +4471,9 @@ type Response interface {
 	//  name: Name of the header.
 	HeaderValues(name string) ([]string, error)
 
+	// Returns the http version used by the response.
+	HttpVersion() (string, error)
+
 	// Returns the JSON representation of response body.
 	// This method will throw if the response body is not parsable via `JSON.parse`.
 	JSON(v any) error
@@ -4433,9 +4521,13 @@ type Route interface {
 	// over to redirected requests.
 	// [Route.Continue] will immediately send the request to the network, other matching handlers won't be invoked. Use
 	// [Route.Fallback] If you want next matching handler in the chain to be invoked.
-	// **NOTE** The `Cookie` header cannot be overridden using this method. If a value is provided, it will be ignored,
-	// and the cookie will be loaded from the browser's cookie store. To set custom cookies, use
-	// [BrowserContext.AddCookies].
+	// **NOTE** Some request headers are **forbidden** and cannot be overridden (for example, `Cookie`, `Host`,
+	// `Content-Length` and others, see
+	// [this MDN page] for full list). If an
+	// override is provided for a forbidden header, it will be ignored and the original request header will be used.
+	// To set custom cookies, use [BrowserContext.AddCookies].
+	//
+	// [this MDN page]: https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_request_header
 	Continue(options ...RouteContinueOptions) error
 
 	// Continues route's request with optional overrides. The method is similar to [Route.Continue] with the difference
@@ -4457,6 +4549,41 @@ type Route interface {
 
 	// A request to be routed.
 	Request() Request
+}
+
+// Interface for capturing screencast frames from a page.
+type Screencast interface {
+	// Starts the screencast. When “[object Object]” is provided, it saves video recording to the specified file. When
+	// “[object Object]” is provided, delivers JPEG-encoded frames to the callback. Both can be used together.
+	Start(options ...ScreencastStartOptions) error
+
+	// Stops the screencast and video recording if active. If a video was being recorded, saves it to the path specified
+	// in [Screencast.Start].
+	Stop() error
+
+	// Adds an overlay with the given HTML content. The overlay is displayed on top of the page until removed. Returns a
+	// disposable that removes the overlay when disposed.
+	//
+	//  html: HTML content for the overlay.
+	ShowOverlay(html string, options ...ScreencastShowOverlayOptions) error
+
+	// Shows a chapter overlay with a title and optional description, centered on the page with a blurred backdrop. Useful
+	// for narrating video recordings. The overlay is removed after the specified duration, or 2000ms.
+	//
+	//  title: Title text displayed prominently in the overlay.
+	ShowChapter(title string, options ...ScreencastShowChapterOptions) error
+
+	// Enables visual annotations on interacted elements. Returns a disposable that stops showing actions when disposed.
+	ShowActions(options ...ScreencastShowActionsOptions) error
+
+	// Shows overlays.
+	ShowOverlays() error
+
+	// Removes action decorations.
+	HideActions() error
+
+	// Hides overlays without removing them.
+	HideOverlays() error
 }
 
 // Selectors can be used to install custom selector engines. See [extensibility] for more

--- a/generated-structs.go
+++ b/generated-structs.go
@@ -646,6 +646,20 @@ type BrowserNewPageOptions struct {
 	Viewport *Size `json:"viewport"`
 }
 
+type Bind struct {
+	Endpoint string `json:"endpoint"`
+}
+
+type BrowserBindOptions struct {
+	// Host to bind the web socket server to. When specified, a web socket server is created instead of a named pipe.
+	Host *string `json:"host"`
+	// Port to bind the web socket server to. When specified, a web socket server is created instead of a named pipe. Use
+	// `0` to let the OS pick an available port.
+	Port *int `json:"port"`
+	// Working directory associated with this browser server.
+	WorkspaceDir *string `json:"workspaceDir"`
+}
+
 type BrowserStartTracingOptions struct {
 	// specify custom categories to use instead of default.
 	Categories []string `json:"categories"`
@@ -819,6 +833,9 @@ type BrowserTypeConnectOptions struct {
 type BrowserTypeConnectOverCDPOptions struct {
 	// Additional HTTP headers to be sent with connect request. Optional.
 	Headers map[string]string `json:"headers"`
+	// Tells Playwright that it runs on the same host as the CDP server. It will enable certain optimizations that rely
+	// upon the file system being the same between Playwright and the Browser.
+	IsLocal *bool `json:"isLocal"`
 	// Slows down Playwright operations by the specified amount of milliseconds. Useful so that you can see what is going
 	// on. Defaults to 0.
 	SlowMo *float64 `json:"slowMo"`
@@ -834,6 +851,10 @@ type BrowserTypeLaunchOptions struct {
 	//
 	// [here]: https://peter.sh/experiments/chromium-command-line-switches/
 	Args []string `json:"args"`
+	// If specified, artifacts (traces, videos, downloads, HAR files, etc.) are saved into this directory. The directory
+	// is not cleaned up when the browser closes. If not specified, a temporary directory is used and cleaned up when the
+	// browser closes.
+	ArtifactsDir *string `json:"artifactsDir"`
 	// Browser distribution channel.
 	// Use "chromium" to [opt in to new headless mode].
 	// Use "chrome", "chrome-beta", "chrome-dev", "chrome-canary", "msedge", "msedge-beta", "msedge-dev", or
@@ -844,13 +865,6 @@ type BrowserTypeLaunchOptions struct {
 	Channel *string `json:"channel"`
 	// Enable Chromium sandboxing. Defaults to `false`.
 	ChromiumSandbox *bool `json:"chromiumSandbox"`
-	// **Chromium-only** Whether to auto-open a Developer Tools panel for each tab. If this option is `true`, the
-	// “[object Object]” option will be set `false`.
-	//
-	// Deprecated: Use [debugging tools] instead.
-	//
-	// [debugging tools]: https://playwright.dev/docs/debug
-	Devtools *bool `json:"devtools"`
 	// If specified, accepted downloads are downloaded into this directory. Otherwise, temporary directory is created and
 	// is deleted when browser is closed. In either case, the downloads are deleted when the browser context they were
 	// created in is closed.
@@ -877,8 +891,7 @@ type BrowserTypeLaunchOptions struct {
 	HandleSIGTERM *bool `json:"handleSIGTERM"`
 	// Whether to run browser in headless mode. More details for
 	// [Chromium] and
-	// [Firefox]. Defaults to `true` unless the
-	// “[object Object]” option is `true`.
+	// [Firefox]. Defaults to `true`.
 	//
 	// [Chromium]: https://developers.google.com/web/updates/2017/04/headless-chrome
 	// [Firefox]: https://hacks.mozilla.org/2017/12/using-headless-mode-in-firefox/
@@ -910,6 +923,10 @@ type BrowserTypeLaunchPersistentContextOptions struct {
 	//
 	// [here]: https://peter.sh/experiments/chromium-command-line-switches/
 	Args []string `json:"args"`
+	// If specified, artifacts (traces, videos, downloads, HAR files, etc.) are saved into this directory. The directory
+	// is not cleaned up when the browser closes. If not specified, a temporary directory is used and cleaned up when the
+	// browser closes.
+	ArtifactsDir *string `json:"artifactsDir"`
 	// When using [Page.Goto], [Page.Route], [Page.WaitForURL], [Page.ExpectRequest], or [Page.ExpectResponse] it takes
 	// the base URL in consideration by using the [`URL()`]
 	// constructor for building the corresponding URL. Unset by default. Examples:
@@ -958,13 +975,6 @@ type BrowserTypeLaunchPersistentContextOptions struct {
 	//
 	// [emulating devices with device scale factor]: https://playwright.dev/docs/emulation#devices
 	DeviceScaleFactor *float64 `json:"deviceScaleFactor"`
-	// **Chromium-only** Whether to auto-open a Developer Tools panel for each tab. If this option is `true`, the
-	// “[object Object]” option will be set `false`.
-	//
-	// Deprecated: Use [debugging tools] instead.
-	//
-	// [debugging tools]: https://playwright.dev/docs/debug
-	Devtools *bool `json:"devtools"`
 	// If specified, accepted downloads are downloaded into this directory. Otherwise, temporary directory is created and
 	// is deleted when browser is closed. In either case, the downloads are deleted when the browser context they were
 	// created in is closed.
@@ -1002,8 +1012,7 @@ type BrowserTypeLaunchPersistentContextOptions struct {
 	HasTouch *bool `json:"hasTouch"`
 	// Whether to run browser in headless mode. More details for
 	// [Chromium] and
-	// [Firefox]. Defaults to `true` unless the
-	// “[object Object]” option is `true`.
+	// [Firefox]. Defaults to `true`.
 	//
 	// [Chromium]: https://developers.google.com/web/updates/2017/04/headless-chrome
 	// [Firefox]: https://hacks.mozilla.org/2017/12/using-headless-mode-in-firefox/
@@ -1123,6 +1132,17 @@ type ConsoleMessageLocation struct {
 	LineNumber int `json:"lineNumber"`
 	// 0-based column number in the resource.
 	ColumnNumber int `json:"columnNumber"`
+}
+
+type PausedDetail struct {
+	Location *PausedDetailLocation `json:"location"`
+	Title    string                `json:"title"`
+}
+
+type DebuggerLocation struct {
+	File   string `json:"file"`
+	Line   *int   `json:"line"`
+	Column *int   `json:"column"`
 }
 
 type Rect struct {
@@ -2134,7 +2154,7 @@ type FrameExpectNavigationOptions struct {
 	// be changed by using the [BrowserContext.SetDefaultNavigationTimeout], [BrowserContext.SetDefaultTimeout],
 	// [Page.SetDefaultNavigationTimeout] or [Page.SetDefaultTimeout] methods.
 	Timeout *float64 `json:"timeout"`
-	// A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if
+	// A glob pattern, regex pattern, or predicate receiving [URL] to match while waiting for the navigation. Note that if
 	// the parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly
 	// equal to the string.
 	URL any `json:"url"`
@@ -2295,6 +2315,11 @@ type KeyboardTypeOptions struct {
 }
 
 type LocatorAriaSnapshotOptions struct {
+	// When specified, limits the depth of the snapshot.
+	Depth *int `json:"depth"`
+	// When set to `"ai"`, returns a snapshot optimized for AI consumption. Defaults to `"default"`. See details for more
+	// information.
+	Mode *AriaSnapshotMode `json:"mode"`
 	// Maximum time in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can
 	// be changed by using the [BrowserContext.SetDefaultTimeout] or [Page.SetDefaultTimeout] methods.
 	Timeout *float64 `json:"timeout"`
@@ -3616,6 +3641,11 @@ type PageIsVisibleOptions struct {
 	Timeout *float64 `json:"timeout"`
 }
 
+type PageConsoleMessagesOptions struct {
+	// Controls which messages are returned:
+	Filter *ConsoleMessagesFilter `json:"filter"`
+}
+
 type PageLocatorOptions struct {
 	// Narrows down the results of the method to those which contain elements matching this relative locator. For example,
 	// `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
@@ -3869,6 +3899,17 @@ type PageSetInputFilesOptions struct {
 	Timeout *float64 `json:"timeout"`
 }
 
+type PageAriaSnapshotOptions struct {
+	// When specified, limits the depth of the snapshot.
+	Depth *int `json:"depth"`
+	// When set to `"ai"`, returns a snapshot optimized for AI consumption: including element references like `[ref=e2]`
+	// and snapshots of `<iframe>`s. Defaults to `"default"`.
+	Mode *AriaSnapshotMode `json:"mode"`
+	// Maximum time in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can
+	// be changed by using the [BrowserContext.SetDefaultTimeout] or [Page.SetDefaultTimeout] methods.
+	Timeout *float64 `json:"timeout"`
+}
+
 type PageTapOptions struct {
 	// Whether to bypass the [actionability] checks. Defaults to `false`.
 	//
@@ -4027,7 +4068,7 @@ type PageExpectNavigationOptions struct {
 	// be changed by using the [BrowserContext.SetDefaultNavigationTimeout], [BrowserContext.SetDefaultTimeout],
 	// [Page.SetDefaultNavigationTimeout] or [Page.SetDefaultTimeout] methods.
 	Timeout *float64 `json:"timeout"`
-	// A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if
+	// A glob pattern, regex pattern, or predicate receiving [URL] to match while waiting for the navigation. Note that if
 	// the parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly
 	// equal to the string.
 	URL any `json:"url"`
@@ -4261,6 +4302,37 @@ type RouteFulfillOptions struct {
 	Status *int `json:"status"`
 }
 
+type ScreencastStartOptions struct {
+	// Callback that receives JPEG-encoded frame data.
+	OnFrame func(OnFrame) `json:"onFrame"`
+	// Path where the video should be saved when the screencast is stopped. When provided, video recording is started.
+	Path *string `json:"path"`
+	// The quality of the image, between 0-100.
+	Quality *int `json:"quality"`
+}
+
+type ScreencastShowOverlayOptions struct {
+	// Duration in milliseconds after which the overlay is automatically removed. Overlay stays until dismissed if not
+	// provided.
+	Duration *float64 `json:"duration"`
+}
+
+type ScreencastShowChapterOptions struct {
+	// Optional description text displayed below the title.
+	Description *string `json:"description"`
+	// Duration in milliseconds after which the overlay is automatically removed. Defaults to `2000`.
+	Duration *float64 `json:"duration"`
+}
+
+type ScreencastShowActionsOptions struct {
+	// How long each annotation is displayed in milliseconds. Defaults to `500`.
+	Duration *float64 `json:"duration"`
+	// Font size of the action title in pixels. Defaults to `24`.
+	FontSize *int `json:"fontSize"`
+	// Position of the action title overlay. Defaults to `"top-right"`.
+	Position *AnnotatePosition `json:"position"`
+}
+
 type SelectorsRegisterOptions struct {
 	// Whether to run this selector engine in isolated JavaScript environment. This environment has access to the same
 	// DOM, but not any JavaScript objects from the frame's scripts. Defaults to `false`. Note that running as a content
@@ -4269,6 +4341,10 @@ type SelectorsRegisterOptions struct {
 }
 
 type TracingStartOptions struct {
+	// When enabled, the trace is written to an unarchived file that is updated in real time as actions occur, instead of
+	// caching changes and archiving them into a zip file at the end. This is useful for live trace viewing during test
+	// execution.
+	Live *bool `json:"live"`
 	// If specified, intermediate trace files are going to be saved into the files with the given name prefix inside the
 	// “[object Object]” directory specified in [BrowserType.Launch]. To specify the final trace zip file name, you need
 	// to pass `path` option to [Tracing.Stop] instead.
@@ -4376,12 +4452,15 @@ type Origin struct {
 }
 
 type RecordVideo struct {
-	// Path to the directory to put videos into.
-	Dir string `json:"dir"`
+	// Path to the directory to put videos into. If not specified, the videos will be stored in `artifactsDir` (see
+	// [BrowserType.Launch] options).
+	Dir *string `json:"dir"`
 	// Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to
 	// fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of
 	// each page will be scaled down if necessary to fit the specified size.
 	Size *Size `json:"size"`
+	// If specified, enables visual annotations on interacted elements during video recording.
+	ShowActions *ShowAction `json:"showActions"`
 }
 
 type OptionalStorageState struct {
@@ -4389,6 +4468,12 @@ type OptionalStorageState struct {
 	Cookies []OptionalCookie `json:"cookies"`
 	// localStorage to set for context
 	Origins []Origin `json:"origins"`
+}
+
+type PausedDetailLocation struct {
+	File   string `json:"file"`
+	Line   *int   `json:"line"`
+	Column *int   `json:"column"`
 }
 
 type Position struct {
@@ -4407,8 +4492,22 @@ type Margin struct {
 	Left *string `json:"left"`
 }
 
+type OnFrame struct {
+	// JPEG-encoded frame data.
+	Data []byte `json:"data"`
+}
+
 type TracingGroupOptionsLocation struct {
 	File   string `json:"file"`
 	Line   *int   `json:"line"`
 	Column *int   `json:"column"`
+}
+
+type ShowAction struct {
+	// How long each annotation is displayed in milliseconds. Defaults to `500`.
+	Duration *float64 `json:"duration"`
+	// Position of the action title overlay. Defaults to `"top-right"`.
+	Position *AnnotatePosition `json:"position"`
+	// Font size of the action title in pixels. Defaults to `24`.
+	FontSize *int `json:"fontSize"`
 }

--- a/helpers.go
+++ b/helpers.go
@@ -21,7 +21,8 @@ func skipFieldSerialization(val reflect.Value) bool {
 	return (typ.Kind() == reflect.Pointer ||
 		typ.Kind() == reflect.Interface ||
 		typ.Kind() == reflect.Map ||
-		typ.Kind() == reflect.Slice) && val.IsNil() || (val.Kind() == reflect.Interface && val.Elem().Kind() == reflect.Pointer && val.Elem().IsNil())
+		typ.Kind() == reflect.Slice ||
+		typ.Kind() == reflect.Func) && val.IsNil() || (val.Kind() == reflect.Interface && val.Elem().Kind() == reflect.Pointer && val.Elem().IsNil())
 }
 
 func transformStructValues(in any) any {

--- a/locator.go
+++ b/locator.go
@@ -646,7 +646,8 @@ func (l *locatorImpl) Locator(selectorOrLocator any, options ...LocatorLocatorOp
 			l.err = errors.Join(l.err, ErrLocatorNotSameFrame)
 			return l
 		}
-		return newLocator(l.frame,
+		return newLocator(
+			l.frame,
 			l.selector+" >> internal:chain="+escapeText(locator.selector),
 			option,
 		)
@@ -929,4 +930,17 @@ func (l *locatorImpl) expect(expression string, options frameExpectOptions) (*fr
 		}
 	}
 	return &frameExpectResult{Received: received, Matches: matches, Log: log}, nil
+}
+
+func (l *locatorImpl) Normalize() Locator {
+	result, err := l.frame.channel.Send("resolveSelector", map[string]any{
+		"selector": l.selector,
+	})
+	if err != nil {
+		return l
+	}
+	if selector, ok := result.(string); ok {
+		return newLocator(l.frame, selector)
+	}
+	return l
 }

--- a/objectFactory.go
+++ b/objectFactory.go
@@ -31,6 +31,8 @@ func createObjectFactory(parent *channelOwner, objectType string, guid string, i
 		return newBrowserType(parent, objectType, guid, initializer)
 	case "BrowserContext":
 		return newBrowserContext(parent, objectType, guid, initializer)
+	case "Debugger":
+		return newDebugger(parent, objectType, guid, initializer)
 	case "CDPSession":
 		return newCDPSession(parent, objectType, guid, initializer)
 	case "Dialog":
@@ -79,6 +81,10 @@ func createObjectFactory(parent *channelOwner, objectType string, guid string, i
 		return newWorker(parent, objectType, guid, initializer)
 	case "WritableStream":
 		return newWritableStream(parent, objectType, guid, initializer)
+	// Disposable objects are sent by the driver but not exposed in Go API.
+	// Methods returning Disposable in JS return only error in Go.
+	case "Disposable":
+		return newDisposable(parent, objectType, guid, initializer)
 	default:
 		panic(objectType)
 	}

--- a/page.go
+++ b/page.go
@@ -131,7 +131,7 @@ func (p *pageImpl) Close(options ...PageCloseOptions) error {
 	if err == nil && p.ownedContext != nil {
 		err = p.ownedContext.Close()
 	}
-	if errors.Is(err, ErrTargetClosed) || (len(options) == 1 && options[0].RunBeforeUnload != nil && *(options[0].RunBeforeUnload)) {
+	if errors.Is(err, ErrTargetClosed) || (len(options) == 1 && options[0].RunBeforeUnload != nil && *options[0].RunBeforeUnload) {
 		return nil
 	}
 	return err
@@ -747,7 +747,7 @@ func (p *pageImpl) Keyboard() Keyboard {
 	return p.keyboard
 }
 
-func (p *pageImpl) ConsoleMessages() ([]ConsoleMessage, error) {
+func (p *pageImpl) ConsoleMessages(options ...PageConsoleMessagesOptions) ([]ConsoleMessage, error) {
 	result, err := p.channel.Send("consoleMessages", nil)
 	if err != nil {
 		return nil, err
@@ -868,10 +868,11 @@ func newPage(parent *channelOwner, objectType string, guid string, initializer m
 		artifact := fromChannel(ev["artifact"]).(*artifactImpl)
 		bt.Emit("download", newDownload(bt, url, suggestedFilename, artifact))
 	})
-	bt.channel.On("video", func(params map[string]any) {
-		artifact := fromChannel(params["artifact"]).(*artifactImpl)
+	// PW 1.59+: video artifact comes from page initializer
+	if videoChannel, ok := initializer["video"]; ok && videoChannel != nil {
+		artifact := fromChannel(videoChannel).(*artifactImpl)
 		bt.Video().(*videoImpl).artifactReady(artifact)
-	})
+	}
 	bt.channel.On("webSocket", func(ev map[string]any) {
 		bt.Emit("websocket", fromChannel(ev["webSocket"]).(*webSocketImpl))
 	})
@@ -1408,4 +1409,42 @@ func (p *pageImpl) updateWebSocketInterceptionPatterns() error {
 		"patterns": patterns,
 	})
 	return err
+}
+
+func (p *pageImpl) AriaSnapshot(options ...PageAriaSnapshotOptions) (string, error) {
+	result, err := p.mainFrame.(*frameImpl).channel.Send("ariaSnapshot", options)
+	if err != nil {
+		return "", err
+	}
+	return result.(string), nil
+}
+
+func (p *pageImpl) ClearConsoleMessages() error {
+	_, err := p.channel.Send("clearConsoleMessages")
+	return err
+}
+
+func (p *pageImpl) ClearPageErrors() error {
+	_, err := p.channel.Send("clearPageErrors")
+	return err
+}
+
+func (p *pageImpl) PageErrors() ([]string, error) {
+	result, err := p.channel.Send("pageErrors")
+	if err != nil {
+		return nil, err
+	}
+	items := result.([]any)
+	errors := make([]string, len(items))
+	for i, item := range items {
+		se := item.(map[string]any)
+		if errObj, ok := se["error"].(map[string]any); ok {
+			errors[i] = errObj["message"].(string)
+		}
+	}
+	return errors, nil
+}
+
+func (p *pageImpl) Screencast() (Screencast, error) {
+	return &screencastImpl{page: p}, nil
 }

--- a/patches/main.patch
+++ b/patches/main.patch
@@ -259,7 +259,7 @@ index c96e01991..8f6f30ab7 100644
  
  Set to `true` to include IndexedDB in the storage state snapshot.
 diff --git a/docs/src/api/class-apiresponse.md b/docs/src/api/class-apiresponse.md
-index 468a5a830..02fce8852 100644
+index d439df999..c29504727 100644
 --- a/docs/src/api/class-apiresponse.md
 +++ b/docs/src/api/class-apiresponse.md
 @@ -66,7 +66,7 @@ Headers with multiple entries, such as `Set-Cookie`, appear in the array multipl
@@ -272,10 +272,10 @@ index 468a5a830..02fce8852 100644
  
  Returns the JSON representation of response body.
 diff --git a/docs/src/api/class-apiresponseassertions.md b/docs/src/api/class-apiresponseassertions.md
-index 9584365d8..35ce3c1bc 100644
+index 720b3dcd4..16ff648da 100644
 --- a/docs/src/api/class-apiresponseassertions.md
 +++ b/docs/src/api/class-apiresponseassertions.md
-@@ -48,7 +48,7 @@ def test_navigates_to_login_page(page: Page) -> None:
+@@ -66,7 +66,7 @@ public class ExampleTests : PageTest
  
  ## property: APIResponseAssertions.not
  * since: v1.20
@@ -283,9 +283,9 @@ index 9584365d8..35ce3c1bc 100644
 +* langs: java, js, csharp, go
  - returns: <[APIResponseAssertions]>
  
- Makes the assertion check for the opposite condition. For example, this code tests that the response status is not successful:
+ Makes the assertion check for the opposite condition.
 diff --git a/docs/src/api/class-browser.md b/docs/src/api/class-browser.md
-index 7867ce5c8..6a27ede39 100644
+index 74759f3ce..6298dd7c8 100644
 --- a/docs/src/api/class-browser.md
 +++ b/docs/src/api/class-browser.md
 @@ -261,6 +261,9 @@ await browser.CloseAsync();
@@ -308,7 +308,7 @@ index 7867ce5c8..6a27ede39 100644
  ### option: Browser.newPage.storageState = %%-csharp-java-context-option-storage-state-%%
  * since: v1.8
  
-@@ -311,7 +317,7 @@ Allows to wait for async listeners to complete or to ignore subsequent errors fr
+@@ -349,7 +355,7 @@ Allows to wait for async listeners to complete or to ignore subsequent errors fr
  
  ## async method: Browser.startTracing
  * since: v1.11
@@ -317,7 +317,7 @@ index 7867ce5c8..6a27ede39 100644
  
  :::note
  This API controls [Chromium Tracing](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool) which is a low-level chromium-specific debugging tool. API to control [Playwright Tracing](../trace-viewer) could be found [here](./class-tracing).
-@@ -349,10 +355,18 @@ browser.stop_tracing()
+@@ -387,10 +393,18 @@ browser.stop_tracing()
  
  ### param: Browser.startTracing.page
  * since: v1.11
@@ -336,7 +336,7 @@ index 7867ce5c8..6a27ede39 100644
  ### option: Browser.startTracing.path
  * since: v1.11
  - `path` <[path]>
-@@ -373,7 +387,7 @@ specify custom categories to use instead of default.
+@@ -411,7 +425,7 @@ specify custom categories to use instead of default.
  
  ## async method: Browser.stopTracing
  * since: v1.11
@@ -346,10 +346,10 @@ index 7867ce5c8..6a27ede39 100644
  
  :::note
 diff --git a/docs/src/api/class-browsercontext.md b/docs/src/api/class-browsercontext.md
-index 3e7529c48..0d433c687 100644
+index c1e034ec3..c488b1a65 100644
 --- a/docs/src/api/class-browsercontext.md
 +++ b/docs/src/api/class-browsercontext.md
-@@ -389,7 +389,7 @@ The order of evaluation of multiple scripts installed via [`method: BrowserConte
+@@ -396,7 +396,7 @@ The order of evaluation of multiple scripts installed via [`method: BrowserConte
  
  ### param: BrowserContext.addInitScript.script
  * since: v1.8
@@ -358,7 +358,16 @@ index 3e7529c48..0d433c687 100644
  - `script` <[function]|[string]|[Object]>
    - `path` ?<[path]> Path to the JavaScript file. If `path` is a relative path, then it is resolved relative to the
      current working directory. Optional.
-@@ -1186,7 +1186,7 @@ handler function to route the request.
+@@ -1197,7 +1197,7 @@ A glob pattern, regex pattern, URL pattern, or predicate that receives a [URL] t
+ 
+ ### param: BrowserContext.route.url
+ * since: v1.8
+-* langs: python, csharp, java
++* langs: python, csharp, java, go
+ - `url` <[string]|[RegExp]|[function]\([URL]\):[boolean]>
+ 
+ A glob pattern, regex pattern, or predicate that receives a [URL] to match during routing. If [`option: Browser.newContext.baseURL`] is set in the context options and the provided URL is a string that does not start with `*`, it is resolved using the [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor.
+@@ -1211,7 +1211,7 @@ handler function to route the request.
  
  ### param: BrowserContext.route.handler
  * since: v1.8
@@ -367,7 +376,7 @@ index 3e7529c48..0d433c687 100644
  - `handler` <[function]\([Route]\)>
  
  handler function to route the request.
-@@ -1329,7 +1329,7 @@ Handler function to route the WebSocket.
+@@ -1354,7 +1354,7 @@ Handler function to route the WebSocket.
  
  ### param: BrowserContext.routeWebSocket.handler
  * since: v1.48
@@ -376,7 +385,7 @@ index 3e7529c48..0d433c687 100644
  - `handler` <[function]\([WebSocketRoute]\)>
  
  Handler function to route the WebSocket.
-@@ -1337,7 +1337,7 @@ Handler function to route the WebSocket.
+@@ -1362,7 +1362,7 @@ Handler function to route the WebSocket.
  
  ## method: BrowserContext.serviceWorkers
  * since: v1.11
@@ -385,7 +394,7 @@ index 3e7529c48..0d433c687 100644
  - returns: <[Array]<[Worker]>>
  
  :::note
-@@ -1477,6 +1477,7 @@ Whether to emulate network being offline for the browser context.
+@@ -1502,6 +1502,7 @@ Whether to emulate network being offline for the browser context.
      - `httpOnly` <[boolean]>
      - `secure` <[boolean]>
      - `sameSite` <[SameSiteAttribute]<"Strict"|"Lax"|"None">>
@@ -393,7 +402,7 @@ index 3e7529c48..0d433c687 100644
    - `origins` <[Array]<[Object]>>
      - `origin` <[string]>
      - `localStorage` <[Array]<[Object]>>
-@@ -1495,6 +1496,7 @@ Returns storage state for this browser context, contains current cookies, local
+@@ -1520,6 +1521,7 @@ Returns storage state for this browser context, contains current cookies, local
  
  ### option: BrowserContext.storageState.indexedDB
  * since: v1.51
@@ -401,7 +410,16 @@ index 3e7529c48..0d433c687 100644
  - `indexedDB` ?<boolean>
  
  Set to `true` to include [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) in the storage state snapshot.
-@@ -1532,6 +1534,13 @@ A glob pattern, regex pattern or predicate receiving [URL] used to register a ro
+@@ -1593,7 +1595,7 @@ A glob pattern, regex pattern, URL pattern, or predicate receiving [URL] used to
+ 
+ ### param: BrowserContext.unroute.url
+ * since: v1.8
+-* langs: python, csharp, java
++* langs: python, csharp, java, go
+ - `url` <[string]|[RegExp]|[function]\([URL]\):[boolean]>
+ 
+ A glob pattern, regex pattern, or predicate receiving [URL] used to register a routing with
+@@ -1606,6 +1608,13 @@ A glob pattern, regex pattern, or predicate receiving [URL] used to register a r
  
  Optional handler function used to register a routing with [`method: BrowserContext.route`].
  
@@ -415,7 +433,7 @@ index 3e7529c48..0d433c687 100644
  ### param: BrowserContext.unroute.handler
  * since: v1.8
  * langs: csharp, java
-@@ -1573,7 +1582,8 @@ Condition to wait for.
+@@ -1647,7 +1656,8 @@ Condition to wait for.
  
  ## async method: BrowserContext.waitForConsoleMessage
  * since: v1.34
@@ -425,7 +443,7 @@ index 3e7529c48..0d433c687 100644
    - alias-python: expect_console_message
    - alias-csharp: RunAndWaitForConsoleMessage
  - returns: <[ConsoleMessage]>
-@@ -1604,7 +1614,8 @@ Receives the [ConsoleMessage] object and resolves to truthy value when the waiti
+@@ -1678,7 +1688,8 @@ Receives the [ConsoleMessage] object and resolves to truthy value when the waiti
  
  ## async method: BrowserContext.waitForEvent
  * since: v1.8
@@ -435,7 +453,7 @@ index 3e7529c48..0d433c687 100644
    - alias-python: expect_event
  - returns: <[any]>
  
-@@ -1670,7 +1681,8 @@ Either a predicate that receives an event or an options object. Optional.
+@@ -1744,7 +1755,8 @@ Either a predicate that receives an event or an options object. Optional.
  
  ## async method: BrowserContext.waitForPage
  * since: v1.9
@@ -445,7 +463,7 @@ index 3e7529c48..0d433c687 100644
    - alias-python: expect_page
    - alias-csharp: RunAndWaitForPage
  - returns: <[Page]>
-@@ -1689,7 +1701,7 @@ Will throw an error if the context closes before new [Page] is created.
+@@ -1763,7 +1775,7 @@ Will throw an error if the context closes before new [Page] is created.
  
  ### option: BrowserContext.waitForPage.predicate
  * since: v1.9
@@ -454,7 +472,7 @@ index 3e7529c48..0d433c687 100644
  - `predicate` <[function]\([Page]\):[boolean]>
  
  Receives the [Page] object and resolves to truthy value when the waiting should resolve.
-@@ -1702,7 +1714,8 @@ Receives the [Page] object and resolves to truthy value when the waiting should
+@@ -1776,7 +1788,8 @@ Receives the [Page] object and resolves to truthy value when the waiting should
  
  ## async method: BrowserContext.waitForEvent2
  * since: v1.8
@@ -465,10 +483,10 @@ index 3e7529c48..0d433c687 100644
  - returns: <[any]>
  
 diff --git a/docs/src/api/class-cdpsession.md b/docs/src/api/class-cdpsession.md
-index a14dd58fb..8e3807d87 100644
+index d14b51a86..4e0959473 100644
 --- a/docs/src/api/class-cdpsession.md
 +++ b/docs/src/api/class-cdpsession.md
-@@ -102,7 +102,7 @@ Optional method parameters.
+@@ -126,7 +126,7 @@ Optional method parameters.
  
  ### param: CDPSession.send.params
  * since: v1.30
@@ -518,7 +536,7 @@ index e5610b424..748b93b68 100644
  - `time` <[float]|[string]|[Date]>
  
 diff --git a/docs/src/api/class-consolemessage.md b/docs/src/api/class-consolemessage.md
-index b712bca26..4a164b95e 100644
+index 0a389a598..0656442c4 100644
 --- a/docs/src/api/class-consolemessage.md
 +++ b/docs/src/api/class-consolemessage.md
 @@ -112,7 +112,7 @@ List of arguments passed to a `console` function call. See also [`event: Page.co
@@ -541,10 +559,10 @@ index b712bca26..4a164b95e 100644
 +
 +The text of the console message.
 +
- ## method: ConsoleMessage.type
- * since: v1.8
- * langs: js, python
-@@ -144,7 +151,7 @@ The text of the console message.
+ ## method: ConsoleMessage.timestamp
+ * since: v1.59
+ - returns: <[float]>
+@@ -150,7 +157,7 @@ The timestamp of the console message in milliseconds since the Unix epoch.
  
  ## method: ConsoleMessage.type
  * since: v1.8
@@ -554,7 +572,7 @@ index b712bca26..4a164b95e 100644
  
  One of the following values: `'log'`, `'debug'`, `'info'`, `'error'`, `'warning'`, `'dir'`, `'dirxml'`, `'table'`,
 diff --git a/docs/src/api/class-frame.md b/docs/src/api/class-frame.md
-index f9c366e42..678bf3e65 100644
+index 531901bcb..0ba39e83e 100644
 --- a/docs/src/api/class-frame.md
 +++ b/docs/src/api/class-frame.md
 @@ -283,6 +283,9 @@ When all steps combined have not finished during the specified [`option: timeout
@@ -597,10 +615,19 @@ index f9c366e42..678bf3e65 100644
    * alias-csharp: RunAndWaitForNavigation
  - returns: <[null]|[Response]>
 diff --git a/docs/src/api/class-locator.md b/docs/src/api/class-locator.md
-index 042c08bb9..a1925c73d 100644
+index 25f025121..87a8a1897 100644
 --- a/docs/src/api/class-locator.md
 +++ b/docs/src/api/class-locator.md
-@@ -1006,7 +1006,7 @@ Optional argument to pass to [`param: expression`].
+@@ -645,7 +645,7 @@ Locator description.
+ 
+ ## method: Locator.description
+ * since: v1.57
+-* langs: python, java, csharp
++* langs: python, java, csharp, go
+ - returns: <[null]|[string]>
+ 
+ Returns locator description previously set with [`method: Locator.describe`]. Returns `null` if no custom description has been set.
+@@ -1033,7 +1033,7 @@ Optional argument to pass to [`param: expression`].
  
  ### option: Locator.evaluate.timeout
  * since: v1.14
@@ -609,7 +636,7 @@ index 042c08bb9..a1925c73d 100644
  - `timeout` <[float]>
  
  Maximum time in milliseconds to wait for the locator before evaluating. Note that after locator is resolved, evaluation itself is not limited by the timeout. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
-@@ -1103,7 +1103,7 @@ Optional argument to pass to [`param: expression`].
+@@ -1130,7 +1130,7 @@ Optional argument to pass to [`param: expression`].
  
  ### option: Locator.evaluateHandle.timeout
  * since: v1.14
@@ -619,7 +646,7 @@ index 042c08bb9..a1925c73d 100644
  
  Maximum time in milliseconds to wait for the locator before evaluating. Note that after locator is resolved, evaluation itself is not limited by the timeout. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
 diff --git a/docs/src/api/class-locatorassertions.md b/docs/src/api/class-locatorassertions.md
-index c2edbf753..2f0a348a0 100644
+index 2ab9ba50e..9f5dcadbe 100644
 --- a/docs/src/api/class-locatorassertions.md
 +++ b/docs/src/api/class-locatorassertions.md
 @@ -67,7 +67,7 @@ public class ExampleTests : PageTest
@@ -630,8 +657,8 @@ index c2edbf753..2f0a348a0 100644
 +* langs: java, js, csharp, go
  - returns: <[LocatorAssertions]>
  
- Makes the assertion check for the opposite condition. For example, this code tests that the Locator doesn't contain text `"error"`:
-@@ -1283,7 +1283,7 @@ Expected substring or RegExp or a list of those.
+ Makes the assertion check for the opposite condition.
+@@ -1287,7 +1287,7 @@ Expected substring or RegExp or a list of those.
  
  ### param: LocatorAssertions.toContainText.expected
  * since: v1.18
@@ -640,7 +667,7 @@ index c2edbf753..2f0a348a0 100644
  - `expected` <[string]|[RegExp]|[Array]<[string]>|[Array]<[RegExp]>|[Array]<[string]|[RegExp]>>
  
  Expected substring or RegExp or a list of those.
-@@ -1627,7 +1627,7 @@ Expected class or RegExp or a list of those.
+@@ -1631,7 +1631,7 @@ Expected class or RegExp or a list of those.
  
  ### param: LocatorAssertions.toHaveClass.expected
  * since: v1.18
@@ -649,7 +676,7 @@ index c2edbf753..2f0a348a0 100644
  - `expected` <[string]|[RegExp]|[Array]<[string]>|[Array]<[RegExp]>|[Array]<[string]|[RegExp]>>
  
  Expected class or RegExp or a list of those.
-@@ -2154,7 +2154,7 @@ Expected string or RegExp or a list of those.
+@@ -2158,7 +2158,7 @@ Expected string or RegExp or a list of those.
  
  ### param: LocatorAssertions.toHaveText.expected
  * since: v1.18
@@ -658,7 +685,7 @@ index c2edbf753..2f0a348a0 100644
  - `expected` <[string]|[RegExp]|[Array]<[string]>|[Array]<[RegExp]>|[Array]<[string]|[RegExp]>>
  
  Expected string or RegExp or a list of those.
-@@ -2288,7 +2288,7 @@ await Expect(locator).ToHaveValuesAsync(new Regex[] { new Regex("R"), new Regex(
+@@ -2292,7 +2292,7 @@ await Expect(locator).ToHaveValuesAsync(new Regex[] { new Regex("R"), new Regex(
  
  ### param: LocatorAssertions.toHaveValues.values
  * since: v1.23
@@ -668,10 +695,10 @@ index c2edbf753..2f0a348a0 100644
  
  Expected options currently selected.
 diff --git a/docs/src/api/class-page.md b/docs/src/api/class-page.md
-index 717cbf06c..a54492b22 100644
+index 89a46e0f5..b9f8e29f6 100644
 --- a/docs/src/api/class-page.md
 +++ b/docs/src/api/class-page.md
-@@ -614,7 +614,7 @@ The order of evaluation of multiple scripts installed via [`method: BrowserConte
+@@ -615,7 +615,7 @@ The order of evaluation of multiple scripts installed via [`method: BrowserConte
  
  ### param: Page.addInitScript.script
  * since: v1.8
@@ -680,7 +707,15 @@ index 717cbf06c..a54492b22 100644
  - `script` <[function]|[string]|[Object]>
    - `path` ?<[path]> Path to the JavaScript file. If `path` is a relative path, then it is resolved relative to the
      current working directory. Optional.
-@@ -808,6 +808,9 @@ When all steps combined have not finished during the specified [`option: timeout
+@@ -717,6 +717,7 @@ Brings page to front (activates tab).
+ 
+ ## async method: Page.cancelPickLocator
+ * since: v1.59
++* langs: js
+ 
+ Cancels an ongoing [`method: Page.pickLocator`] call by deactivating pick locator mode.
+ If no pick locator mode is active, this method is a no-op.
+@@ -815,6 +816,9 @@ When all steps combined have not finished during the specified [`option: timeout
  ### option: Page.click.trial = %%-input-trial-with-modifiers-%%
  * since: v1.11
  
@@ -690,7 +725,7 @@ index 717cbf06c..a54492b22 100644
  ## async method: Page.close
  * since: v1.8
  
-@@ -1263,6 +1266,14 @@ Passing `null` disables CSS media emulation.
+@@ -1270,6 +1274,14 @@ Passing `null` disables CSS media emulation.
  Changes the CSS media type of the page. The only allowed values are `'Screen'`, `'Print'` and `'Null'`.
  Passing `'Null'` disables CSS media emulation.
  
@@ -705,7 +740,7 @@ index 717cbf06c..a54492b22 100644
  ### option: Page.emulateMedia.colorScheme
  * since: v1.9
  * langs: js, java
-@@ -1279,6 +1290,14 @@ Emulates [prefers-colors-scheme](https://developer.mozilla.org/en-US/docs/Web/CS
+@@ -1286,6 +1298,14 @@ Emulates [prefers-colors-scheme](https://developer.mozilla.org/en-US/docs/Web/CS
  Emulates [prefers-colors-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) media feature, supported values are `'light'` and `'dark'`. Passing
  `'Null'` disables color scheme emulation. `'no-preference'` is deprecated.
  
@@ -720,7 +755,7 @@ index 717cbf06c..a54492b22 100644
  ### option: Page.emulateMedia.reducedMotion
  * since: v1.12
  * langs: js, java
-@@ -1293,6 +1312,13 @@ Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce
+@@ -1300,6 +1320,13 @@ Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce
  
  Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce'`, `'no-preference'`. Passing `null` disables reduced motion emulation.
  
@@ -734,7 +769,7 @@ index 717cbf06c..a54492b22 100644
  ### option: Page.emulateMedia.forcedColors
  * since: v1.15
  * langs: js, java
-@@ -1305,6 +1331,13 @@ Emulates `'forced-colors'` media feature, supported values are `'active'` and `'
+@@ -1312,6 +1339,13 @@ Emulates `'forced-colors'` media feature, supported values are `'active'` and `'
  * langs: csharp, python
  - `forcedColors` <[ForcedColors]<"active"|"none"|"null">>
  
@@ -748,7 +783,7 @@ index 717cbf06c..a54492b22 100644
  ### option: Page.emulateMedia.contrast
  * since: v1.51
  * langs: js, java
-@@ -1317,6 +1350,13 @@ Emulates `'prefers-contrast'` media feature, supported values are `'no-preferenc
+@@ -1324,6 +1358,13 @@ Emulates `'prefers-contrast'` media feature, supported values are `'no-preferenc
  * langs: csharp, python
  - `contrast` <[Contrast]<"no-preference"|"more"|"null">>
  
@@ -762,7 +797,7 @@ index 717cbf06c..a54492b22 100644
  ## async method: Page.evalOnSelector
  * since: v1.9
  * discouraged: This method does not wait for the element to pass actionability
-@@ -2136,14 +2176,14 @@ Frame name specified in the `iframe`'s `name` attribute.
+@@ -2145,14 +2186,14 @@ Frame name specified in the `iframe`'s `name` attribute.
  
  ### option: Page.frame.name
  * since: v1.8
@@ -779,7 +814,16 @@ index 717cbf06c..a54492b22 100644
  - `url` ?<[string]|[RegExp]|[function]\([URL]\):[boolean]>
  
  A glob pattern, regex pattern or predicate receiving frame's `url` as a [URL] object. Optional.
-@@ -2936,7 +2976,7 @@ Paper width, accepts values labeled with units.
+@@ -2717,7 +2758,7 @@ Returns up to (currently) 200 last page errors from this page. See [`event: Page
+ 
+ ## async method: Page.pageErrors
+ * since: v1.56
+-* langs: csharp, java
++* langs: csharp, java, go
+ - returns: <[Array]<[string]>>
+ 
+ Returns up to (currently) 200 last page errors from this page. See [`event: Page.pageError`] for more details.
+@@ -2971,7 +3012,7 @@ Paper width, accepts values labeled with units.
  
  ### option: Page.pdf.width
  * since: v1.8
@@ -788,7 +832,7 @@ index 717cbf06c..a54492b22 100644
  - `width` <[string]>
  
  Paper width, accepts values labeled with units.
-@@ -2950,7 +2990,7 @@ Paper height, accepts values labeled with units.
+@@ -2985,7 +3026,7 @@ Paper height, accepts values labeled with units.
  
  ### option: Page.pdf.height
  * since: v1.8
@@ -797,7 +841,7 @@ index 717cbf06c..a54492b22 100644
  - `height` <[string]>
  
  Paper height, accepts values labeled with units.
-@@ -2968,7 +3008,7 @@ Paper margins, defaults to none.
+@@ -3003,7 +3044,7 @@ Paper margins, defaults to none.
  
  ### option: Page.pdf.margin
  * since: v1.8
@@ -806,7 +850,15 @@ index 717cbf06c..a54492b22 100644
  - `margin` <[Object]>
    - `top` ?<[string]> Top margin, accepts values labeled with units. Defaults to `0`.
    - `right` ?<[string]> Right margin, accepts values labeled with units. Defaults to `0`.
-@@ -3400,7 +3440,7 @@ Function that should be run once [`param: locator`] appears. This function shoul
+@@ -3034,6 +3075,7 @@ Whether or not to embed the document outline into the PDF. Defaults to `false`.
+ 
+ ## async method: Page.pickLocator
+ * since: v1.59
++* langs: js
+ - returns: <[Locator]>
+ 
+ Enters pick locator mode where hovering over page elements highlights them and shows the corresponding locator.
+@@ -3469,7 +3511,7 @@ Function that should be run once [`param: locator`] appears. This function shoul
  Function that should be run once [`param: locator`] appears. This function should get rid of the element that blocks actions like click.
  
  ### param: Page.addLocatorHandler.handler
@@ -815,7 +867,16 @@ index 717cbf06c..a54492b22 100644
  * since: v1.42
  - `handler` <[function]\([Locator]\)>
  
-@@ -3646,6 +3686,13 @@ A glob pattern, regex pattern, or predicate that receives a [URL] to match durin
+@@ -3714,7 +3756,7 @@ A glob pattern, regex pattern, URL pattern, or predicate that receives a [URL] t
+ 
+ ### param: Page.route.url
+ * since: v1.8
+-* langs: python, csharp, java
++* langs: python, csharp, java, go
+ - `url` <[string]|[RegExp]|[function]\([URL]\):[boolean]>
+ 
+ A glob pattern, regex pattern, or predicate that receives a [URL] to match during routing. If [`option: Browser.newContext.baseURL`] is set in the context options and the provided URL is a string that does not start with `*`, it is resolved using the [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor.
+@@ -3726,6 +3768,13 @@ A glob pattern, regex pattern, or predicate that receives a [URL] to match durin
  
  handler function to route the request.
  
@@ -829,7 +890,16 @@ index 717cbf06c..a54492b22 100644
  ### param: Page.route.handler
  * since: v1.8
  * langs: csharp, java
-@@ -3780,7 +3827,7 @@ Handler function to route the WebSocket.
+@@ -3854,7 +3903,7 @@ Only WebSockets with the url matching this pattern will be routed. A string patt
+ 
+ ### param: Page.routeWebSocket.url
+ * since: v1.48
+-* langs: python, csharp, java
++* langs: python, csharp, java, go
+ - `url` <[string]|[RegExp]|[function]\([URL]\):[boolean]>
+ 
+ Only WebSockets with the url matching this pattern will be routed. A string pattern can be relative to the [`option: Browser.newContext.baseURL`] context option.
+@@ -3868,7 +3917,7 @@ Handler function to route the WebSocket.
  
  ### param: Page.routeWebSocket.handler
  * since: v1.48
@@ -838,7 +908,7 @@ index 717cbf06c..a54492b22 100644
  - `handler` <[function]\([WebSocketRoute]\)>
  
  Handler function to route the WebSocket.
-@@ -4109,14 +4156,14 @@ await page.GotoAsync("https://www.microsoft.com");
+@@ -4215,14 +4264,14 @@ await page.GotoAsync("https://www.microsoft.com");
  
  ### param: Page.setViewportSize.width
  * since: v1.10
@@ -855,7 +925,16 @@ index 717cbf06c..a54492b22 100644
  - `height` <[int]>
  
  Page height in pixels.
-@@ -4303,6 +4350,13 @@ A glob pattern, regex pattern or predicate receiving [URL] to match while routin
+@@ -4429,7 +4478,7 @@ A glob pattern, regex pattern, URL pattern, or predicate receiving [URL] to matc
+ 
+ ### param: Page.unroute.url
+ * since: v1.8
+-* langs: python, csharp, java
++* langs: python, csharp, java, go
+ - `url` <[string]|[RegExp]|[function]\([URL]\):[boolean]>
+ 
+ A glob pattern, regex pattern, or predicate receiving [URL] to match while routing.
+@@ -4441,6 +4490,13 @@ A glob pattern, regex pattern, or predicate receiving [URL] to match while routi
  
  Optional handler function to route the request.
  
@@ -869,7 +948,7 @@ index 717cbf06c..a54492b22 100644
  ### param: Page.unroute.handler
  * since: v1.8
  * langs: csharp, java
-@@ -4341,7 +4395,8 @@ Performs action and waits for the Page to close.
+@@ -4479,7 +4535,8 @@ Performs action and waits for the Page to close.
  
  ## async method: Page.waitForConsoleMessage
  * since: v1.9
@@ -879,7 +958,7 @@ index 717cbf06c..a54492b22 100644
    - alias-python: expect_console_message
    - alias-csharp: RunAndWaitForConsoleMessage
  - returns: <[ConsoleMessage]>
-@@ -4372,7 +4427,8 @@ Receives the [ConsoleMessage] object and resolves to truthy value when the waiti
+@@ -4510,7 +4567,8 @@ Receives the [ConsoleMessage] object and resolves to truthy value when the waiti
  
  ## async method: Page.waitForDownload
  * since: v1.9
@@ -889,7 +968,7 @@ index 717cbf06c..a54492b22 100644
    - alias-python: expect_download
    - alias-csharp: RunAndWaitForDownload
  - returns: <[Download]>
-@@ -4403,7 +4459,8 @@ Receives the [Download] object and resolves to truthy value when the waiting sho
+@@ -4541,7 +4599,8 @@ Receives the [Download] object and resolves to truthy value when the waiting sho
  
  ## async method: Page.waitForEvent
  * since: v1.8
@@ -899,7 +978,7 @@ index 717cbf06c..a54492b22 100644
    - alias-python: expect_event
  - returns: <[any]>
  
-@@ -4456,7 +4513,8 @@ Either a predicate that receives an event or an options object. Optional.
+@@ -4594,7 +4653,8 @@ Either a predicate that receives an event or an options object. Optional.
  
  ## async method: Page.waitForFileChooser
  * since: v1.9
@@ -909,7 +988,7 @@ index 717cbf06c..a54492b22 100644
    - alias-python: expect_file_chooser
    - alias-csharp: RunAndWaitForFileChooser
  - returns: <[FileChooser]>
-@@ -4614,7 +4672,7 @@ await page.WaitForFunctionAsync("selector => !!document.querySelector(selector)"
+@@ -4752,7 +4812,7 @@ await page.WaitForFunctionAsync("selector => !!document.querySelector(selector)"
  
  Optional argument to pass to [`param: expression`].
  
@@ -918,7 +997,7 @@ index 717cbf06c..a54492b22 100644
  * since: v1.8
  
  ### option: Page.waitForFunction.polling = %%-csharp-java-wait-for-function-polling-%%
-@@ -4711,6 +4769,11 @@ Console.WriteLine(await popup.TitleAsync()); // popup is ready to use.
+@@ -4849,6 +4909,11 @@ Console.WriteLine(await popup.TitleAsync()); // popup is ready to use.
  ```
  
  ### param: Page.waitForLoadState.state = %%-wait-for-load-state-state-%%
@@ -930,7 +1009,7 @@ index 717cbf06c..a54492b22 100644
  * since: v1.8
  
  ### option: Page.waitForLoadState.timeout = %%-navigation-timeout-%%
-@@ -4723,6 +4786,7 @@ Console.WriteLine(await popup.TitleAsync()); // popup is ready to use.
+@@ -4861,6 +4926,7 @@ Console.WriteLine(await popup.TitleAsync()); // popup is ready to use.
  * since: v1.8
  * deprecated: This method is inherently racy, please use [`method: Page.waitForURL`] instead.
  * langs:
@@ -938,7 +1017,7 @@ index 717cbf06c..a54492b22 100644
    * alias-python: expect_navigation
    * alias-csharp: RunAndWaitForNavigation
  - returns: <[null]|[Response]>
-@@ -4807,7 +4871,8 @@ a navigation.
+@@ -4948,7 +5014,8 @@ a navigation.
  
  ## async method: Page.waitForPopup
  * since: v1.9
@@ -948,7 +1027,7 @@ index 717cbf06c..a54492b22 100644
    - alias-python: expect_popup
    - alias-csharp: RunAndWaitForPopup
  - returns: <[Page]>
-@@ -4839,6 +4904,7 @@ Receives the [Page] object and resolves to truthy value when the waiting should
+@@ -4980,6 +5047,7 @@ Receives the [Page] object and resolves to truthy value when the waiting should
  ## async method: Page.waitForRequest
  * since: v1.8
  * langs:
@@ -956,7 +1035,7 @@ index 717cbf06c..a54492b22 100644
    * alias-python: expect_request
    * alias-csharp: RunAndWaitForRequest
  - returns: <[Request]>
-@@ -4946,7 +5012,8 @@ changed by using the [`method: Page.setDefaultTimeout`] method.
+@@ -5087,7 +5155,8 @@ changed by using the [`method: Page.setDefaultTimeout`] method.
  
  ## async method: Page.waitForRequestFinished
  * since: v1.12
@@ -966,7 +1045,7 @@ index 717cbf06c..a54492b22 100644
    - alias-python: expect_request_finished
    - alias-csharp: RunAndWaitForRequestFinished
  - returns: <[Request]>
-@@ -4978,6 +5045,7 @@ Receives the [Request] object and resolves to truthy value when the waiting shou
+@@ -5119,6 +5188,7 @@ Receives the [Request] object and resolves to truthy value when the waiting shou
  ## async method: Page.waitForResponse
  * since: v1.8
  * langs:
@@ -974,7 +1053,7 @@ index 717cbf06c..a54492b22 100644
    * alias-python: expect_response
    * alias-csharp: RunAndWaitForResponse
  - returns: <[Response]>
-@@ -5341,7 +5409,8 @@ await page.WaitForURLAsync("**/target.html");
+@@ -5485,7 +5555,8 @@ await page.WaitForURLAsync("**/target.html");
  
  ## async method: Page.waitForWebSocket
  * since: v1.9
@@ -984,7 +1063,7 @@ index 717cbf06c..a54492b22 100644
    - alias-python: expect_websocket
    - alias-csharp: RunAndWaitForWebSocket
  - returns: <[WebSocket]>
-@@ -5372,7 +5441,8 @@ Receives the [WebSocket] object and resolves to truthy value when the waiting sh
+@@ -5516,7 +5587,8 @@ Receives the [WebSocket] object and resolves to truthy value when the waiting sh
  
  ## async method: Page.waitForWorker
  * since: v1.9
@@ -994,7 +1073,7 @@ index 717cbf06c..a54492b22 100644
    - alias-python: expect_worker
    - alias-csharp: RunAndWaitForWorker
  - returns: <[Worker]>
-@@ -5414,7 +5484,8 @@ This does not contain ServiceWorkers
+@@ -5558,7 +5630,8 @@ This does not contain ServiceWorkers
  
  ## async method: Page.waitForEvent2
  * since: v1.8
@@ -1005,7 +1084,7 @@ index 717cbf06c..a54492b22 100644
  - returns: <[any]>
  
 diff --git a/docs/src/api/class-pageassertions.md b/docs/src/api/class-pageassertions.md
-index 6420735f2..7cfa9c3ca 100644
+index 7b0a983cb..776df4b4e 100644
 --- a/docs/src/api/class-pageassertions.md
 +++ b/docs/src/api/class-pageassertions.md
 @@ -69,7 +69,7 @@ public class ExampleTests : PageTest
@@ -1016,8 +1095,8 @@ index 6420735f2..7cfa9c3ca 100644
 +* langs: java, js, csharp, go
  - returns: <[PageAssertions]>
  
- Makes the assertion check for the opposite condition. For example, this code tests that the page URL doesn't contain `"error"`:
-@@ -344,7 +344,7 @@ When [`option: Browser.newContext.baseURL`] is provided via the context options
+ Makes the assertion check for the opposite condition.
+@@ -351,7 +351,7 @@ When [`option: Browser.newContext.baseURL`] is provided via the context options
  
  ### param: PageAssertions.toHaveURL.urlOrRegExp
  * since: v1.18
@@ -1062,7 +1141,7 @@ index aa4e0a42a..2b822104e 100644
  
  Creates a [PageAssertions] object for the given [Page].
 diff --git a/docs/src/api/class-request.md b/docs/src/api/class-request.md
-index e13d9de69..6fb14af3d 100644
+index 1ee132d79..20a7354ae 100644
 --- a/docs/src/api/class-request.md
 +++ b/docs/src/api/class-request.md
 @@ -126,6 +126,13 @@ Headers with multiple entries, such as `Set-Cookie`, appear in the array multipl
@@ -1089,7 +1168,7 @@ index e13d9de69..6fb14af3d 100644
  
  Returns parsed request's body for `form-urlencoded` and JSON as a fallback if any.
 diff --git a/docs/src/api/class-response.md b/docs/src/api/class-response.md
-index cddaf6965..6aa3225f5 100644
+index 9433109a0..5e3712eac 100644
 --- a/docs/src/api/class-response.md
 +++ b/docs/src/api/class-response.md
 @@ -23,7 +23,7 @@ Waits for this response to finish, returns always `null`.
@@ -1116,7 +1195,7 @@ index cddaf6965..6aa3225f5 100644
  ### param: Response.headerValue.name
  * since: v1.15
  - `name` <[string]>
-@@ -82,7 +90,7 @@ Name of the header.
+@@ -88,7 +96,7 @@ Returns the http version used by the response.
  
  ## async method: Response.json
  * since: v1.8
@@ -1126,10 +1205,10 @@ index cddaf6965..6aa3225f5 100644
  
  Returns the JSON representation of response body.
 diff --git a/docs/src/api/class-route.md b/docs/src/api/class-route.md
-index dbbe12149..db1c96d14 100644
+index 5bbe4b3f8..b7c9624c1 100644
 --- a/docs/src/api/class-route.md
 +++ b/docs/src/api/class-route.md
-@@ -131,7 +131,7 @@ If set changes the post data of request.
+@@ -134,7 +134,7 @@ If set changes the post data of request.
  
  ### option: Route.continue.postData
  * since: v1.8
@@ -1138,7 +1217,7 @@ index dbbe12149..db1c96d14 100644
  - `postData` <[string]|[Buffer]>
  
  If set changes the post data of request.
-@@ -418,7 +418,7 @@ If set changes the post data of request.
+@@ -421,7 +421,7 @@ If set changes the post data of request.
  
  ### option: Route.fallback.postData
  * since: v1.23
@@ -1147,7 +1226,7 @@ index dbbe12149..db1c96d14 100644
  - `postData` <[string]|[Buffer]>
  
  If set changes the post data of request.
-@@ -541,7 +541,7 @@ and `content-type` header will be set to `application/json` if not explicitly se
+@@ -544,7 +544,7 @@ and `content-type` header will be set to `application/json` if not explicitly se
  set to `application/octet-stream` if not explicitly set.
  
  ### option: Route.fetch.postData
@@ -1156,7 +1235,7 @@ index dbbe12149..db1c96d14 100644
  * since: v1.29
  - `postData` <[string]|[Buffer]>
  
-@@ -654,7 +654,7 @@ If set, equals to setting `Content-Type` response header.
+@@ -657,7 +657,7 @@ If set, equals to setting `Content-Type` response header.
  
  ### option: Route.fulfill.body
  * since: v1.8
@@ -1179,7 +1258,7 @@ index 4c3011430..4ced2d60d 100644
    - `path` ?<[path]> Path to the JavaScript file. If `path` is a relative path, then it is resolved relative to the
      current working directory. Optional.
 diff --git a/docs/src/api/class-tracing.md b/docs/src/api/class-tracing.md
-index 0528891fd..1323d2393 100644
+index 9c4b5221d..7b8187f6f 100644
 --- a/docs/src/api/class-tracing.md
 +++ b/docs/src/api/class-tracing.md
 @@ -156,7 +156,7 @@ If this option is true tracing will
@@ -1271,7 +1350,7 @@ index fcbe1b21f..dc6503e4f 100644
  * since: v1.48
  * langs: csharp, java
 diff --git a/docs/src/api/params.md b/docs/src/api/params.md
-index 37f6665a9..048201370 100644
+index 391504655..459c084da 100644
 --- a/docs/src/api/params.md
 +++ b/docs/src/api/params.md
 @@ -8,7 +8,7 @@ When to consider operation succeeded, defaults to `load`. Events can be either:
@@ -1378,7 +1457,7 @@ index 37f6665a9..048201370 100644
  - `storageStatePath` <[path]>
  
  Populates context with given storage state. This option can be used to initialize context with logged-in information
-@@ -388,7 +412,7 @@ Query parameters to be sent with the URL.
+@@ -420,7 +444,7 @@ Query parameters to be sent with the URL.
  Query parameters to be sent with the URL.
  
  ## csharp-fetch-option-params
@@ -1387,7 +1466,7 @@ index 37f6665a9..048201370 100644
  - `params` <[Object]<[string], [Serializable]>>
  
  Query parameters to be sent with the URL.
-@@ -406,19 +430,19 @@ Query parameters to be sent with the URL.
+@@ -438,19 +462,19 @@ Query parameters to be sent with the URL.
  Optional request parameters.
  
  ## js-python-csharp-fetch-option-headers
@@ -1410,7 +1489,7 @@ index 37f6665a9..048201370 100644
  - `failOnStatusCode` <[boolean]>
  
  Whether to throw on response codes other than 2xx and 3xx. By default response object is returned
-@@ -450,6 +474,14 @@ unless explicitly provided.
+@@ -482,6 +506,14 @@ unless explicitly provided.
  
  An instance of [FormData] can be created via [`method: APIRequestContext.createFormData`].
  
@@ -1425,7 +1504,7 @@ index 37f6665a9..048201370 100644
  ## js-fetch-option-multipart
  * langs: js
  - `multipart` <[FormData]|[Object]<[string], [string]|[float]|[boolean]|[ReadStream]|[Object]>>
-@@ -483,6 +515,15 @@ unless explicitly provided. File values can be passed as file-like object contai
+@@ -515,6 +547,15 @@ unless explicitly provided. File values can be passed as file-like object contai
  
  An instance of [FormData] can be created via [`method: APIRequestContext.createFormData`].
  
@@ -1441,7 +1520,7 @@ index 37f6665a9..048201370 100644
  ## js-python-csharp-fetch-option-data
  * langs: js, python, csharp
  - `data` <[string]|[Buffer]|[Serializable]>
-@@ -491,21 +532,29 @@ Allows to set post data of the request. If the data parameter is an object, it w
+@@ -523,21 +564,29 @@ Allows to set post data of the request. If the data parameter is an object, it w
  and `content-type` header will be set to `application/json` if not explicitly set. Otherwise the `content-type` header will be
  set to `application/octet-stream` if not explicitly set.
  
@@ -1474,7 +1553,7 @@ index 37f6665a9..048201370 100644
  - `maxRetries` <[int]>
  
  Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
-@@ -547,7 +596,7 @@ Function to be evaluated in the worker context.
+@@ -579,7 +628,7 @@ Function to be evaluated in the worker context.
  Function to be evaluated in the main Electron process.
  
  ## python-context-option-viewport
@@ -1483,7 +1562,7 @@ index 37f6665a9..048201370 100644
  - `viewport` <[null]|[Object]>
    - `width` <[int]> page width in pixels.
    - `height` <[int]> page height in pixels.
-@@ -555,7 +604,7 @@ Function to be evaluated in the main Electron process.
+@@ -587,7 +636,7 @@ Function to be evaluated in the main Electron process.
  Sets a consistent viewport for each page. Defaults to an 1280x720 viewport. `no_viewport` disables the fixed viewport. Learn more about [viewport emulation](../emulation.md#viewport).
  
  ## python-context-option-no-viewport
@@ -1492,7 +1571,7 @@ index 37f6665a9..048201370 100644
  - `noViewport` <[boolean]>
  
  Does not enforce fixed viewport, allows resizing window in the headed mode.
-@@ -665,6 +714,13 @@ Emulates [prefers-colors-scheme](https://developer.mozilla.org/en-US/docs/Web/CS
+@@ -697,6 +746,13 @@ Emulates [prefers-colors-scheme](https://developer.mozilla.org/en-US/docs/Web/CS
  Emulates [prefers-colors-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) media feature, supported values are `'light'` and `'dark'`. See
  [`method: Page.emulateMedia`] for more details. Passing `'null'` resets emulation to system defaults. Defaults to `'light'`.
  
@@ -1506,7 +1585,7 @@ index 37f6665a9..048201370 100644
  ## context-option-reducedMotion
  * langs: js, java
  - `reducedMotion` <null|[ReducedMotion]<"reduce"|"no-preference">>
-@@ -677,6 +733,12 @@ Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce
+@@ -709,6 +765,12 @@ Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce
  
  Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce'`, `'no-preference'`. See [`method: Page.emulateMedia`] for more details. Passing `'null'` resets emulation to system defaults. Defaults to `'no-preference'`.
  
@@ -1519,7 +1598,7 @@ index 37f6665a9..048201370 100644
  ## context-option-forcedColors
  * langs: js, java
  - `forcedColors` <null|[ForcedColors]<"active"|"none">>
-@@ -684,10 +746,10 @@ Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce
+@@ -716,10 +778,10 @@ Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce
  Emulates `'forced-colors'` media feature, supported values are `'active'`, `'none'`. See [`method: Page.emulateMedia`] for more details. Passing `null` resets emulation to system defaults. Defaults to `'none'`.
  
  ## context-option-forcedColors-csharp-python
@@ -1533,7 +1612,7 @@ index 37f6665a9..048201370 100644
  
  ## context-option-contrast
  * langs: js, java
-@@ -735,7 +797,7 @@ specified, the HAR is not recorded. Make sure to await [`method: BrowserContext.
+@@ -767,7 +829,7 @@ specified, the HAR is not recorded. Make sure to await [`method: BrowserContext.
  saved.
  
  ## context-option-recordhar-path
@@ -1542,7 +1621,7 @@ index 37f6665a9..048201370 100644
    - alias-python: record_har_path
  - `recordHarPath` <[path]>
  
-@@ -744,33 +806,33 @@ specified HAR file on the filesystem. If not specified, the HAR is not recorded.
+@@ -776,33 +838,33 @@ specified HAR file on the filesystem. If not specified, the HAR is not recorded.
  call [`method: BrowserContext.close`] for the HAR to be saved.
  
  ## context-option-recordhar-omit-content
@@ -1579,9 +1658,9 @@ index 37f6665a9..048201370 100644
 -* langs: js
 +* langs: js, go
  - `recordVideo` <[Object]>
-   - `dir` <[path]> Path to the directory to put videos into.
-   - `size` ?<[Object]> Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport`
-@@ -837,7 +899,7 @@ Specifies whether to wait for already running listeners and what to do if they t
+   - `dir` ?<[path]> Path to the directory to put videos into. If not specified, the videos will be stored in `artifactsDir` (see [`method: BrowserType.launch`] options).
+   - `size` ?<[Object=RecordVideoSize]> Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport`
+@@ -873,7 +935,7 @@ Specifies whether to wait for already running listeners and what to do if they t
  * `'ignoreErrors'` - do not wait for current listener calls (if any) to finish, all errors thrown by the listeners after removal are silently caught
  
  ## unroute-all-options-behavior
@@ -1590,7 +1669,7 @@ index 37f6665a9..048201370 100644
  * since: v1.41
  - `behavior` <[UnrouteBehavior]<"wait"|"ignoreErrors"|"default">>
  
-@@ -848,7 +910,7 @@ Specifies whether to wait for already running handlers and what to do if they th
+@@ -884,7 +946,7 @@ Specifies whether to wait for already running handlers and what to do if they th
  
  
  ## select-options-values
@@ -1599,7 +1678,16 @@ index 37f6665a9..048201370 100644
  - `values` <[null]|[string]|[ElementHandle]|[Array]<[string]>|[Object]|[Array]<[ElementHandle]>|[Array]<[Object]>>
    - `value` ?<[string]> Matches by `option.value`. Optional.
    - `label` ?<[string]> Matches by `option.label`. Optional.
-@@ -866,7 +928,7 @@ the parameter is a string without wildcard characters, the method will wait for
+@@ -903,7 +965,7 @@ the parameter is a string without wildcard characters, the method will wait for
+ equal to the string.
+ 
+ ## python-csharp-java-wait-for-navigation-url
+-* langs: python, csharp, java
++* langs: python, csharp, java, go
+ - `url` <[string]|[RegExp]|[function]\([URL]\):[boolean]>
+ 
+ A glob pattern, regex pattern, or predicate receiving [URL] to match while waiting for the navigation. Note that if
+@@ -911,7 +973,7 @@ the parameter is a string without wildcard characters, the method will wait for
  equal to the string.
  
  ## wait-for-event-event
@@ -1608,7 +1696,7 @@ index 37f6665a9..048201370 100644
  - `event` <[string]>
  
  Event name, same one typically passed into `*.on(event)`.
-@@ -924,7 +986,7 @@ only the first option matching one of the passed options is selected. Optional.
+@@ -969,7 +1031,7 @@ only the first option matching one of the passed options is selected. Optional.
  Receives the event data and resolves to truthy value when the waiting should resolve.
  
  ## wait-for-event-timeout
@@ -1617,7 +1705,7 @@ index 37f6665a9..048201370 100644
  - `timeout` <[float]>
  
  Maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
-@@ -944,7 +1006,7 @@ using the [`method: AndroidDevice.setDefaultTimeout`] method.
+@@ -989,7 +1051,7 @@ using the [`method: AndroidDevice.setDefaultTimeout`] method.
  Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
  
  ## csharp-java-python-assertions-timeout
@@ -1626,7 +1714,7 @@ index 37f6665a9..048201370 100644
  - `timeout` <[float]>
  
  Time to retry the assertion for in milliseconds. Defaults to `5000`.
-@@ -998,8 +1060,10 @@ between the same pixel in compared images, between zero (strict) and one (lax),
+@@ -1043,8 +1105,10 @@ between the same pixel in compared images, between zero (strict) and one (lax),
  - %%-context-option-httpcredentials-%%
  - %%-context-option-colorscheme-%%
  - %%-context-option-colorscheme-csharp-python-%%
@@ -1637,7 +1725,7 @@ index 37f6665a9..048201370 100644
  - %%-context-option-forcedColors-%%
  - %%-context-option-forcedColors-csharp-python-%%
  - %%-context-option-contrast-%%
-@@ -1091,7 +1155,7 @@ Firefox user preferences. Learn more about the Firefox user preferences at
+@@ -1135,7 +1199,7 @@ Firefox user preferences. Learn more about the Firefox user preferences at
  You can also provide a path to a custom [`policies.json` file](https://mozilla.github.io/policy-templates/) via `PLAYWRIGHT_FIREFOX_POLICIES_JSON` environment variable.
  
  ## csharp-java-browser-option-firefoxuserprefs
@@ -1648,10 +1736,10 @@ index 37f6665a9..048201370 100644
  Firefox user preferences. Learn more about the Firefox user preferences at
 diff --git a/utils/doclint/generateGoApi.js b/utils/doclint/generateGoApi.js
 new file mode 100644
-index 000000000..996ad6108
+index 000000000..0bcbee3c5
 --- /dev/null
 +++ b/utils/doclint/generateGoApi.js
-@@ -0,0 +1,871 @@
+@@ -0,0 +1,880 @@
 +/**
 + * Copyright (c) Microsoft Corporation.
 + *
@@ -2094,7 +2182,10 @@ index 000000000..996ad6108
 +  if (member.kind === 'event') {
 +    const payloadType = translateType(member.type, parent, t => generateNameDefault(member, name, t, parent), false, false)
 +    output(transformComment(member));
-+    output(`${name}(fn func(${payloadType}))`);
++    if (payloadType === 'void')
++      output(`${name}(fn func())`);
++    else
++      output(`${name}(fn func(${payloadType}))`);
 +    return;
 +  }
 +
@@ -2348,6 +2439,8 @@ index 000000000..996ad6108
 +  // a few special cases we can fix automatically
 +  if (type.expression === '[null]|[Error]')
 +    return 'void';
++  else if (type.expression === '[Disposable]')
++    return 'void';
 +  else if (type.expression === '[Error]')
 +    return 'error';
 +  else if (type.expression === '[boolean]|"mixed"')
@@ -2355,6 +2448,8 @@ index 000000000..996ad6108
 +  else if (type.expression === '[string]|[Request]')
 +    return 'any';
 +  else if (type.expression === '[path]|[Array]<[path]>|[Object]|[Array]<[Object]>')
++    return 'any';
++  else if (type.expression === '[path]|[Array]<[path]>|[Object=FilePayload]|[Array]<[Object=FilePayload]>')
 +    return 'any';
 +  else if (type.expression === '[function]([null]|[int], [null]|[string])')
 +    return 'func(*int, *string)';
@@ -2492,6 +2587,8 @@ index 000000000..996ad6108
 +      let returnType = removePointer(translateType(type.returnType, parent, generateNameCallback, false, true));
 +      if (returnType == null)
 +        throw new Error('Unexpected null as return type.');
++      if (returnType === 'void' || returnType === 'Promise')
++        return `func(${argsList})`;
 +      return `func(${argsList}) ${returnType}`;
 +    }
 +  }

--- a/request.go
+++ b/request.go
@@ -22,6 +22,7 @@ type requestImpl struct {
 	redirectedTo       Request
 	failureText        string
 	fallbackOverrides  *serializedFallbackOverrides
+	hasResponse        bool
 }
 
 func (r *requestImpl) URL() string {
@@ -272,6 +273,9 @@ func newRequest(parent *channelOwner, objectType string, guid string, initialize
 		ResponseEnd:           -1,
 	}
 	req.provisionalHeaders = newRawHeaders(req.initializer["headers"])
+	if hr, ok := initializer["hasResponse"].(bool); ok {
+		req.hasResponse = hr
+	}
 	req.fallbackOverrides = &serializedFallbackOverrides{}
 	return req
 }

--- a/run.go
+++ b/run.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 )
 
-const playwrightCliVersion = "1.57.0"
+const playwrightCliVersion = "1.59.1"
 
 var (
 	logger               = slog.Default()

--- a/run_test.go
+++ b/run_test.go
@@ -76,8 +76,8 @@ func TestRunOptions_OnlyInstallShell(t *testing.T) {
 	require.NoError(t, w.Close())
 	wg.Wait()
 
-	assert.Contains(t, output, "browser: chromium-headless-shell version")
-	assert.NotContains(t, output, "browser: chromium version")
+	assert.Contains(t, output, "chromium-headless-shell")
+	assert.NotContains(t, output, "Chrome for Testing")
 }
 
 func TestDriverInstall(t *testing.T) {

--- a/screencast.go
+++ b/screencast.go
@@ -1,0 +1,64 @@
+package playwright
+
+import "encoding/base64"
+
+type screencastImpl struct {
+	page *pageImpl
+}
+
+func (s *screencastImpl) Start(options ...ScreencastStartOptions) error {
+	overrides := map[string]any{}
+	if len(options) == 1 {
+		if options[0].OnFrame != nil {
+			onFrame := options[0].OnFrame
+			s.page.channel.On("screencastFrame", func(params map[string]any) {
+				data, _ := base64.StdEncoding.DecodeString(params["data"].(string))
+				onFrame(OnFrame{Data: data})
+			})
+			overrides["sendFrames"] = true
+			options[0].OnFrame = nil // don't serialize the callback
+		}
+		if options[0].Path != nil {
+			overrides["record"] = true
+		}
+	}
+	_, err := s.page.channel.Send("screencastStart", options, overrides)
+	return err
+}
+
+func (s *screencastImpl) Stop() error {
+	_, err := s.page.channel.Send("screencastStop")
+	return err
+}
+
+func (s *screencastImpl) ShowActions(options ...ScreencastShowActionsOptions) error {
+	_, err := s.page.channel.Send("screencastShowActions", options)
+	return err
+}
+
+func (s *screencastImpl) HideActions() error {
+	_, err := s.page.channel.Send("screencastHideActions")
+	return err
+}
+
+func (s *screencastImpl) ShowOverlay(html string, options ...ScreencastShowOverlayOptions) error {
+	overrides := map[string]any{"html": html}
+	_, err := s.page.channel.Send("screencastShowOverlay", options, overrides)
+	return err
+}
+
+func (s *screencastImpl) ShowChapter(title string, options ...ScreencastShowChapterOptions) error {
+	overrides := map[string]any{"title": title}
+	_, err := s.page.channel.Send("screencastChapter", options, overrides)
+	return err
+}
+
+func (s *screencastImpl) ShowOverlays() error {
+	_, err := s.page.channel.Send("screencastSetOverlayVisible", map[string]any{"visible": true})
+	return err
+}
+
+func (s *screencastImpl) HideOverlays() error {
+	_, err := s.page.channel.Send("screencastSetOverlayVisible", map[string]any{"visible": false})
+	return err
+}

--- a/tests/browser_context_client_certificates_test.go
+++ b/tests/browser_context_client_certificates_test.go
@@ -112,7 +112,8 @@ func TestClientCerts(t *testing.T) {
 						KeyPath:  playwright.String(Asset("client-certificates/client/trusted/key.pem")),
 					},
 				},
-			})
+			},
+		)
 		require.NoError(t, err)
 		defer context2.Close()
 		page2, err := context2.NewPage()

--- a/tests/browser_type_test.go
+++ b/tests/browser_type_test.go
@@ -207,7 +207,7 @@ func TestBrowserTypeConnectArtifactPath(t *testing.T) {
 	recordVideoDir := t.TempDir()
 	browserContext, err := browser1.NewContext(playwright.BrowserNewContextOptions{
 		RecordVideo: &playwright.RecordVideo{
-			Dir: recordVideoDir,
+			Dir: playwright.String(recordVideoDir),
 		},
 	})
 	require.NoError(t, err)
@@ -387,4 +387,30 @@ func TestShouldUploadAFolderRemote(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, string(b), content.(string))
 	}
+}
+
+func TestBrowserBind(t *testing.T) {
+	BeforeEach(t)
+
+	result, err := browser.Bind("test-server")
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Endpoint)
+
+	// Connect from another Playwright instance
+	pw2, err := playwright.Run()
+	require.NoError(t, err)
+	defer func() { _ = pw2.Stop() }()
+
+	browser2, err := pw2.Chromium.Connect(result.Endpoint)
+	require.NoError(t, err)
+	require.NotNil(t, browser2)
+
+	page2, err := browser2.NewPage()
+	require.NoError(t, err)
+	_, err = page2.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	require.Equal(t, server.EMPTY_PAGE, page2.URL())
+
+	require.NoError(t, browser2.Close())
+	require.NoError(t, browser.Unbind())
 }

--- a/tests/console_message_test.go
+++ b/tests/console_message_test.go
@@ -84,7 +84,8 @@ func TestConsoleShouldWorkForDifferentConsoleAPICalls(t *testing.T) {
       console.warn('calling console.warn');
       console.error('calling console.error');
       console.log(Promise.resolve('should not wait until resolved!'));
-	}`)
+	}`,
+	)
 	messages := ChanToSlice(messagesChan, 6)
 	require.NoError(t, err)
 	require.Equal(t, []string{

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -362,7 +362,8 @@ func TestElementHandleSelectOptionOverElementHandle(t *testing.T) {
 	})
 	require.NoError(t, err)
 	selected2, err := page.Locator("#lang").SelectOption(
-		playwright.SelectOptionValues{Values: playwright.StringSlice("python")})
+		playwright.SelectOptionValues{Values: playwright.StringSlice("python")},
+	)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(selected))
 	require.Equal(t, "python", selected[0])

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -613,7 +613,8 @@ func TestShouldSupportLocatorOr(t *testing.T) {
 	require.NoError(t, expect.Locator(page.Locator("div").Or(page.Locator("span"))).ToHaveCount(2))
 	require.NoError(t, expect.Locator(page.Locator("div").Or(page.Locator("span"))).ToHaveText([]string{"hello", "world"}))
 	require.NoError(t, expect.Locator(
-		page.Locator("span").Or(page.Locator("article")).Or(page.Locator("div"))).ToHaveText([]string{"hello", "world"}))
+		page.Locator("span").Or(page.Locator("article")).Or(page.Locator("div")),
+	).ToHaveText([]string{"hello", "world"}))
 
 	require.NoError(t, expect.Locator(page.Locator("article").Or(page.Locator("something"))).ToHaveCount(0))
 	require.NoError(t, expect.Locator(page.Locator("article").Or(page.Locator("div"))).ToHaveText("hello"))

--- a/tests/page_add_locator_handler_test.go
+++ b/tests/page_add_locator_handler_test.go
@@ -275,7 +275,8 @@ func TestPageAddLocatorHandlerShouldWorkWithTimes(t *testing.T) {
 	_, err = page.Evaluate(`() => { window.clicked = 0; window.setupAnnoyingInterstitial("mouseover", 4); }`)
 	require.NoError(t, err)
 	err1 := page.Locator("#target").Click(
-		playwright.LocatorClickOptions{Timeout: playwright.Float(2000)})
+		playwright.LocatorClickOptions{Timeout: playwright.Float(2000)},
+	)
 	require.Equal(t, 2, called)
 
 	ret, err := page.Evaluate(`window.clicked`)
@@ -307,7 +308,8 @@ func TestPageAddLocatorHandlerShouldWorkWithNoWaitAfter(t *testing.T) {
 		},
 		playwright.PageAddLocatorHandlerOptions{
 			NoWaitAfter: playwright.Bool(true),
-		})
+		},
+	)
 	require.NoError(t, err)
 
 	require.NoError(t, page.Locator("#aside").Hover())
@@ -335,7 +337,8 @@ func TestPageAddLocatorHandlerShouldRemoveLocatorHandler(t *testing.T) {
 		func(loc playwright.Locator) {
 			called++
 			require.NoError(t, loc.Click())
-		})
+		},
+	)
 	require.NoError(t, err)
 
 	_, err = page.Evaluate(`() => { window.clicked = 0; window.setupAnnoyingInterstitial("hide", 1); }`)
@@ -352,7 +355,8 @@ func TestPageAddLocatorHandlerShouldRemoveLocatorHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, page.RemoveLocatorHandler(page.GetByRole("button", playwright.PageGetByRoleOptions{Name: "close"})))
 	err1 := page.Locator("#target").Click(
-		playwright.LocatorClickOptions{Timeout: playwright.Float(2000)})
+		playwright.LocatorClickOptions{Timeout: playwright.Float(2000)},
+	)
 	require.Equal(t, 1, called)
 	ret, err = page.Evaluate(`window.clicked`)
 	require.NoError(t, err)

--- a/tests/page_clock_test.go
+++ b/tests/page_clock_test.go
@@ -86,7 +86,8 @@ func TestPageClockRunFor(t *testing.T) {
 		beforePageClock(t, 0, 1000)
 
 		_, err := page.Evaluate(
-			"setTimeout(window.stub, 100); setTimeout(window.stub, 100); setTimeout(window.stub, 99); setTimeout(window.stub, 100)")
+			"setTimeout(window.stub, 100); setTimeout(window.stub, 100); setTimeout(window.stub, 99); setTimeout(window.stub, 100)",
+		)
 		require.NoError(t, err)
 		require.NoError(t, page.Clock().RunFor(100))
 		require.Eventually(t, func() bool { return calls.Len() == 4 }, 1*time.Second, 10*time.Millisecond)

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -259,7 +259,8 @@ func TestPageExpectWorker(t *testing.T) {
 	worker = page.Workers()[0]
 	require.Contains(t, worker.URL(), "worker.js")
 	// flaky in the macos-latest of gh action
-	require.Eventually(t,
+	require.Eventually(
+		t,
 		func() bool {
 			v, err := worker.Evaluate(`() => self["workerFunction"] ? true : false`)
 			require.NoError(t, err)
@@ -1004,11 +1005,12 @@ func TestPageShouldSetBodysizeAndHeadersize(t *testing.T) {
 
 	_, err := page.Goto(server.EMPTY_PAGE)
 	require.NoError(t, err)
-	request, err := page.ExpectRequest("**/*", func() error {
-		_, err = page.Evaluate("() => fetch('./get', { method: 'POST', body: '12345'}).then(r => r.text())")
-		require.NoError(t, err)
-		return nil
-	},
+	request, err := page.ExpectRequest(
+		"**/*", func() error {
+			_, err = page.Evaluate("() => fetch('./get', { method: 'POST', body: '12345'}).then(r => r.text())")
+			require.NoError(t, err)
+			return nil
+		},
 	)
 	require.NoError(t, err)
 	sizes, err := request.Sizes()
@@ -1022,11 +1024,12 @@ func TestPageTestShouldSetBodysizeTo0(t *testing.T) {
 
 	_, err := page.Goto(server.EMPTY_PAGE)
 	require.NoError(t, err)
-	request, err := page.ExpectRequest("**/*", func() error {
-		_, err = page.Evaluate("() => fetch('./get').then(r => r.text())")
-		require.NoError(t, err)
-		return nil
-	},
+	request, err := page.ExpectRequest(
+		"**/*", func() error {
+			_, err = page.Evaluate("() => fetch('./get').then(r => r.text())")
+			require.NoError(t, err)
+			return nil
+		},
 	)
 	require.NoError(t, err)
 	sizes, err := request.Sizes()

--- a/tests/video_test.go
+++ b/tests/video_test.go
@@ -16,7 +16,7 @@ func TestVideoShouldWork(t *testing.T) {
 	recordVideoDir := t.TempDir()
 	BeforeEach(t, playwright.BrowserNewContextOptions{
 		RecordVideo: &playwright.RecordVideo{
-			Dir: recordVideoDir,
+			Dir: playwright.String(recordVideoDir),
 			Size: &playwright.Size{
 				Width:  500,
 				Height: 400,
@@ -57,7 +57,7 @@ func TestVideo(t *testing.T) {
 		recordVideoDir := t.TempDir()
 		BeforeEach(t, playwright.BrowserNewContextOptions{
 			RecordVideo: &playwright.RecordVideo{
-				Dir: recordVideoDir,
+				Dir: playwright.String(recordVideoDir),
 				Size: &playwright.Size{
 					Width:  500,
 					Height: 400,
@@ -81,7 +81,7 @@ func TestVideo(t *testing.T) {
 		recordVideoDir := t.TempDir()
 		BeforeEach(t, playwright.BrowserNewContextOptions{
 			RecordVideo: &playwright.RecordVideo{
-				Dir: recordVideoDir,
+				Dir: playwright.String(recordVideoDir),
 				Size: &playwright.Size{
 					Width:  500,
 					Height: 400,
@@ -108,7 +108,7 @@ func TestVideo(t *testing.T) {
 		recordVideoDir := t.TempDir()
 		BeforeEach(t, playwright.BrowserNewContextOptions{
 			RecordVideo: &playwright.RecordVideo{
-				Dir: recordVideoDir,
+				Dir: playwright.String(recordVideoDir),
 				Size: &playwright.Size{
 					Width:  500,
 					Height: 400,
@@ -158,7 +158,7 @@ func TestVideo(t *testing.T) {
 		context, err := bt.LaunchPersistentContext(tmpDir, playwright.BrowserTypeLaunchPersistentContextOptions{
 			Headless: playwright.Bool(os.Getenv("HEADFUL") == ""),
 			RecordVideo: &playwright.RecordVideo{
-				Dir: tmpDir,
+				Dir: playwright.String(tmpDir),
 			},
 		})
 		require.NoError(t, err)
@@ -193,7 +193,7 @@ func TestVideo(t *testing.T) {
 
 		browser_context, err := browser1.NewContext(playwright.BrowserNewContextOptions{
 			RecordVideo: &playwright.RecordVideo{
-				Dir: tmpDir,
+				Dir: playwright.String(tmpDir),
 			},
 		})
 		require.NoError(t, err)
@@ -212,4 +212,34 @@ func TestVideo(t *testing.T) {
 		require.NoError(t, video.SaveAs(tmpFile))
 		require.FileExists(t, tmpFile)
 	})
+}
+
+func TestScreencastStartStop(t *testing.T) {
+	BeforeEach(t)
+
+	_, err := page.Goto(server.PREFIX + "/grid.html")
+	require.NoError(t, err)
+
+	screencast, err := page.Screencast()
+	require.NoError(t, err)
+
+	var frames [][]byte
+	err = screencast.Start(playwright.ScreencastStartOptions{
+		OnFrame: func(frame playwright.OnFrame) {
+			frames = append(frames, frame.Data)
+		},
+	})
+	require.NoError(t, err)
+
+	// Trigger some activity to generate frames
+	_, err = page.Reload()
+	require.NoError(t, err)
+	//nolint:staticcheck
+	page.WaitForTimeout(500)
+
+	err = screencast.Stop()
+	require.NoError(t, err)
+
+	require.Greater(t, len(frames), 0, "should have received at least one frame")
+	require.Greater(t, len(frames[0]), 0, "frame data should not be empty")
 }

--- a/tests/worker_test.go
+++ b/tests/worker_test.go
@@ -21,7 +21,8 @@ func TestWorkerShouldWork(t *testing.T) {
 	worker = page.Workers()[0]
 	require.Contains(t, worker.URL(), "worker.js")
 	// flaky in the macos-latest of gh action
-	require.Eventually(t,
+	require.Eventually(
+		t,
 		func() bool {
 			v, err := worker.Evaluate(`() => self["workerFunction"] ? true : false`)
 			require.NoError(t, err)


### PR DESCRIPTION
## Changes

Roll Playwright from v1.57.0 to v1.59.1.

### New APIs
- `Browser.Bind/Unbind` — bind browser to named pipe/WebSocket for remote clients
- `BrowserContext.Debugger` — access the Playwright debugger API
- `BrowserContext.IsClosed/SetStorageState`
- `Page.AriaSnapshot/Screencast/ClearConsoleMessages/ClearPageErrors/PageErrors`
- `CDPSession.OnClose`, `ConsoleMessage.Timestamp`, `Response.HttpVersion`
- `Request.ExistingResponse`, `Locator.Normalize`, `Locator.Description`
- `Debugger` class (pause/resume/next/runTo with event-based state)
- `Screencast` class (start/stop/showActions/showOverlay/showChapter)

### Protocol Changes
- `Connect`: `wsEndpoint` → `endpoint` field rename
- Video artifact now comes from page initializer (no longer event-based)
- `Disposable` objects handled in objectFactory (not exposed in Go API)

### Generator/Patch Fixes
- Map `Disposable` → `void` (JS-only concept)
- Map `Promise` → `void` in function return types
- Map `FilePayload` union → `any` for SetInputFiles
- Handle `void` event payloads correctly
- Add `go` to langs for: route.url, unroute.url, routeWebSocket.url, waitForURL, pageErrors, Description

### Other
- `skipFieldSerialization`: handle nil `Func` types (for Screencast.OnFrame callback)
- Tests: TestBrowserBind, TestScreencastStartStop

### Breaking Changes
- `RecordVideo.Dir`: `string` → `*string` (generated from protocol; dir is now optional)

### Browser Versions
- Chromium 147.0.7727.15
- Firefox 148.0.2
- WebKit 26.4