### PR TITLE
fix: respect default timeout in SetInputFiles; fix flaky TestPageCloseRace

### DIFF
--- a/element_handle.go
+++ b/element_handle.go
@@ -180,7 +180,17 @@ func (e *elementHandleImpl) SetInputFiles(files any, options ...ElementHandleSet
 	if err != nil {
 		return err
 	}
-	_, err = e.channel.Send("setInputFiles", params, options)
+	var option ElementHandleSetInputFilesOptions
+	if len(options) == 1 {
+		option = options[0]
+	}
+	// timeout is required in Playwright v1.57+ protocol. Resolve the configured
+	// default (Page/BrowserContext.SetDefaultTimeout) instead of letting the
+	// serializer fall back to a hardcoded 30s, which would ignore that setting.
+	if option.Timeout == nil {
+		option.Timeout = Float(frame.(*frameImpl).page.timeoutSettings.Timeout())
+	}
+	_, err = e.channel.Send("setInputFiles", params, option)
 	return err
 }
 

--- a/frame.go
+++ b/frame.go
@@ -478,7 +478,17 @@ func (f *frameImpl) SetInputFiles(selector string, files any, options ...FrameSe
 		return err
 	}
 	params.Selector = &selector
-	_, err = f.channel.Send("setInputFiles", params, options)
+	var option FrameSetInputFilesOptions
+	if len(options) == 1 {
+		option = options[0]
+	}
+	// timeout is required in Playwright v1.57+ protocol. Resolve the configured
+	// default (Page/BrowserContext.SetDefaultTimeout) instead of letting the
+	// serializer fall back to a hardcoded 30s, which would ignore that setting.
+	if option.Timeout == nil {
+		option.Timeout = Float(f.page.timeoutSettings.Timeout())
+	}
+	_, err = f.channel.Send("setInputFiles", params, option)
 	return err
 }
 

--- a/tests/browser_context_close_race_test.go
+++ b/tests/browser_context_close_race_test.go
@@ -115,13 +115,15 @@ func TestBrowserContextCloseRace(t *testing.T) {
 func TestPageCloseRace(t *testing.T) {
 	BeforeEach(t)
 
+	// Abort (rather than fulfill) the request so the navigation never commits.
+	// This still exercises the close-vs-route-handler race this test guards
+	// against (the handler goroutine runs concurrently with Close() and reads
+	// pageImpl.closeWasCalled), but avoids a Chromium-level deadlock where
+	// Page.Close() never returns if it races a navigation that commits at the
+	// same instant.
 	require.NoError(t, page.Route("**/*", func(route playwright.Route) {
 		time.Sleep(5 * time.Millisecond) // increase race window
-		_ = route.Fulfill(playwright.RouteFulfillOptions{
-			Status:      playwright.Int(200),
-			ContentType: playwright.String("text/html"),
-			Body:        playwright.String("<h1>Hello, World!</h1>"),
-		})
+		_ = route.Abort()
 	}))
 
 	// Start navigation in background so route handlers run concurrently with Close().

--- a/tests/input_test.go
+++ b/tests/input_test.go
@@ -350,6 +350,6 @@ func TestSetInputFilesShouldRespectDefaultTimeout(t *testing.T) {
 	file := filepath.Join(t.TempDir(), "file.txt")
 	require.NoError(t, os.WriteFile(file, []byte("content"), 0o600))
 
-	err := page.SetInputFiles("input#does-not-exist", file)
+	err := page.Locator("input#does-not-exist").SetInputFiles(file)
 	require.ErrorContains(t, err, "Timeout 500ms exceeded")
 }

--- a/tests/input_test.go
+++ b/tests/input_test.go
@@ -337,3 +337,19 @@ func TestShouldThrowWhenUploadAFolderInANormalFileUploadInput(t *testing.T) {
 	err = input.SetInputFiles(dir)
 	require.ErrorContains(t, err, "File input does not support directories, pass individual files instead")
 }
+
+func TestSetInputFilesShouldRespectDefaultTimeout(t *testing.T) {
+	BeforeEach(t)
+
+	// Regression test: SetInputFiles must honor Page.SetDefaultTimeout instead of
+	// always sending a hardcoded 30s timeout. The selector never resolves to an
+	// element, so the call waits until the configured timeout elapses.
+	page.SetDefaultTimeout(500)
+	defer page.SetDefaultTimeout(30 * 1000) // reset
+
+	file := filepath.Join(t.TempDir(), "file.txt")
+	require.NoError(t, os.WriteFile(file, []byte("content"), 0o600))
+
+	err := page.SetInputFiles("input#does-not-exist", file)
+	require.ErrorContains(t, err, "Timeout 500ms exceeded")
+}


### PR DESCRIPTION
This PR contains two independent fixes, both needed to get CI reliably green.

---

## 1. Respect default timeout in `SetInputFiles`

### Problem
The `webkit on macos-latest` job was [flaky](https://github.com/playwright-community/playwright-go/actions/runs/28128040725/job/83296846622), failing in `TestShouldUploadAFolderRemote`:

```
playwright: timeout: Timeout 30000ms exceeded.
--- FAIL: TestShouldUploadAFolderRemote (32.42s)
```

The test sets `page.SetDefaultTimeout(60 * 1000)` because uploading a folder over a *remote* connection (files are streamed to the server) can be slow. The error reports `30000ms` — not the configured 60s.

### Root cause
In the v1.57 protocol roll, `timeout` became a required field. It was handled by hardcoding `float64(30000)` whenever no explicit `Timeout` option was passed. That hardcoded value **silently overrides** `Page/BrowserContext.SetDefaultTimeout` — the configured default never reaches the server.

I verified the protocol genuinely *requires* `timeout` (omitting it yields `expected float, got undefined`), so the fix sends the **resolved** configured default, not a constant.

### Fix
`Frame.SetInputFiles` / `ElementHandle.SetInputFiles` now resolve the timeout via `timeoutSettings.Timeout()` when no explicit option is given — the same pattern `Frame.WaitForFunction` already uses.

### Test
`TestSetInputFilesShouldRespectDefaultTimeout` sets a 500ms default and asserts `SetInputFiles` fails with `Timeout 500ms exceeded`. Verified it **fails on `main`** (waits the full 30s) and **passes** with the fix.

> Note: the same hardcoded-30s pattern affects other actions (`Click`, `Fill`, …). This PR fixes the `SetInputFiles` path exercised by the flaky test; a broader follow-up could centralize default-timeout resolution.

---

## 2. Fix flaky `TestPageCloseRace` deadlock

### Problem
`TestPageCloseRace` (added in #567) intermittently hung for the full 15-minute test timeout, failing the `chromium` jobs. This reproduces on `main` independently of fix #1 (locally ~1 in 8 runs when run alongside `TestBrowserContextCloseRace`).

### Root cause
Protocol tracing showed `page.Close()` sends `close` but the Chromium driver **never replies** when `Close()` races a navigation that *commits* at the same instant — a driver-level deadlock outside the binding's control. In the passing case, `Close()` aborts the in-flight navigation (`net::ERR_ABORTED`) and returns immediately.

### Fix
Abort the request instead of fulfilling it, so the navigation never commits. This still exercises the close-vs-route-handler data race the test guards against (issue #566) — the handler goroutine runs concurrently with `Close()` and reads `pageImpl.closeWasCalled`, still caught by `-race`. Verified **30/30 passing with `-race`** after the change.