### PR TITLE
fix: prevent jsonPipe deadlock that hung remote connections

### DIFF
--- a/jsonPipe.go
+++ b/jsonPipe.go
@@ -4,11 +4,22 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 )
 
 type jsonPipe struct {
 	channelOwner
-	msgChan chan *message
+	// mu guards the queue and closed flag.
+	mu sync.Mutex
+	// queue holds messages received from the outer connection that have not yet
+	// been consumed by Poll(). It is unbounded on purpose: the outer connection's
+	// dispatch goroutine must never block while delivering a message here,
+	// otherwise it cannot deliver the reply that an in-flight Send() is waiting
+	// for, which deadlocks the whole connection (see the streaming upload path).
+	queue  []*message
+	closed bool
+	// signal wakes up a Poll() that is waiting for a message or for close.
+	signal chan struct{}
 }
 
 func (j *jsonPipe) Send(message map[string]any) error {
@@ -24,16 +35,57 @@ func (j *jsonPipe) Close() error {
 }
 
 func (j *jsonPipe) Poll() (*message, error) {
-	msg := <-j.msgChan
-	if msg == nil {
-		return nil, errors.New("jsonPipe closed")
+	for {
+		j.mu.Lock()
+		if len(j.queue) > 0 {
+			msg := j.queue[0]
+			j.queue = j.queue[1:]
+			j.mu.Unlock()
+			return msg, nil
+		}
+		if j.closed {
+			j.mu.Unlock()
+			return nil, errors.New("jsonPipe closed")
+		}
+		j.mu.Unlock()
+		<-j.signal
 	}
-	return msg, nil
+}
+
+// enqueue appends a message and wakes a waiting Poll(). It never blocks, so it
+// is safe to call from the outer connection's dispatch goroutine.
+func (j *jsonPipe) enqueue(msg *message) {
+	j.mu.Lock()
+	if j.closed {
+		j.mu.Unlock()
+		return
+	}
+	j.queue = append(j.queue, msg)
+	j.mu.Unlock()
+	j.wake()
+}
+
+func (j *jsonPipe) markClosed() {
+	j.mu.Lock()
+	if j.closed {
+		j.mu.Unlock()
+		return
+	}
+	j.closed = true
+	j.mu.Unlock()
+	j.wake()
+}
+
+func (j *jsonPipe) wake() {
+	select {
+	case j.signal <- struct{}{}:
+	default:
+	}
 }
 
 func newJsonPipe(parent *channelOwner, objectType string, guid string, initializer map[string]any) *jsonPipe {
 	j := &jsonPipe{
-		msgChan: make(chan *message, 10),
+		signal: make(chan struct{}, 1),
 	}
 	j.createChannelOwner(j, parent, objectType, guid, initializer)
 	j.channel.On("message", func(ev map[string]any) {
@@ -54,17 +106,14 @@ func newJsonPipe(parent *channelOwner, objectType string, guid string, initializ
 				},
 			}
 		}
-		// Send directly to maintain message ordering - the channel buffer prevents blocking
-		// Previously used a goroutine which could cause out-of-order delivery
-		defer func() {
-			// Recover from panic if channel is closed
-			_ = recover()
-		}()
-		j.msgChan <- &msg
+		// Enqueue without blocking the dispatch goroutine, while preserving
+		// message ordering. A bounded channel here could fill up and stall the
+		// dispatch goroutine, deadlocking any in-flight Send() awaiting a reply.
+		j.enqueue(&msg)
 	})
 	j.channel.Once("closed", func() {
 		j.Emit("closed")
-		close(j.msgChan)
+		j.markClosed()
 	})
 	return j
 }

