### PR TITLE
fix: prevent deadlock when calling blocking methods inside event handlers

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -68,7 +68,7 @@ func (c *channel) SendReturnAsDict(method string, options ...any) (map[string]an
 func (c *channel) innerSend(method string, options ...any) *protocolCallback {
 	if err := c.connection.err.Get(); err != nil {
 		c.connection.err.Set(nil)
-		pc := newProtocolCallback(false, c.connection.abort)
+		pc := newProtocolCallback(c.connection, false, c.connection.abort)
 		pc.SetError(err)
 		return pc
 	}

--- a/connection.go
+++ b/connection.go
@@ -115,7 +115,14 @@ func (c *connection) Dispatch(msg *message) {
 	}
 	method := msg.Method
 	if msg.ID != 0 {
-		cb, _ := c.callbacks.LoadAndDelete(uint32(msg.ID))
+		cb, ok := c.callbacks.LoadAndDelete(uint32(msg.ID))
+		if !ok {
+			// No pending callback for this id (duplicate or unknown reply).
+			// Upstream throws "Cannot find command to respond"; dereferencing
+			// the nil callback below would instead panic the dispatch
+			// goroutine, so guard and ignore the stray reply.
+			return
+		}
 		if cb.noReply {
 			return
 		}

--- a/connection.go
+++ b/connection.go
@@ -416,14 +416,28 @@ func (pc *protocolCallback) waitResult() {
 	// A blocking call made from within an event handler runs on the dispatch
 	// goroutine, which is the only goroutine that can deliver this reply.
 	// Blocking on pc.done would deadlock, so instead drive the receive loop
-	// re-entrantly until the reply (or connection close) arrives.
-	if pc.connection.dispatchGID.Load() == currentGoroutineID() {
+	// re-entrantly until the reply (or connection close) arrives. If a reply
+	// dispatched here triggers another event whose handler makes a blocking
+	// call, waitResult re-enters; the recursion is bounded by the nesting depth
+	// of blocking-handler chains, which mirrors the synchronous client model.
+	//
+	// dispatchGID is 0 until the receive loop records its id; currentGoroutineID
+	// also returns 0 if the stack header can't be parsed. Guarding against 0
+	// ensures neither case is mistaken for the dispatch goroutine.
+	if gid := pc.connection.dispatchGID.Load(); gid != 0 && gid == currentGoroutineID() {
 		for {
 			select {
 			case <-pc.done:
 				return
 			case <-pc.abort:
-				pc.err = errors.New("Connection closed")
+				// Prefer a delivered result over the close error: setResultOnce
+				// sets value/err before closing done, so a closed done means a
+				// real result is already available.
+				select {
+				case <-pc.done:
+				default:
+					pc.err = errors.New("Connection closed")
+				}
 				return
 			default:
 			}

--- a/connection.go
+++ b/connection.go
@@ -36,18 +36,25 @@ type connection struct {
 	abortOnce    sync.Once
 	err          *safeValue[error] // for event listener error
 	closedError  *safeValue[error]
+
+	// dispatchGID is the id of the goroutine that runs the receive loop (and
+	// therefore synchronously runs event handlers). When a handler makes a
+	// blocking server call, the reply can only be delivered by this same
+	// goroutine; blocking on it would deadlock. waitResult detects that case by
+	// comparing against this id and instead pumps the receive loop re-entrantly
+	// until the reply arrives. Keeping all message processing on one goroutine
+	// preserves the original event ordering and avoids data races on the object
+	// graph.
+	dispatchGID atomic.Uint64
 }
 
 func (c *connection) Start() (*Playwright, error) {
 	go func() {
+		c.dispatchGID.Store(currentGoroutineID())
 		for {
-			msg, err := c.transport.Poll()
-			if err != nil {
-				_ = c.transport.Close()
-				c.cleanup(err)
+			if !c.pollOnce() {
 				return
 			}
-			c.Dispatch(msg)
 		}
 	}()
 
@@ -59,6 +66,21 @@ func (c *connection) Start() (*Playwright, error) {
 	}
 
 	return c.rootObject.initialize()
+}
+
+// pollOnce reads and dispatches a single message. It returns false when the
+// transport is closed or errors, signalling the receive loop to stop. It is
+// also called re-entrantly from waitResult to drain replies for a blocking
+// call made on the dispatch goroutine itself (see waitResult).
+func (c *connection) pollOnce() bool {
+	msg, err := c.transport.Poll()
+	if err != nil {
+		_ = c.transport.Close()
+		c.cleanup(err)
+		return false
+	}
+	c.Dispatch(msg)
+	return true
 }
 
 func (c *connection) Stop() error {
@@ -224,7 +246,7 @@ func (c *connection) replaceGuidsWithChannels(payload any) (any, error) {
 }
 
 func (c *connection) sendMessageToServer(object *channelOwner, method string, params any, noReply bool) (cb *protocolCallback) {
-	cb = newProtocolCallback(noReply, c.abort)
+	cb = newProtocolCallback(c, noReply, c.abort)
 
 	if err := c.closedError.Get(); err != nil {
 		cb.SetError(err)
@@ -368,12 +390,13 @@ func fromNullableChannel(v any) any {
 }
 
 type protocolCallback struct {
-	done    chan struct{}
-	noReply bool
-	abort   <-chan struct{}
-	once    sync.Once
-	value   map[string]any
-	err     error
+	connection *connection
+	done       chan struct{}
+	noReply    bool
+	abort      <-chan struct{}
+	once       sync.Once
+	value      map[string]any
+	err        error
 }
 
 func (pc *protocolCallback) setResultOnce(result map[string]any, err error) {
@@ -389,6 +412,30 @@ func (pc *protocolCallback) setResultOnce(result map[string]any, err error) {
 func (pc *protocolCallback) waitResult() {
 	if pc.noReply {
 		return
+	}
+	// A blocking call made from within an event handler runs on the dispatch
+	// goroutine, which is the only goroutine that can deliver this reply.
+	// Blocking on pc.done would deadlock, so instead drive the receive loop
+	// re-entrantly until the reply (or connection close) arrives.
+	if pc.connection.dispatchGID.Load() == currentGoroutineID() {
+		for {
+			select {
+			case <-pc.done:
+				return
+			case <-pc.abort:
+				pc.err = errors.New("Connection closed")
+				return
+			default:
+			}
+			if !pc.connection.pollOnce() {
+				select {
+				case <-pc.done:
+				default:
+					pc.err = errors.New("Connection closed")
+				}
+				return
+			}
+		}
 	}
 	select {
 	case <-pc.done: // wait for result
@@ -432,15 +479,17 @@ func (pc *protocolCallback) GetResultValue() (any, error) {
 	return pc.value, pc.err
 }
 
-func newProtocolCallback(noReply bool, abort <-chan struct{}) *protocolCallback {
+func newProtocolCallback(connection *connection, noReply bool, abort <-chan struct{}) *protocolCallback {
 	if noReply {
 		return &protocolCallback{
-			noReply: true,
-			abort:   abort,
+			connection: connection,
+			noReply:    true,
+			abort:      abort,
 		}
 	}
 	return &protocolCallback{
-		done:  make(chan struct{}, 1),
-		abort: abort,
+		connection: connection,
+		done:       make(chan struct{}, 1),
+		abort:      abort,
 	}
 }

--- a/goid.go
+++ b/goid.go
@@ -3,15 +3,7 @@ package playwright
 import (
 	"runtime"
 	"strconv"
-	"sync"
 )
-
-var goidStackPool = sync.Pool{
-	New: func() any {
-		b := make([]byte, 64)
-		return &b
-	},
-}
 
 // currentGoroutineID returns the ID of the calling goroutine. The Go runtime
 // does not expose this, so it is parsed from the runtime stack header
@@ -19,18 +11,32 @@ var goidStackPool = sync.Pool{
 // call is being made from the dispatch goroutine, in which case the reply must
 // be awaited by re-entrantly pumping the receive loop rather than blocking on a
 // channel that only the dispatch goroutine could ever signal.
+//
+// It is called once per blocking server call. runtime.Stack and the 64-byte
+// buffer it fills are not free, but both are cheap relative to the protocol
+// round-trip each such call already pays.
 func currentGoroutineID() uint64 {
-	bp := goidStackPool.Get().(*[]byte)
-	defer goidStackPool.Put(bp)
-	b := (*bp)[:cap(*bp)]
-	b = b[:runtime.Stack(b, false)]
+	// The header alone ("goroutine 123 [running]:") fits comfortably in 64
+	// bytes; runtime.Stack truncates to the buffer, which is all we need.
+	var buf [64]byte
+	b := buf[:runtime.Stack(buf[:], false)]
 	// Format: "goroutine 123 [running]:\n..."
 	const prefix = "goroutine "
+	if len(b) < len(prefix) {
+		return 0
+	}
 	b = b[len(prefix):]
 	i := 0
 	for i < len(b) && b[i] >= '0' && b[i] <= '9' {
 		i++
 	}
-	id, _ := strconv.ParseUint(string(b[:i]), 10, 64)
+	id, err := strconv.ParseUint(string(b[:i]), 10, 64)
+	if err != nil {
+		// Unexpected stack header format. Return 0, which is never a valid
+		// goroutine id (the runtime numbers them from 1), so the caller is not
+		// mistaken for the dispatch goroutine and safely takes the normal
+		// blocking path.
+		return 0
+	}
 	return id
 }

--- a/goid.go
+++ b/goid.go
@@ -1,0 +1,36 @@
+package playwright
+
+import (
+	"runtime"
+	"strconv"
+	"sync"
+)
+
+var goidStackPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 64)
+		return &b
+	},
+}
+
+// currentGoroutineID returns the ID of the calling goroutine. The Go runtime
+// does not expose this, so it is parsed from the runtime stack header
+// ("goroutine <id> [...]"). It is used only to detect whether a blocking server
+// call is being made from the dispatch goroutine, in which case the reply must
+// be awaited by re-entrantly pumping the receive loop rather than blocking on a
+// channel that only the dispatch goroutine could ever signal.
+func currentGoroutineID() uint64 {
+	bp := goidStackPool.Get().(*[]byte)
+	defer goidStackPool.Put(bp)
+	b := (*bp)[:cap(*bp)]
+	b = b[:runtime.Stack(b, false)]
+	// Format: "goroutine 123 [running]:\n..."
+	const prefix = "goroutine "
+	b = b[len(prefix):]
+	i := 0
+	for i < len(b) && b[i] >= '0' && b[i] <= '9' {
+		i++
+	}
+	id, _ := strconv.ParseUint(string(b[:i]), 10, 64)
+	return id
+}

--- a/tests/network_test.go
+++ b/tests/network_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/playwright-community/playwright-go"
 	"github.com/stretchr/testify/require"
@@ -264,6 +265,42 @@ func TestNetworkEventsShouldFireEventsInProperOrder(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, response.Finished())
 	require.Equal(t, []string{"request", "response", "requestfinished"}, events)
+}
+
+// TestBlockingServerCallInsideEventHandler reproduces the deadlock cluster
+// (#391, #481, #398, #524, #574): making a blocking server round-trip from
+// inside an event handler must not freeze the connection dispatcher.
+func TestBlockingServerCallInsideEventHandler(t *testing.T) {
+	BeforeEach(t)
+
+	type result struct {
+		headers []playwright.NameValue
+		body    []byte
+		err     error
+	}
+	done := make(chan result, 1)
+	page.OnResponse(func(response playwright.Response) {
+		// HeadersArray() and Body() each issue a blocking server call.
+		// Before the fix these run on the dispatcher goroutine and deadlock.
+		headers, err := response.HeadersArray()
+		if err != nil {
+			done <- result{err: err}
+			return
+		}
+		body, err := response.Body()
+		done <- result{headers: headers, body: body, err: err}
+	})
+
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+
+	select {
+	case res := <-done:
+		require.NoError(t, res.err)
+		require.NotEmpty(t, res.headers)
+	case <-time.After(10 * time.Second):
+		t.Fatal("blocking server call inside an event handler deadlocked the dispatcher")
+	}
 }
 
 func TestRequestExistingResponse(t *testing.T) {


### PR DESCRIPTION
Second of two small, independent connection-layer deadlock fixes (the other is the jsonPipe unbounded-queue PR #602). They touch **disjoint files** and were verified independent by ablation, so they can be reviewed/merged in any order.

> [!IMPORTANT]
> This branch must be brought up to date with `main` before merging. The fix has a correctness dependency on #604 ("do not hold the eventRegister lock while running event handlers"), which is already on `main` but is **not** in this branch's merge-base. The merged result is safe (the files are disjoint and git merges cleanly), but the branch built in isolation deadlocks on the nested-event case below — see Tests.

## Problem

Event handlers run **synchronously on the single connection dispatch goroutine** (`connection.Dispatch` → `channel.Emit`). That same goroutine is the *only* one that delivers protocol replies — the replies that unblock `channel.Send`.

So any **blocking server call made from inside an event handler** waits forever: the reply it needs can only be delivered by the goroutine it is currently blocking. This affects, among others:

- `Response.Body()` / `Text()` / `JSON()` inside `OnResponse`
- `Request/Response.HeadersArray()` / `AllHeaders()` / `HeaderValue()` inside `OnRequest` / `OnResponse`
- `Page.Evaluate()` / `EvaluateHandle()` inside `OnDOMContentLoaded`

Route handlers don't hit this because they already run on a separate goroutine via `channel.CreateTask`; plain event handlers do not. This is the root cause shared by #391, #481, #398, #574.

## Fix

When `protocolCallback.waitResult` is invoked **on the dispatch goroutine itself** (detected via goroutine id), it drives the receive loop re-entrantly (`connection.pollOnce()`) until the reply (or connection close) arrives — instead of blocking on a channel only the dispatch goroutine could ever signal. Calls from any other goroutine behave exactly as before.

The dispatch goroutine is identified by recording its goroutine id at loop start (`goid.go`) and comparing in `waitResult`. This mirrors the upstream **playwright-python sync API**, which solves the identical problem by switching back to the dispatcher fiber (greenlet) while a blocking call is in flight.

This also bundles a small, related robustness fix: `Dispatch` now guards against a missing callback on an unknown/duplicate reply id instead of dereferencing a nil `*protocolCallback`. That nil-deref was latent before, but the re-entrant pump makes `Dispatch` reachable from inside a user handler, widening its blast radius. Upstream throws "Cannot find command to respond"; here we ignore the stray reply rather than panic the dispatch goroutine.

### Why re-entrant pumping rather than a separate event-loop goroutine
Moving event emission to a dedicated goroutine was considered and rejected: it (a) lets replies overtake still-queued events, breaking the ordering guarantee that events arriving before a command's reply are observable by the time `Send` returns, and (b) introduces data races on the object graph, because object lifecycle (`__create__`, e.g. `newPage` writing `frame.page`) and event handlers (e.g. `onFrameNavigated` reading `frame.page`) would then run on different goroutines. Keeping all message processing on one goroutine preserves ordering and stays race-free.

## Tests

`TestBlockingServerCallInsideEventHandler` — calls `HeadersArray()` + `Body()` inside `OnResponse`, guarded by a 10s timeout. Deadlocks on `main`, passes here.

This covers the single-event case. There is a second, nastier case: a blocking call inside a handler pumps the receive loop, which can deliver **another event of the same type** before the reply arrives, re-entering `Emit` → `callHandlers`. If `callHandlers` holds the eventRegister lock across handler execution (as it did before #604), this re-locks a non-reentrant mutex on the same goroutine and deadlocks. #604 already makes `callHandlers` lock-free, so the case is safe **once this branch is up to date with `main`** — hence the note at the top. (Reproduced locally: a page loading many parallel subresources with a blocking `Body()` in `OnResponse` deadlocks against the pre-#604 lock and passes with it.)

Stress-tested locally with `-race`: 100×/20-parallel on chromium, firefox, and webkit (100/100 each); full `./tests` and root package report no data races.

Closes #391
Closes #481
Closes #398
Closes #574
