### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,19 +4,22 @@ on:
     branches: [ main, roll/* ]
   pull_request:
     branches: [ main, roll/* ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Go 1.x
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: oldstable
       id: go
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v9
       with:
         version: latest
   test:
@@ -29,16 +32,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     name:  ${{ matrix.browser }} on ${{ matrix.os }}, go ${{ matrix.go }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: true
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go }}
       id: go
     - name: Cache drivers
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         # In order:
         # * Driver for linux
@@ -84,9 +87,9 @@ jobs:
   test-examples:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Go 1.x
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: oldstable
       id: go

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,12 +2,15 @@ name: Docs
 on:
   push:
     branches: [ main ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   deploy:
     name: Deploy docs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.3'

--- a/.github/workflows/verify_type_generation.yml
+++ b/.github/workflows/verify_type_generation.yml
@@ -4,15 +4,18 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: true
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: oldstable
       - name: Install gofumpt

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,17 @@
----
+version: "2"
 linters:
-  enable-all: false
-  disable-all: false
+  default: standard
+  settings:
+    staticcheck:
+      checks:
+        - all
+        # disable the stylecheck (ST10xx) rules that v2 merged into staticcheck:
+        # error strings and identifier names mirror upstream Playwright verbatim
+        - -ST1000
+        - -ST1003
+        - -ST1005
+        - -ST1016
+        - -ST1021
+formatters:
   enable:
     - gofumpt

--- a/errors.go
+++ b/errors.go
@@ -42,9 +42,10 @@ func (e *Error) Is(target error) bool {
 }
 
 func parseError(err Error) error {
-	if err.Name == "TimeoutError" {
+	switch err.Name {
+	case "TimeoutError":
 		return fmt.Errorf("%w: %w: %w", ErrPlaywright, ErrTimeout, &err)
-	} else if err.Name == "TargetClosedError" {
+	case "TargetClosedError":
 		return fmt.Errorf("%w: %w: %w", ErrPlaywright, ErrTargetClosed, &err)
 	}
 	return fmt.Errorf("%w: %w", ErrPlaywright, &err)

--- a/har_router.go
+++ b/har_router.go
@@ -45,7 +45,7 @@ func (r *harRouter) addPageRoute(page Page) error {
 }
 
 func (r *harRouter) dispose() {
-	go r.localUtils.HarClose(r.harId)
+	go r.localUtils.HarClose(r.harId) //nolint:errcheck
 }
 
 func (r *harRouter) handle(route Route) error {

--- a/locator_helpers.go
+++ b/locator_helpers.go
@@ -28,7 +28,7 @@ func escapeForAttributeSelector(text any, exact bool) string {
 		if exact {
 			suffix = "s"
 		}
-		return fmt.Sprintf(`"%s"%s`, strings.Replace(strings.Replace(text.(string), `\`, `\\`, -1), `"`, `\"`, -1), suffix)
+		return fmt.Sprintf(`"%s"%s`, strings.ReplaceAll(strings.ReplaceAll(text.(string), `\`, `\\`), `"`, `\"`), suffix)
 	}
 }
 

--- a/run.go
+++ b/run.go
@@ -455,7 +455,7 @@ func downloadDriver(driverURLs []string) (body []byte, e error) {
 			e = errors.Join(e, fmt.Errorf("could not download driver from %s: %w", driverURL, err))
 			continue
 		}
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck
 		if resp.StatusCode != http.StatusOK {
 			e = errors.Join(e, fmt.Errorf("error: got non 200 status code: %d (%s) from %s", resp.StatusCode, resp.Status, driverURL))
 			continue

--- a/run_test.go
+++ b/run_test.go
@@ -96,7 +96,7 @@ func TestDriverInstall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not set PLAYWRIGHT_BROWSERS_PATH: %v", err)
 	}
-	defer os.Unsetenv("PLAYWRIGHT_BROWSERS_PATH")
+	defer os.Unsetenv("PLAYWRIGHT_BROWSERS_PATH") //nolint:errcheck
 	err = driver.Install()
 	if err != nil {
 		t.Fatalf("could not install driver: %v", err)
@@ -127,7 +127,7 @@ func TestDriverDownloadHostEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not set PLAYWRIGHT_DOWNLOAD_HOST: %v", err)
 	}
-	defer os.Unsetenv("PLAYWRIGHT_DOWNLOAD_HOST")
+	defer os.Unsetenv("PLAYWRIGHT_DOWNLOAD_HOST") //nolint:errcheck
 	err = driver.Install()
 	if err == nil || !strings.Contains(err.Error(), "404 Not Found") || !strings.Contains(uri, "/builds/driver") {
 		t.Fatalf("PLAYWRIGHT_DOWNLOAD_HOST do not work: %v", err)

--- a/stream.go
+++ b/stream.go
@@ -20,7 +20,7 @@ func (s *streamImpl) SaveAs(path string) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer file.Close() //nolint:errcheck
 	writer := bufio.NewWriter(file)
 	for {
 		binary, err := s.channel.Send("read", map[string]any{"size": 1024 * 1024})

--- a/tests/browser_context_client_certificates_test.go
+++ b/tests/browser_context_client_certificates_test.go
@@ -115,7 +115,7 @@ func TestClientCerts(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		defer context2.Close()
+		defer context2.Close() //nolint:errcheck
 		page2, err := context2.NewPage()
 		require.NoError(t, err)
 

--- a/tests/browser_context_close_race_test.go
+++ b/tests/browser_context_close_race_test.go
@@ -56,16 +56,16 @@ func TestBrowserContextCloseRace(t *testing.T) {
 
 	harFile, err := os.CreateTemp("", "test-*.har")
 	require.NoError(t, err)
-	defer os.Remove(harFile.Name())
+	defer os.Remove(harFile.Name()) //nolint:errcheck
 
 	_, err = harFile.WriteString(harContent)
 	require.NoError(t, err)
-	harFile.Close()
+	harFile.Close() //nolint:errcheck
 
 	// Create a new context for this test (don't use BeforeEach)
 	testContext, err := browser.NewContext()
 	require.NoError(t, err)
-	defer testContext.Close()
+	defer testContext.Close() //nolint:errcheck
 
 	// Set up HAR replay - registers internal route handlers
 	err = testContext.RouteFromHAR(harFile.Name(), playwright.BrowserContextRouteFromHAROptions{

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -106,7 +106,7 @@ func TestBrowserContextSetHttpCredentials(t *testing.T) {
 	response, err := page.Goto(server.EMPTY_PAGE)
 	require.NoError(t, err)
 	require.Equal(t, 401, response.Status())
-	context.Close()
+	context.Close() //nolint:errcheck
 
 	context, page = newBrowserContextAndPage(t, playwright.BrowserNewContextOptions{
 		AcceptDownloads: playwright.Bool(true),
@@ -372,7 +372,7 @@ func TestBrowserContextEventsRequestFailed(t *testing.T) {
 		if ok {
 			conn, _, err := hw.Hijack()
 			if err == nil {
-				conn.Close()
+				conn.Close() //nolint:errcheck
 			}
 		}
 	})
@@ -412,7 +412,7 @@ func TestBrowserContextShouldFireCloseEvent(t *testing.T) {
 
 	browser1, err := browserType.Launch()
 	require.NoError(t, err)
-	defer browser1.Close()
+	defer browser1.Close() //nolint:errcheck
 	context1, err := browser1.NewContext()
 	require.NoError(t, err)
 	closed := false

--- a/tests/browser_type_test.go
+++ b/tests/browser_type_test.go
@@ -77,7 +77,7 @@ func TestBrowserTypeConnect(t *testing.T) {
 	browser1, err := browserType.Connect(remoteServer.url)
 	require.NoError(t, err)
 	require.NotNil(t, browser1)
-	defer browser1.Close()
+	defer browser1.Close() //nolint:errcheck
 
 	browser_context, err := browser1.NewContext()
 	require.NoError(t, err)
@@ -99,7 +99,7 @@ func TestBrowserTypeConnectShouldBeAbleToReconnectToBrowser(t *testing.T) {
 	browser1, err := browserType.Connect(remoteServer.url)
 	require.NoError(t, err)
 	require.NotNil(t, browser1)
-	defer browser1.Close()
+	defer browser1.Close() //nolint:errcheck
 
 	require.Len(t, browser1.Contexts(), 0)
 	browser_context, err := browser1.NewContext()
@@ -117,7 +117,7 @@ func TestBrowserTypeConnectShouldBeAbleToReconnectToBrowser(t *testing.T) {
 	browser1, err = browserType.Connect(remoteServer.url)
 	require.NoError(t, err)
 	require.NotNil(t, browser1)
-	defer browser1.Close()
+	defer browser1.Close() //nolint:errcheck
 
 	require.Len(t, browser1.Contexts(), 0)
 	browser_context, err = browser1.NewContext()
@@ -178,7 +178,7 @@ func TestBrowserTypeConnectSlowMo(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, browser1)
-	defer browser1.Close()
+	defer browser1.Close() //nolint:errcheck
 
 	browser_context, err := browser1.NewContext()
 	require.NoError(t, err)
@@ -202,7 +202,7 @@ func TestBrowserTypeConnectArtifactPath(t *testing.T) {
 	browser1, err := browserType.Connect(remoteServer.url)
 	require.NoError(t, err)
 	require.NotNil(t, browser1)
-	defer browser1.Close()
+	defer browser1.Close() //nolint:errcheck
 
 	recordVideoDir := t.TempDir()
 	browserContext, err := browser1.NewContext(playwright.BrowserNewContextOptions{
@@ -212,10 +212,10 @@ func TestBrowserTypeConnectArtifactPath(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, browserContext)
-	defer browserContext.Close()
+	defer browserContext.Close() //nolint:errcheck
 	page, err := browserContext.NewPage()
 	require.NoError(t, err)
-	defer page.Close()
+	defer page.Close() //nolint:errcheck
 	_, err = page.Goto(server.EMPTY_PAGE)
 	require.NoError(t, err)
 	_, err = page.Video().Path()
@@ -235,11 +235,11 @@ func TestBrowserTypeConnectOverCDP(t *testing.T) {
 		Args: []string{fmt.Sprintf("--remote-debugging-port=%d", port)},
 	})
 	require.NoError(t, err)
-	defer browserServer.Close()
+	defer browserServer.Close() //nolint:errcheck
 	browser, err := browserType.ConnectOverCDP(fmt.Sprintf("http://localhost:%d", port))
 	require.NoError(t, err)
 	require.NotNil(t, browser)
-	defer browser.Close()
+	defer browser.Close() //nolint:errcheck
 	require.Len(t, browser.Contexts(), 1)
 }
 
@@ -255,15 +255,15 @@ func TestBrowserTypeConnectOverCDPTwice(t *testing.T) {
 		Args: []string{fmt.Sprintf("--remote-debugging-port=%d", port)},
 	})
 	require.NoError(t, err)
-	defer browserServer.Close()
+	defer browserServer.Close() //nolint:errcheck
 	browser1, err := browserType.ConnectOverCDP(fmt.Sprintf("http://localhost:%d", port))
 	require.NoError(t, err)
 	require.NotNil(t, browser1)
 	browser2, err := browserType.ConnectOverCDP(fmt.Sprintf("http://localhost:%d", port))
 	require.NoError(t, err)
 	require.NotNil(t, browser2)
-	defer browser1.Close()
-	defer browser2.Close()
+	defer browser1.Close() //nolint:errcheck
+	defer browser2.Close() //nolint:errcheck
 	require.Len(t, browser1.Contexts(), 1)
 	page1, err := browser1.Contexts()[0].NewPage()
 	require.NoError(t, err)
@@ -289,7 +289,7 @@ func TestSetInputFilesShouldPreserveLastModifiedTimestamp(t *testing.T) {
 	browser1, err := browserType.Connect(remoteServer.url)
 	require.NoError(t, err)
 	require.NotNil(t, browser1)
-	defer browser1.Close()
+	defer browser1.Close() //nolint:errcheck
 
 	browser_context, err := browser1.NewContext()
 	require.NoError(t, err)
@@ -337,7 +337,7 @@ func TestShouldUploadAFolderRemote(t *testing.T) {
 	browser1, err := browserType.Connect(remoteServer.url)
 	require.NoError(t, err)
 	require.NotNil(t, browser1)
-	defer browser1.Close()
+	defer browser1.Close() //nolint:errcheck
 
 	browser_context, err := browser1.NewContext()
 	require.NoError(t, err)
@@ -366,7 +366,7 @@ func TestShouldUploadAFolderRemote(t *testing.T) {
 
 	expectResult := []interface{}{"file-upload-test/file1.txt", "file-upload-test/file2"}
 	// https://issues.chromium.org/issues/345393164
-	if !(isChromium && headless && chromiumVersionLessThan(browser.Version(), "127.0.6533.0")) {
+	if !isChromium || !headless || !chromiumVersionLessThan(browser.Version(), "127.0.6533.0") {
 		expectResult = append(expectResult, "file-upload-test/sub-dir/really.txt")
 	}
 	slices.SortFunc(ret.([]interface{}), func(i, j interface{}) int {

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -64,11 +64,12 @@ func BeforeAll() {
 	if err != nil {
 		log.Fatalf("could not start Playwright: %v", err)
 	}
-	if browserName == "chromium" || browserName == "" {
+	switch browserName {
+	case "chromium", "":
 		browserType = pw.Chromium
-	} else if browserName == "firefox" {
+	case "firefox":
 		browserType = pw.Firefox
-	} else if browserName == "webkit" {
+	case "webkit":
 		browserType = pw.WebKit
 	}
 	launchOptions := playwright.BrowserTypeLaunchOptions{

--- a/tests/input_test.go
+++ b/tests/input_test.go
@@ -258,7 +258,7 @@ func TestShouldUploadAFolder(t *testing.T) {
 
 	expectResult := []interface{}{"file-upload-test/file1.txt", "file-upload-test/file2"}
 	// https://issues.chromium.org/issues/345393164
-	if !(isChromium && headless && chromiumVersionLessThan(browser.Version(), "127.0.6533.0")) {
+	if !isChromium || !headless || !chromiumVersionLessThan(browser.Version(), "127.0.6533.0") {
 		expectResult = append(expectResult, "file-upload-test/sub-dir/really.txt")
 	}
 	slices.SortFunc(ret.([]interface{}), func(i, j interface{}) int {

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -534,7 +534,7 @@ func TestLocatorsShouldUploadFileRemote(t *testing.T) {
 	browser1, err := browserType.Connect(remoteServer.url)
 	require.NoError(t, err)
 	require.NotNil(t, browser1)
-	defer browser1.Close()
+	defer browser1.Close() //nolint:errcheck
 
 	browser_context, err := browser1.NewContext()
 	require.NoError(t, err)

--- a/tests/tracing_test.go
+++ b/tests/tracing_test.go
@@ -107,7 +107,7 @@ func TestBrowserContextTracingRemoteConnect(t *testing.T) {
 	browser1, err := browserType.Connect(remoteServer.url)
 	require.NoError(t, err)
 	require.NotNil(t, browser1)
-	defer browser1.Close()
+	defer browser1.Close() //nolint:errcheck
 
 	context1, err := browser1.NewContext()
 	require.NoError(t, err)
@@ -223,7 +223,7 @@ func parseTrace(t *testing.T, tracePath string) (files map[string][]byte, events
 	// read and unzip trace
 	r, err := zip.OpenReader(tracePath)
 	require.NoError(t, err)
-	defer r.Close()
+	defer r.Close() //nolint:errcheck
 
 	files = make(map[string][]byte)
 	events = make([]interface{}, 0)
@@ -231,7 +231,7 @@ func parseTrace(t *testing.T, tracePath string) (files map[string][]byte, events
 	for _, f := range r.File {
 		rc, err := f.Open()
 		require.NoError(t, err)
-		defer rc.Close()
+		defer rc.Close() //nolint:errcheck
 
 		buf := new(bytes.Buffer)
 		_, err = io.Copy(buf, rc)
@@ -268,9 +268,7 @@ func parseTrace(t *testing.T, tracePath string) (files map[string][]byte, events
 					actionMap[event["callId"].(string)] = event
 					events = append(events, event)
 				case "input":
-					break
 				case "after":
-					break
 				default:
 					events = append(events, event)
 				}
@@ -363,7 +361,7 @@ func TestTracingStartHarZipped(t *testing.T) {
 	// The zip contains the har.har entry alongside attached resources.
 	zr, err := zip.OpenReader(harPath)
 	require.NoError(t, err)
-	defer zr.Close()
+	defer zr.Close() //nolint:errcheck
 	var harEntry *zip.File
 	for _, f := range zr.File {
 		if f.Name == "har.har" {
@@ -374,7 +372,7 @@ func TestTracingStartHarZipped(t *testing.T) {
 	require.NotNil(t, harEntry, "zip should contain har.har")
 	rc, err := harEntry.Open()
 	require.NoError(t, err)
-	defer rc.Close()
+	defer rc.Close() //nolint:errcheck
 	data, err := io.ReadAll(rc)
 	require.NoError(t, err)
 	require.Contains(t, string(data), server.PREFIX+"/one-style.html")

--- a/tests/utils_test.go
+++ b/tests/utils_test.go
@@ -158,7 +158,7 @@ func (t *testServer) wsHandler(w http.ResponseWriter, r *http.Request) {
 		log.Println("testServer: could not upgrade ws connection:", err)
 		return
 	}
-	defer c.Close(websocket.StatusNormalClosure, "")
+	defer c.Close(websocket.StatusNormalClosure, "") //nolint:errcheck
 
 	t.eventEmitter.Emit("connection", c, r)
 
@@ -362,7 +362,7 @@ func getFreePort() (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer l.Close()
+	defer l.Close() //nolint:errcheck
 	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
@@ -371,7 +371,7 @@ func readFromZip(zipFile string, fileName string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer r.Close()
+	defer r.Close() //nolint:errcheck
 
 	for _, f := range r.File {
 		if f.Name == fileName {
@@ -379,7 +379,7 @@ func readFromZip(zipFile string, fileName string) ([]byte, error) {
 			if err != nil {
 				return nil, err
 			}
-			defer rc.Close()
+			defer rc.Close() //nolint:errcheck
 
 			buf := new(bytes.Buffer)
 			_, err = io.Copy(buf, rc)

--- a/tests/video_test.go
+++ b/tests/video_test.go
@@ -189,7 +189,7 @@ func TestVideo(t *testing.T) {
 		browser1, err := browserType.Connect(remoteServer.url)
 		require.NoError(t, err)
 		require.NotNil(t, browser1)
-		defer browser1.Close()
+		defer browser1.Close() //nolint:errcheck
 
 		browser_context, err := browser1.NewContext(playwright.BrowserNewContextOptions{
 			RecordVideo: &playwright.RecordVideo{

--- a/transport.go
+++ b/transport.go
@@ -46,7 +46,7 @@ func (t *pipeTransport) Poll() (*message, error) {
 		return nil, fmt.Errorf("could not decode json: %w", err)
 	}
 	if os.Getenv("DEBUGP") != "" {
-		fmt.Fprintf(os.Stdout, "\x1b[33mRECV>\x1b[0m\n%s\n", data)
+		fmt.Fprintf(os.Stdout, "\x1b[33mRECV>\x1b[0m\n%s\n", data) //nolint:errcheck
 	}
 	return msg, nil
 }
@@ -71,7 +71,7 @@ func (t *pipeTransport) Send(msg map[string]any) error {
 		return fmt.Errorf("pipeTransport: could not marshal json: %w", err)
 	}
 	if os.Getenv("DEBUGP") != "" {
-		fmt.Fprintf(os.Stdout, "\x1b[32mSEND>\x1b[0m\n%s\n", msgBytes)
+		fmt.Fprintf(os.Stdout, "\x1b[32mSEND>\x1b[0m\n%s\n", msgBytes) //nolint:errcheck
 	}
 
 	lengthPadding := make([]byte, 4)

--- a/writable_stream.go
+++ b/writable_stream.go
@@ -15,7 +15,7 @@ func (s *writableStream) Copy(file string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer f.Close() //nolint:errcheck
 
 	for {
 		buf := make([]byte, defaultCopyBufSize)


### PR DESCRIPTION
## What

Updates all GitHub Actions in the workflow files to their latest major versions and adds workflow concurrency control.

### Action version bumps
| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4 | v7 |
| `actions/setup-go` | v5 | v6 |
| `actions/cache` | v4 | v6 |
| `golangci/golangci-lint-action` | v6 | v9 |

Actions already pinned to their latest major (`shogo82148/actions-goveralls@v1`, `ruby/setup-ruby@v1`, `peaceiris/actions-gh-pages@v4`) are left as-is — those tags already track the newest release.

### golangci-lint v2 migration
`golangci-lint-action@v9` runs **golangci-lint v2**, which uses an incompatible config format. `.golangci.yaml` is migrated to the v2 schema:
- `gofumpt` moves from `linters` to `formatters`.
- v2 folds the old `stylecheck` (`ST10xx`) checks into `staticcheck`. These were never enforced here and would flag ~125 cosmetic issues (snake_case names, comment phrasing, capitalized error strings) — many of which intentionally mirror upstream Playwright. They are disabled so identifiers and error messages stay aligned with upstream.

### Lint fixes
With the v2 linters active, the remaining real findings are fixed:
- Unchecked error returns (`errcheck`) on deferred `Close()` / `Unsetenv()` calls — suppressed with `//nolint:errcheck`.
- `errors.go`: if/else-if → tagged `switch`.
- `helper_test.go`: if/else-if → tagged `switch`.
- `locator_helpers.go`: `strings.Replace(..., -1)` → `strings.ReplaceAll`.
- `input_test.go` / `browser_type_test.go`: De Morgan simplification.
- `tracing_test.go`: removed two ineffective `break` statements inside a `switch` (`SA4011`).

### Concurrency
Adds a `concurrency` group to each workflow (per the [GitHub docs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)):
- **build** and **verify_type_generation**: `cancel-in-progress: true` to cancel superseded CI runs on the same ref.
- **docs**: `cancel-in-progress: false` so an in-flight deploy is never interrupted.

## Verification
`golangci-lint run` (v2.12.2), `go build ./...`, `go vet ./...`, and `gofumpt -l .` all pass clean locally.