### PR TITLE
fix: eliminate the two remaining connection-layer deadlocks (event-handler + jsonPipe)

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -68,7 +68,7 @@ func (c *channel) SendReturnAsDict(method string, options ...any) (map[string]an
 func (c *channel) innerSend(method string, options ...any) *protocolCallback {
 	if err := c.connection.err.Get(); err != nil {
 		c.connection.err.Set(nil)
-		pc := newProtocolCallback(false, c.connection.abort)
+		pc := newProtocolCallback(c.connection, false, c.connection.abort)
 		pc.SetError(err)
 		return pc
 	}

--- a/connection.go
+++ b/connection.go
@@ -36,18 +36,25 @@ type connection struct {
 	abortOnce    sync.Once
 	err          *safeValue[error] // for event listener error
 	closedError  *safeValue[error]
+
+	// dispatchGID is the id of the goroutine that runs the receive loop (and
+	// therefore synchronously runs event handlers). When a handler makes a
+	// blocking server call, the reply can only be delivered by this same
+	// goroutine; blocking on it would deadlock. waitResult detects that case by
+	// comparing against this id and instead pumps the receive loop re-entrantly
+	// until the reply arrives. Keeping all message processing on one goroutine
+	// preserves the original event ordering and avoids data races on the object
+	// graph.
+	dispatchGID atomic.Uint64
 }
 
 func (c *connection) Start() (*Playwright, error) {
 	go func() {
+		c.dispatchGID.Store(currentGoroutineID())
 		for {
-			msg, err := c.transport.Poll()
-			if err != nil {
-				_ = c.transport.Close()
-				c.cleanup(err)
+			if !c.pollOnce() {
 				return
 			}
-			c.Dispatch(msg)
 		}
 	}()
 
@@ -59,6 +66,21 @@ func (c *connection) Start() (*Playwright, error) {
 	}
 
 	return c.rootObject.initialize()
+}
+
+// pollOnce reads and dispatches a single message. It returns false when the
+// transport is closed or errors, signalling the receive loop to stop. It is
+// also called re-entrantly from waitResult to drain replies for a blocking
+// call made on the dispatch goroutine itself (see waitResult).
+func (c *connection) pollOnce() bool {
+	msg, err := c.transport.Poll()
+	if err != nil {
+		_ = c.transport.Close()
+		c.cleanup(err)
+		return false
+	}
+	c.Dispatch(msg)
+	return true
 }
 
 func (c *connection) Stop() error {
@@ -224,7 +246,7 @@ func (c *connection) replaceGuidsWithChannels(payload any) (any, error) {
 }
 
 func (c *connection) sendMessageToServer(object *channelOwner, method string, params any, noReply bool) (cb *protocolCallback) {
-	cb = newProtocolCallback(noReply, c.abort)
+	cb = newProtocolCallback(c, noReply, c.abort)
 
 	if err := c.closedError.Get(); err != nil {
 		cb.SetError(err)
@@ -368,12 +390,13 @@ func fromNullableChannel(v any) any {
 }
 
 type protocolCallback struct {
-	done    chan struct{}
-	noReply bool
-	abort   <-chan struct{}
-	once    sync.Once
-	value   map[string]any
-	err     error
+	connection *connection
+	done       chan struct{}
+	noReply    bool
+	abort      <-chan struct{}
+	once       sync.Once
+	value      map[string]any
+	err        error
 }
 
 func (pc *protocolCallback) setResultOnce(result map[string]any, err error) {
@@ -389,6 +412,30 @@ func (pc *protocolCallback) setResultOnce(result map[string]any, err error) {
 func (pc *protocolCallback) waitResult() {
 	if pc.noReply {
 		return
+	}
+	// A blocking call made from within an event handler runs on the dispatch
+	// goroutine, which is the only goroutine that can deliver this reply.
+	// Blocking on pc.done would deadlock, so instead drive the receive loop
+	// re-entrantly until the reply (or connection close) arrives.
+	if pc.connection.dispatchGID.Load() == currentGoroutineID() {
+		for {
+			select {
+			case <-pc.done:
+				return
+			case <-pc.abort:
+				pc.err = errors.New("Connection closed")
+				return
+			default:
+			}
+			if !pc.connection.pollOnce() {
+				select {
+				case <-pc.done:
+				default:
+					pc.err = errors.New("Connection closed")
+				}
+				return
+			}
+		}
 	}
 	select {
 	case <-pc.done: // wait for result
@@ -432,15 +479,17 @@ func (pc *protocolCallback) GetResultValue() (any, error) {
 	return pc.value, pc.err
 }
 
-func newProtocolCallback(noReply bool, abort <-chan struct{}) *protocolCallback {
+func newProtocolCallback(connection *connection, noReply bool, abort <-chan struct{}) *protocolCallback {
 	if noReply {
 		return &protocolCallback{
-			noReply: true,
-			abort:   abort,
+			connection: connection,
+			noReply:    true,
+			abort:      abort,
 		}
 	}
 	return &protocolCallback{
-		done:  make(chan struct{}, 1),
-		abort: abort,
+		connection: connection,
+		done:       make(chan struct{}, 1),
+		abort:      abort,
 	}
 }

--- a/goid.go
+++ b/goid.go
@@ -1,0 +1,36 @@
+package playwright
+
+import (
+	"runtime"
+	"strconv"
+	"sync"
+)
+
+var goidStackPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 64)
+		return &b
+	},
+}
+
+// currentGoroutineID returns the ID of the calling goroutine. The Go runtime
+// does not expose this, so it is parsed from the runtime stack header
+// ("goroutine <id> [...]"). It is used only to detect whether a blocking server
+// call is being made from the dispatch goroutine, in which case the reply must
+// be awaited by re-entrantly pumping the receive loop rather than blocking on a
+// channel that only the dispatch goroutine could ever signal.
+func currentGoroutineID() uint64 {
+	bp := goidStackPool.Get().(*[]byte)
+	defer goidStackPool.Put(bp)
+	b := (*bp)[:cap(*bp)]
+	b = b[:runtime.Stack(b, false)]
+	// Format: "goroutine 123 [running]:\n..."
+	const prefix = "goroutine "
+	b = b[len(prefix):]
+	i := 0
+	for i < len(b) && b[i] >= '0' && b[i] <= '9' {
+		i++
+	}
+	id, _ := strconv.ParseUint(string(b[:i]), 10, 64)
+	return id
+}

--- a/jsonPipe.go
+++ b/jsonPipe.go
@@ -4,11 +4,22 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 )
 
 type jsonPipe struct {
 	channelOwner
-	msgChan chan *message
+	// mu guards the queue and closed flag.
+	mu sync.Mutex
+	// queue holds messages received from the outer connection that have not yet
+	// been consumed by Poll(). It is unbounded on purpose: the outer connection's
+	// dispatch goroutine must never block while delivering a message here,
+	// otherwise it cannot deliver the reply that an in-flight Send() is waiting
+	// for, which deadlocks the whole connection (see the streaming upload path).
+	queue  []*message
+	closed bool
+	// signal wakes up a Poll() that is waiting for a message or for close.
+	signal chan struct{}
 }
 
 func (j *jsonPipe) Send(message map[string]any) error {
@@ -24,16 +35,57 @@ func (j *jsonPipe) Close() error {
 }
 
 func (j *jsonPipe) Poll() (*message, error) {
-	msg := <-j.msgChan
-	if msg == nil {
-		return nil, errors.New("jsonPipe closed")
+	for {
+		j.mu.Lock()
+		if len(j.queue) > 0 {
+			msg := j.queue[0]
+			j.queue = j.queue[1:]
+			j.mu.Unlock()
+			return msg, nil
+		}
+		if j.closed {
+			j.mu.Unlock()
+			return nil, errors.New("jsonPipe closed")
+		}
+		j.mu.Unlock()
+		<-j.signal
 	}
-	return msg, nil
+}
+
+// enqueue appends a message and wakes a waiting Poll(). It never blocks, so it
+// is safe to call from the outer connection's dispatch goroutine.
+func (j *jsonPipe) enqueue(msg *message) {
+	j.mu.Lock()
+	if j.closed {
+		j.mu.Unlock()
+		return
+	}
+	j.queue = append(j.queue, msg)
+	j.mu.Unlock()
+	j.wake()
+}
+
+func (j *jsonPipe) markClosed() {
+	j.mu.Lock()
+	if j.closed {
+		j.mu.Unlock()
+		return
+	}
+	j.closed = true
+	j.mu.Unlock()
+	j.wake()
+}
+
+func (j *jsonPipe) wake() {
+	select {
+	case j.signal <- struct{}{}:
+	default:
+	}
 }
 
 func newJsonPipe(parent *channelOwner, objectType string, guid string, initializer map[string]any) *jsonPipe {
 	j := &jsonPipe{
-		msgChan: make(chan *message, 10),
+		signal: make(chan struct{}, 1),
 	}
 	j.createChannelOwner(j, parent, objectType, guid, initializer)
 	j.channel.On("message", func(ev map[string]any) {
@@ -54,17 +106,14 @@ func newJsonPipe(parent *channelOwner, objectType string, guid string, initializ
 				},
 			}
 		}
-		// Send directly to maintain message ordering - the channel buffer prevents blocking
-		// Previously used a goroutine which could cause out-of-order delivery
-		defer func() {
-			// Recover from panic if channel is closed
-			_ = recover()
-		}()
-		j.msgChan <- &msg
+		// Enqueue without blocking the dispatch goroutine, while preserving
+		// message ordering. A bounded channel here could fill up and stall the
+		// dispatch goroutine, deadlocking any in-flight Send() awaiting a reply.
+		j.enqueue(&msg)
 	})
 	j.channel.Once("closed", func() {
 		j.Emit("closed")
-		close(j.msgChan)
+		j.markClosed()
 	})
 	return j
 }

--- a/jsonPipe_test.go
+++ b/jsonPipe_test.go
@@ -1,0 +1,114 @@
+package playwright
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newTestJsonPipe builds a jsonPipe without a backing connection so the queue
+// behavior can be tested in isolation.
+func newTestJsonPipe() *jsonPipe {
+	return &jsonPipe{
+		signal: make(chan struct{}, 1),
+	}
+}
+
+// TestJsonPipeEnqueueNeverBlocks guards against the deadlock where the outer
+// connection's dispatch goroutine blocks delivering a message because the queue
+// is full. enqueue must always return promptly, even with no consumer polling.
+func TestJsonPipeEnqueueNeverBlocks(t *testing.T) {
+	j := newTestJsonPipe()
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 1000; i++ {
+			j.enqueue(&message{ID: i})
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("enqueue blocked: producer did not finish without a consumer")
+	}
+}
+
+// TestJsonPipePreservesOrder verifies messages are delivered in the order they
+// were enqueued.
+func TestJsonPipePreservesOrder(t *testing.T) {
+	j := newTestJsonPipe()
+	for i := 0; i < 100; i++ {
+		j.enqueue(&message{ID: i})
+	}
+	for i := 0; i < 100; i++ {
+		msg, err := j.Poll()
+		require.NoError(t, err)
+		require.Equal(t, i, msg.ID)
+	}
+}
+
+// TestJsonPipePollBlocksUntilMessage verifies Poll waits for a message that is
+// enqueued concurrently.
+func TestJsonPipePollBlocksUntilMessage(t *testing.T) {
+	j := newTestJsonPipe()
+	got := make(chan *message, 1)
+	go func() {
+		msg, err := j.Poll()
+		require.NoError(t, err)
+		got <- msg
+	}()
+
+	// Give Poll a moment to start waiting, then deliver.
+	time.Sleep(50 * time.Millisecond)
+	j.enqueue(&message{ID: 42})
+
+	select {
+	case msg := <-got:
+		require.Equal(t, 42, msg.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Poll did not return after enqueue")
+	}
+}
+
+// TestJsonPipeCloseUnblocksPoll verifies that closing the pipe wakes a waiting
+// Poll with an error.
+func TestJsonPipeCloseUnblocksPoll(t *testing.T) {
+	j := newTestJsonPipe()
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := j.Poll()
+		errCh <- err
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	j.markClosed()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Poll did not return after close")
+	}
+}
+
+// TestJsonPipeDrainsQueueBeforeClose verifies buffered messages are still
+// delivered after the pipe is marked closed, before the close error.
+func TestJsonPipeDrainsQueueBeforeClose(t *testing.T) {
+	j := newTestJsonPipe()
+	for i := 0; i < 3; i++ {
+		j.enqueue(&message{ID: i})
+	}
+	j.markClosed()
+
+	for i := 0; i < 3; i++ {
+		msg, err := j.Poll()
+		require.NoError(t, err, fmt.Sprintf("message %d should drain before close", i))
+		require.Equal(t, i, msg.ID)
+	}
+	_, err := j.Poll()
+	require.Error(t, err)
+}

--- a/tests/network_test.go
+++ b/tests/network_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/playwright-community/playwright-go"
 	"github.com/stretchr/testify/require"
@@ -264,6 +265,42 @@ func TestNetworkEventsShouldFireEventsInProperOrder(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, response.Finished())
 	require.Equal(t, []string{"request", "response", "requestfinished"}, events)
+}
+
+// TestBlockingServerCallInsideEventHandler reproduces the deadlock cluster
+// (#391, #481, #398, #524, #574): making a blocking server round-trip from
+// inside an event handler must not freeze the connection dispatcher.
+func TestBlockingServerCallInsideEventHandler(t *testing.T) {
+	BeforeEach(t)
+
+	type result struct {
+		headers []playwright.NameValue
+		body    []byte
+		err     error
+	}
+	done := make(chan result, 1)
+	page.OnResponse(func(response playwright.Response) {
+		// HeadersArray() and Body() each issue a blocking server call.
+		// Before the fix these run on the dispatcher goroutine and deadlock.
+		headers, err := response.HeadersArray()
+		if err != nil {
+			done <- result{err: err}
+			return
+		}
+		body, err := response.Body()
+		done <- result{headers: headers, body: body, err: err}
+	})
+
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+
+	select {
+	case res := <-done:
+		require.NoError(t, res.err)
+		require.NotEmpty(t, res.headers)
+	case <-time.After(10 * time.Second):
+		t.Fatal("blocking server call inside an event handler deadlocked the dispatcher")
+	}
 }
 
 func TestRequestExistingResponse(t *testing.T) {


### PR DESCRIPTION
Supersedes #599 and #600 — combines both connection-layer deadlock fixes into one branch and validates them together under heavy stress.

The transport/connection layer has **two independent deadlocks**, both rooted in the same fact: a single goroutine reads the transport, dispatches events, *and* delivers the replies that unblock `channel.Send`. Each fix targets a distinct way that goroutine can get stuck. They are orthogonal — neither fixes the other — so they belong together.

---

## Change 1 — blocking server calls inside event handlers (was #600)

**Problem.** Event handlers run synchronously on the dispatch goroutine (`connection.Dispatch` → `channel.Emit`). That goroutine is the *only* one that delivers protocol replies. So any blocking server call from inside a handler waits forever for a reply that only the goroutine it is blocking could deliver. This is the root cause behind a cluster of reports: #391, #481, #398, #574 (e.g. `Response.Body()` in `OnResponse`, `HeadersArray()` in `OnRequest`, `Evaluate()` in `OnDOMContentLoaded`).

**Fix.** When `waitResult` runs *on the dispatch goroutine* (detected via goroutine id), it pumps the receive loop re-entrantly (`pollOnce`) until the reply or connection-close arrives, instead of blocking on a channel only that goroutine could signal. Calls from any other goroutine are unchanged.

**Why re-entrant pumping and not a dedicated event goroutine:** a separate goroutine would (a) let replies overtake still-queued events, breaking the ordering guarantee that events arriving before a command's reply are observable when `Send` returns, and (b) race the object graph (`__create__`/`newPage` writing `frame.page` vs `onFrameNavigated` reading it). Single-goroutine processing keeps ordering and stays race-free.

## Change 2 — jsonPipe bounded-channel backpressure deadlock (was #599)

**Problem.** For remote connections (`browserType.Connect`), the inner transport `jsonPipe` delivered incoming messages into a **bounded channel (buffer 10)** *from the outer connection's dispatch goroutine*. When more than 10 messages queued before the inner `Poll()` drained them, that blocking send stalled the **outer** dispatch goroutine — which is also the only goroutine that delivers replies to in-flight `Send()` calls → deadlock. Streaming a folder upload to a remote server (`createTempFiles` + `write`/`close` per file + async page events) is exactly such a burst. Symptom: flaky hang in `TestShouldUploadAFolderRemote` / `TestLocatorsShouldUploadFileRemote`.

**Reproduction.** Shrinking the buffer to 1 makes it deadlock deterministically; the goroutine dump shows the dispatch goroutine blocked on `chan send` at `jsonPipe` while the test goroutine blocks on `chan receive` in `jsonPipe.Send`.

**Fix.** Replace the bounded channel with an unbounded, order-preserving queue drained by `Poll()`, so the dispatch goroutine never blocks while delivering a message. Ordering is preserved.

## Why these are different deadlocks (both needed)

- Change 1 fires inside `waitResult` when the **caller is the dispatch goroutine** (a user handler blocking on a reply).
- Change 2 fires inside the `jsonPipe` `"message"` handler when the **bounded channel is full** (backpressure stalling the outer dispatch goroutine for a *remote* connection).

Change 1 does not help Change 2: the jsonPipe block is a `chan send` on `msgChan`, not a `waitResult` on the dispatch goroutine. Change 2 does not help Change 1: a local connection has no jsonPipe. Shipping only one leaves the other class of hang in place.

## Tests

- `TestBlockingServerCallInsideEventHandler` — calls `HeadersArray()` + `Body()` inside `OnResponse` (10s guard). Deadlocks on `main`, passes here.
- `jsonPipe_test.go` — unit tests for the queue: non-blocking enqueue (the deadlock guard — fails against the old bounded channel), ordering, blocking `Poll`, close-unblocks-Poll, drain-before-close.

## Stress validation

All affected tests, run locally with `-race`, 12–20 concurrent processes:

| Test set | Browser(s) | Runs | Result |
|---|---|---|---|
| `TestBlockingServerCallInsideEventHandler` | chromium, firefox, webkit | 100× each | 100/100 |
| network/event-handler tests | chromium, firefox | 100× (×~5 tests) | 100/100 |
| remote/connect tests (jsonPipe) | chromium | 100× (×~10 tests) | 100/100 |
| `TestShouldUploadAFolderRemote` | webkit | 100× | 100/100 |
| close-race tests | chromium | 100× | 100/100 |

`go test -race .` (internal unit tests) and the full `./tests` suite pass with no data races.

Closes #391, #481, #398, #574.