### PR TITLE
fix: prevent panic in EvaluateHandle when it returns an ElementHandle

### DIFF
--- a/console_message.go
+++ b/console_message.go
@@ -22,7 +22,7 @@ func (c *consoleMessageImpl) Args() []JSHandle {
 	args := c.event["args"].([]any)
 	out := []JSHandle{}
 	for idx := range args {
-		out = append(out, fromChannel(args[idx]).(*jsHandleImpl))
+		out = append(out, fromChannel(args[idx]).(JSHandle))
 	}
 	return out
 }

--- a/frame.go
+++ b/frame.go
@@ -540,7 +540,7 @@ func (f *frameImpl) WaitForFunction(expression string, arg any, options ...Frame
 	if handle == nil {
 		return nil, nil
 	}
-	return handle.(*jsHandleImpl), nil
+	return handle.(JSHandle), nil
 }
 
 func (f *frameImpl) Title() (string, error) {

--- a/js_handle.go
+++ b/js_handle.go
@@ -49,7 +49,7 @@ func (j *jsHandleImpl) EvaluateHandle(expression string, options ...any) (JSHand
 	if channelOwner == nil {
 		return nil, nil
 	}
-	return channelOwner.(*jsHandleImpl), nil
+	return channelOwner.(JSHandle), nil
 }
 
 func (j *jsHandleImpl) GetProperty(name string) (JSHandle, error) {
@@ -59,7 +59,7 @@ func (j *jsHandleImpl) GetProperty(name string) (JSHandle, error) {
 	if err != nil {
 		return nil, err
 	}
-	return fromChannel(channel).(*jsHandleImpl), nil
+	return fromChannel(channel).(JSHandle), nil
 }
 
 func (j *jsHandleImpl) GetProperties() (map[string]JSHandle, error) {
@@ -70,7 +70,7 @@ func (j *jsHandleImpl) GetProperties() (map[string]JSHandle, error) {
 	propertiesMap := make(map[string]JSHandle)
 	for _, property := range properties.([]any) {
 		item := property.(map[string]any)
-		propertiesMap[item["name"].(string)] = fromChannel(item["value"]).(*jsHandleImpl)
+		propertiesMap[item["name"].(string)] = fromChannel(item["value"]).(JSHandle)
 	}
 	return propertiesMap, nil
 }

--- a/tests/js_handle_test.go
+++ b/tests/js_handle_test.go
@@ -88,6 +88,46 @@ func TestJSHandleEvaluateHandle(t *testing.T) {
 	require.Equal(t, value, 2)
 }
 
+func TestJSHandleEvaluateHandleReturningElement(t *testing.T) {
+	BeforeEach(t)
+
+	_, err := page.Goto(server.PREFIX + "/dom.html")
+	require.NoError(t, err)
+	inner, err := page.QuerySelector("#inner")
+	require.NoError(t, err)
+
+	// EvaluateHandle may return an ElementHandle (e.g. element.parentElement).
+	// It must not panic when the underlying handle is an ElementHandle.
+	// See https://github.com/playwright-community/playwright-go/issues/332
+	parent, err := inner.EvaluateHandle("element => element.parentElement")
+	require.NoError(t, err)
+	require.NotNil(t, parent.AsElement())
+
+	id, err := parent.AsElement().GetAttribute("id")
+	require.NoError(t, err)
+	require.Equal(t, "outer", id)
+
+	// GetProperty must likewise survive returning an ElementHandle.
+	childHandle, err := parent.GetProperty("firstElementChild")
+	require.NoError(t, err)
+	require.NotNil(t, childHandle.AsElement())
+}
+
+func TestJSHandleGetPropertiesReturningElement(t *testing.T) {
+	BeforeEach(t)
+
+	_, err := page.Goto(server.PREFIX + "/dom.html")
+	require.NoError(t, err)
+	inner, err := page.QuerySelector("#inner")
+	require.NoError(t, err)
+
+	parent, err := inner.EvaluateHandle("element => ({ parent: element.parentElement })")
+	require.NoError(t, err)
+	props, err := parent.GetProperties()
+	require.NoError(t, err)
+	require.NotNil(t, props["parent"].AsElement())
+}
+
 func TestJSHandleTypeParsing(t *testing.T) {
 	BeforeEach(t)
 

--- a/tests/js_handle_test.go
+++ b/tests/js_handle_test.go
@@ -93,7 +93,7 @@ func TestJSHandleEvaluateHandleReturningElement(t *testing.T) {
 
 	_, err := page.Goto(server.PREFIX + "/dom.html")
 	require.NoError(t, err)
-	inner, err := page.QuerySelector("#inner")
+	inner, err := page.QuerySelector("#inner") // nolint: staticcheck
 	require.NoError(t, err)
 
 	// EvaluateHandle may return an ElementHandle (e.g. element.parentElement).
@@ -103,7 +103,7 @@ func TestJSHandleEvaluateHandleReturningElement(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, parent.AsElement())
 
-	id, err := parent.AsElement().GetAttribute("id")
+	id, err := parent.AsElement().GetAttribute("id") // nolint: staticcheck
 	require.NoError(t, err)
 	require.Equal(t, "outer", id)
 
@@ -118,7 +118,7 @@ func TestJSHandleGetPropertiesReturningElement(t *testing.T) {
 
 	_, err := page.Goto(server.PREFIX + "/dom.html")
 	require.NoError(t, err)
-	inner, err := page.QuerySelector("#inner")
+	inner, err := page.QuerySelector("#inner") // nolint: staticcheck
 	require.NoError(t, err)
 
 	parent, err := inner.EvaluateHandle("element => ({ parent: element.parentElement })")

--- a/worker.go
+++ b/worker.go
@@ -37,7 +37,7 @@ func (w *workerImpl) EvaluateHandle(expression string, options ...any) (JSHandle
 	if err != nil {
 		return nil, err
 	}
-	return fromChannel(result).(*jsHandleImpl), nil
+	return fromChannel(result).(JSHandle), nil
 }
 
 func (w *workerImpl) onClose() {


### PR DESCRIPTION
## Problem

Fixes #332.

`JSHandle.EvaluateHandle`, `JSHandle.GetProperty` and `JSHandle.GetProperties` cast the channel object returned by the driver to the concrete `*jsHandleImpl`. When the evaluated expression resolves to a DOM element (e.g. `element => element.parentElement`), the driver returns an `ElementHandle` whose concrete type is `*elementHandleImpl`. Because `*elementHandleImpl` is not `*jsHandleImpl`, the type assertion panics:

```
panic: interface conversion: interface {} is *playwright.elementHandleImpl, not *playwright.jsHandleImpl
```

Reproducer from the issue:

```go
func findXPath(handle playwright.ElementHandle) string {
  eval, _ := handle.EvaluateHandle(`(element) => element.parentElement`, handle)
  return eval.String()
}
```

## Fix

Cast to the `JSHandle` interface instead of the concrete `*jsHandleImpl`. Both `*jsHandleImpl` and `*elementHandleImpl` (which embeds `jsHandleImpl`) satisfy `JSHandle`, and `fromChannel` already constructs the correct concrete type via the object factory. This mirrors how `Frame.EvaluateHandle` already casts to `JSHandle`, and matches the behavior of the Python/JS bindings where `from_channel` returns the properly typed handle.

The same latent bug existed in `Worker.EvaluateHandle`, `Frame.WaitForFunction` and `ConsoleMessage.Args`, which are fixed as well.

## Tests

Added `TestJSHandleEvaluateHandleReturningElement` and `TestJSHandleGetPropertiesReturningElement`, which reproduced the panic before the fix and pass after it. Existing JSHandle, ElementHandle, Worker and ConsoleMessage tests continue to pass.