--- a/jsonPipe_test.go
+++ b/jsonPipe_test.go
@@ -1,0 +1,114 @@
+package playwright
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newTestJsonPipe builds a jsonPipe without a backing connection so the queue
+// behavior can be tested in isolation.
+func newTestJsonPipe() *jsonPipe {
+	return &jsonPipe{
+		signal: make(chan struct{}, 1),
+	}
+}
+
+// TestJsonPipeEnqueueNeverBlocks guards against the deadlock where the outer
+// connection's dispatch goroutine blocks delivering a message because the queue
+// is full. enqueue must always return promptly, even with no consumer polling.
+func TestJsonPipeEnqueueNeverBlocks(t *testing.T) {
+	j := newTestJsonPipe()
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 1000; i++ {
+			j.enqueue(&message{ID: i})
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("enqueue blocked: producer did not finish without a consumer")
+	}
+}
+
+// TestJsonPipePreservesOrder verifies messages are delivered in the order they
+// were enqueued.
+func TestJsonPipePreservesOrder(t *testing.T) {
+	j := newTestJsonPipe()
+	for i := 0; i < 100; i++ {
+		j.enqueue(&message{ID: i})
+	}
+	for i := 0; i < 100; i++ {
+		msg, err := j.Poll()
+		require.NoError(t, err)
+		require.Equal(t, i, msg.ID)
+	}
+}
+
+// TestJsonPipePollBlocksUntilMessage verifies Poll waits for a message that is
+// enqueued concurrently.
+func TestJsonPipePollBlocksUntilMessage(t *testing.T) {
+	j := newTestJsonPipe()
+	got := make(chan *message, 1)
+	go func() {
+		msg, err := j.Poll()
+		require.NoError(t, err)
+		got <- msg
+	}()
+
+	// Give Poll a moment to start waiting, then deliver.
+	time.Sleep(50 * time.Millisecond)
+	j.enqueue(&message{ID: 42})
+
+	select {
+	case msg := <-got:
+		require.Equal(t, 42, msg.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Poll did not return after enqueue")
+	}
+}
+
+// TestJsonPipeCloseUnblocksPoll verifies that closing the pipe wakes a waiting
+// Poll with an error.
+func TestJsonPipeCloseUnblocksPoll(t *testing.T) {
+	j := newTestJsonPipe()
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := j.Poll()
+		errCh <- err
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	j.markClosed()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Poll did not return after close")
+	}
+}
+
+// TestJsonPipeDrainsQueueBeforeClose verifies buffered messages are still
+// delivered after the pipe is marked closed, before the close error.
+func TestJsonPipeDrainsQueueBeforeClose(t *testing.T) {
+	j := newTestJsonPipe()
+	for i := 0; i < 3; i++ {
+		j.enqueue(&message{ID: i})
+	}
+	j.markClosed()
+
+	for i := 0; i < 3; i++ {
+		msg, err := j.Poll()
+		require.NoError(t, err, fmt.Sprintf("message %d should drain before close", i))
+		require.Equal(t, i, msg.ID)
+	}
+	_, err := j.Poll()
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Problem

`TestShouldUploadAFolderRemote` is flaky on CI (e.g. [this main run](https://github.com/playwright-community/playwright-go/actions/runs/28136695452)), hanging until the test timeout:

```
playwright: timeout: Timeout 60000ms exceeded.
--- FAIL: TestShouldUploadAFolderRemote (60.89s)
```

It passes on re-run, and other remote tests on the same connection path can hang the same way.

## Root cause — a buffered-channel deadlock

The remote-connection transport (`jsonPipe`) delivered incoming messages into a **bounded channel (buffer 10)** directly from the *outer* connection's dispatch goroutine:

```go
msgChan: make(chan *message, 10)
...
j.channel.On("message", func(ev map[string]any) {
    ...
    j.msgChan <- &msg   // blocks when the buffer is full
})
```

The inner remote connection's `Poll()` drains `msgChan`. But that same outer dispatch goroutine is **also the only goroutine that delivers replies** to in-flight `Send()` calls. When more than 10 messages queue up before the inner connection drains them, the blocking send stalls the dispatch goroutine → it can no longer deliver the reply that an in-flight `Send()` is waiting for → the whole connection deadlocks.

Streaming a folder to a remote server produces exactly this burst: `createTempFiles` + a `write`/`close` per file + async page events (`loadstate`, `previewUpdated`, …). Under CI load this occasionally exceeds the buffer.

### Reproduction
Shrinking the buffer to 1 makes it deadlock deterministically. The goroutine dump confirms the mechanism:

```
goroutine N [chan send]:   jsonPipe.go  (dispatch goroutine blocked filling msgChan)
goroutine 1 [chan receive]: jsonPipe.Send (awaiting a reply that can never arrive)
```

## Fix

Replace the bounded channel with an **unbounded, order-preserving queue** drained by `Poll()`. The `message` handler now appends to the queue and signals a waiter, so the dispatch goroutine **never blocks**, while message ordering is preserved.

## Tests

Added `jsonPipe_test.go`:
- `TestJsonPipeEnqueueNeverBlocks` — the deadlock guard: 1000 enqueues with no consumer must complete promptly (the old bounded channel blocks here).
- `TestJsonPipePreservesOrder`, `TestJsonPipePollBlocksUntilMessage`, `TestJsonPipeCloseUnblocksPoll`, `TestJsonPipeDrainsQueueBeforeClose`.

All pass with `-race`. `TestShouldUploadAFolderRemote` runs 10/10 green locally after the change; the full internal suite passes with `-race`.