### PR TITLE
chore: add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ _site/
 .jekyll-cache/
 
 .vscode/settings.json
+.claude/


### PR DESCRIPTION
Ignores the `.claude/` directory (Claude Code local config) so it doesn't get committed.