### PR TITLE
fix: allow blocking server calls inside event handlers (WIP)

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -68,7 +68,7 @@ func (c *channel) SendReturnAsDict(method string, options ...any) (map[string]an
 func (c *channel) innerSend(method string, options ...any) *protocolCallback {
 	if err := c.connection.err.Get(); err != nil {
 		c.connection.err.Set(nil)
-		pc := newProtocolCallback(false, c.connection.abort)
+		pc := newProtocolCallback(c.connection, false, c.connection.abort)
 		pc.SetError(err)
 		return pc
 	}

--- a/connection.go
+++ b/connection.go
@@ -36,18 +36,25 @@ type connection struct {
 	abortOnce    sync.Once
 	err          *safeValue[error] // for event listener error
 	closedError  *safeValue[error]
+
+	// dispatchGID is the id of the goroutine that runs the receive loop (and
+	// therefore synchronously runs event handlers). When a handler makes a
+	// blocking server call, the reply can only be delivered by this same
+	// goroutine; blocking on it would deadlock. waitResult detects that case by
+	// comparing against this id and instead pumps the receive loop re-entrantly
+	// until the reply arrives. Keeping all message processing on one goroutine
+	// preserves the original event ordering and avoids data races on the object
+	// graph.
+	dispatchGID atomic.Uint64
 }
 
 func (c *connection) Start() (*Playwright, error) {
 	go func() {
+		c.dispatchGID.Store(currentGoroutineID())
 		for {
-			msg, err := c.transport.Poll()
-			if err != nil {
-				_ = c.transport.Close()
-				c.cleanup(err)
+			if !c.pollOnce() {
 				return
 			}
-			c.Dispatch(msg)
 		}
 	}()
 
@@ -59,6 +66,21 @@ func (c *connection) Start() (*Playwright, error) {
 	}
 
 	return c.rootObject.initialize()
+}
+
+// pollOnce reads and dispatches a single message. It returns false when the
+// transport is closed or errors, signalling the receive loop to stop. It is
+// also called re-entrantly from waitResult to drain replies for a blocking
+// call made on the dispatch goroutine itself (see waitResult).
+func (c *connection) pollOnce() bool {
+	msg, err := c.transport.Poll()
+	if err != nil {
+		_ = c.transport.Close()
+		c.cleanup(err)
+		return false
+	}
+	c.Dispatch(msg)
+	return true
 }
 
 func (c *connection) Stop() error {
@@ -224,7 +246,7 @@ func (c *connection) replaceGuidsWithChannels(payload any) (any, error) {
 }
 
 func (c *connection) sendMessageToServer(object *channelOwner, method string, params any, noReply bool) (cb *protocolCallback) {
-	cb = newProtocolCallback(noReply, c.abort)
+	cb = newProtocolCallback(c, noReply, c.abort)
 
 	if err := c.closedError.Get(); err != nil {
 		cb.SetError(err)
@@ -368,12 +390,13 @@ func fromNullableChannel(v any) any {
 }
 
 type protocolCallback struct {
-	done    chan struct{}
-	noReply bool
-	abort   <-chan struct{}
-	once    sync.Once
-	value   map[string]any
-	err     error
+	connection *connection
+	done       chan struct{}
+	noReply    bool
+	abort      <-chan struct{}
+	once       sync.Once
+	value      map[string]any
+	err        error
 }
 
 func (pc *protocolCallback) setResultOnce(result map[string]any, err error) {
@@ -389,6 +412,30 @@ func (pc *protocolCallback) setResultOnce(result map[string]any, err error) {
 func (pc *protocolCallback) waitResult() {
 	if pc.noReply {
 		return
+	}
+	// A blocking call made from within an event handler runs on the dispatch
+	// goroutine, which is the only goroutine that can deliver this reply.
+	// Blocking on pc.done would deadlock, so instead drive the receive loop
+	// re-entrantly until the reply (or connection close) arrives.
+	if pc.connection.dispatchGID.Load() == currentGoroutineID() {
+		for {
+			select {
+			case <-pc.done:
+				return
+			case <-pc.abort:
+				pc.err = errors.New("Connection closed")
+				return
+			default:
+			}
+			if !pc.connection.pollOnce() {
+				select {
+				case <-pc.done:
+				default:
+					pc.err = errors.New("Connection closed")
+				}
+				return
+			}
+		}
 	}
 	select {
 	case <-pc.done: // wait for result
@@ -432,15 +479,17 @@ func (pc *protocolCallback) GetResultValue() (any, error) {
 	return pc.value, pc.err
 }
 
-func newProtocolCallback(noReply bool, abort <-chan struct{}) *protocolCallback {
+func newProtocolCallback(connection *connection, noReply bool, abort <-chan struct{}) *protocolCallback {
 	if noReply {
 		return &protocolCallback{
-			noReply: true,
-			abort:   abort,
+			connection: connection,
+			noReply:    true,
+			abort:      abort,
 		}
 	}
 	return &protocolCallback{
-		done:  make(chan struct{}, 1),
-		abort: abort,
+		connection: connection,
+		done:       make(chan struct{}, 1),
+		abort:      abort,
 	}
 }

--- a/goid.go
+++ b/goid.go
@@ -1,0 +1,36 @@
+package playwright
+
+import (
+	"runtime"
+	"strconv"
+	"sync"
+)
+
+var goidStackPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 64)
+		return &b
+	},
+}
+
+// currentGoroutineID returns the ID of the calling goroutine. The Go runtime
+// does not expose this, so it is parsed from the runtime stack header
+// ("goroutine <id> [...]"). It is used only to detect whether a blocking server
+// call is being made from the dispatch goroutine, in which case the reply must
+// be awaited by re-entrantly pumping the receive loop rather than blocking on a
+// channel that only the dispatch goroutine could ever signal.
+func currentGoroutineID() uint64 {
+	bp := goidStackPool.Get().(*[]byte)
+	defer goidStackPool.Put(bp)
+	b := (*bp)[:cap(*bp)]
+	b = b[:runtime.Stack(b, false)]
+	// Format: "goroutine 123 [running]:\n..."
+	const prefix = "goroutine "
+	b = b[len(prefix):]
+	i := 0
+	for i < len(b) && b[i] >= '0' && b[i] <= '9' {
+		i++
+	}
+	id, _ := strconv.ParseUint(string(b[:i]), 10, 64)
+	return id
+}

--- a/tests/network_test.go
+++ b/tests/network_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/playwright-community/playwright-go"
 	"github.com/stretchr/testify/require"
@@ -264,6 +265,42 @@ func TestNetworkEventsShouldFireEventsInProperOrder(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, response.Finished())
 	require.Equal(t, []string{"request", "response", "requestfinished"}, events)
+}
+
+// TestBlockingServerCallInsideEventHandler reproduces the deadlock cluster
+// (#391, #481, #398, #524, #574): making a blocking server round-trip from
+// inside an event handler must not freeze the connection dispatcher.
+func TestBlockingServerCallInsideEventHandler(t *testing.T) {
+	BeforeEach(t)
+
+	type result struct {
+		headers []playwright.NameValue
+		body    []byte
+		err     error
+	}
+	done := make(chan result, 1)
+	page.OnResponse(func(response playwright.Response) {
+		// HeadersArray() and Body() each issue a blocking server call.
+		// Before the fix these run on the dispatcher goroutine and deadlock.
+		headers, err := response.HeadersArray()
+		if err != nil {
+			done <- result{err: err}
+			return
+		}
+		body, err := response.Body()
+		done <- result{headers: headers, body: body, err: err}
+	})
+
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+
+	select {
+	case res := <-done:
+		require.NoError(t, res.err)
+		require.NotEmpty(t, res.headers)
+	case <-time.After(10 * time.Second):
+		t.Fatal("blocking server call inside an event handler deadlocked the dispatcher")
+	}
 }
 
 func TestRequestExistingResponse(t *testing.T) {


### PR DESCRIPTION
> **Draft — not ready to merge.** Known deadlock in the current approach (see below). Filed to track the issue and the iteration plan; #599 is unbundled from this and should merge on its own.

## The bug this targets (#391, #481, #398, #574)

The connection has **one dispatch goroutine** that both runs event handlers (`Dispatch` → `Emit`) and delivers the replies that unblock `Send()`. So a blocking call from inside an event handler — `Response.Body()`, `Request/Response.HeadersArray()`/`AllHeaders()`, `Page.EvaluateHandle()` from `OnResponse`/`OnRequest`/`OnRequestFinished`/`OnDOMContentLoaded` — waits forever for a reply only the goroutine it's occupying can deliver. Route handlers are immune because they run on a separate goroutine via `channel.CreateTask`.

## Why this PR is NOT ready

The current commit makes `waitResult` pump the receive loop re-entrantly when called on the dispatch goroutine. This works for a single event, **but deadlocks when a second event on the same channel arrives while the first handler is blocked**: `eventRegister.callHandlers` holds a per-event mutex across the whole handler, and the re-entrant `Emit` tries to re-lock it. Reproduced deterministically with a page of multiple sub-resources + `OnResponse` calling `Body()` (the common real-world case). The included test only covers the single-response path, which is why it passed.

## Iteration plan (shipping smaller, correct pieces instead of one big change)

1. **#599 (jsonPipe bounded-channel deadlock)** — independent, correct, ships on its own. *(unbundled from here)*
2. **Don't hold the `eventRegister` lock across handler execution** — small, independently-valuable fix; prerequisite for any re-entrant or cross-goroutine handler dispatch.
3. **The event-handler deadlock fix itself** — reworked and tested against the multi-event repro, not just the single-response happy path.

Superseding approach TBD; keeping this draft for the analysis and repro.