### PR TITLE
fix: do not hold eventRegister lock while running event handlers

### DIFF
--- a/event_emitter.go
+++ b/event_emitter.go
@@ -154,15 +154,18 @@ func (er *eventRegister) callHandlers(payloads ...any) int {
 	// lock, but invoke the handlers *without* the lock held. Handlers run
 	// arbitrary user code that may call back into the emitter (e.g. removing a
 	// listener) or block on a server round-trip; holding er across that call
-	// would serialize or deadlock those paths.
+	// would serialize or deadlock those paths. The snapshot also fixes the set
+	// of handlers for this dispatch: listeners added or removed by a handler
+	// take effect on the next Emit, matching Node's EventEmitter semantics.
 	er.Lock()
-	snapshot := make([]listener, len(er.listeners))
-	copy(snapshot, er.listeners)
-	for _, l := range snapshot {
-		if l.once {
-			er.removeHandler(l.handler)
-		}
+	if len(er.listeners) == 0 {
+		er.Unlock()
+		return 0
 	}
+	snapshot := slices.Clone(er.listeners)
+	er.listeners = slices.DeleteFunc(er.listeners, func(l listener) bool {
+		return l.once
+	})
 	er.Unlock()
 
 	for _, l := range snapshot {

--- a/event_emitter.go
+++ b/event_emitter.go
@@ -150,14 +150,23 @@ func (er *eventRegister) callHandlers(payloads ...any) int {
 		handlerV.Call(payloadV[:int(math.Min(float64(handlerV.Type().NumIn()), float64(len(payloadV))))])
 	}
 
+	// Snapshot the listeners and remove the one-shot ones while holding the
+	// lock, but invoke the handlers *without* the lock held. Handlers run
+	// arbitrary user code that may call back into the emitter (e.g. removing a
+	// listener) or block on a server round-trip; holding er across that call
+	// would serialize or deadlock those paths.
 	er.Lock()
-	defer er.Unlock()
-	count := len(er.listeners)
-	for _, l := range er.listeners {
+	snapshot := make([]listener, len(er.listeners))
+	copy(snapshot, er.listeners)
+	for _, l := range snapshot {
 		if l.once {
-			defer er.removeHandler(l.handler)
+			er.removeHandler(l.handler)
 		}
+	}
+	er.Unlock()
+
+	for _, l := range snapshot {
 		handle(l)
 	}
-	return count
+	return len(snapshot)
 }

--- a/event_emitter_test.go
+++ b/event_emitter_test.go
@@ -1,7 +1,9 @@
 package playwright
 
 import (
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -102,4 +104,42 @@ func TestEventEmitterOnLessArgsAcceptingReceiver(t *testing.T) {
 	})
 	handler.Emit(testEventName)
 	<-wasCalled
+}
+
+// TestEventEmitterHandlerCanReenter verifies that a handler may call back into
+// the same event's registry (here, registering another listener) while it is
+// running. This only works if Emit does not hold the per-event lock across
+// handler execution; otherwise the re-entrant call would deadlock.
+func TestEventEmitterHandlerCanReenter(t *testing.T) {
+	handler := &eventEmitter{}
+	done := make(chan bool, 1)
+	handler.On(testEventName, func(...any) {
+		// Re-enter the emitter from within the handler.
+		handler.On(testEventNameFoo, func(...any) {})
+		_ = handler.ListenerCount(testEventName)
+		done <- true
+	})
+
+	go handler.Emit(testEventName)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler that re-enters the emitter deadlocked: lock held across handler execution")
+	}
+	require.Equal(t, 1, handler.ListenerCount(testEventNameFoo))
+}
+
+// TestEventEmitterOnceRunsExactlyOnce verifies a one-shot listener fires once
+// even though removal now happens before handler invocation.
+func TestEventEmitterOnceRunsExactlyOnce(t *testing.T) {
+	handler := &eventEmitter{}
+	var calls int32
+	handler.Once(testEventName, func(...any) {
+		atomic.AddInt32(&calls, 1)
+	})
+	handler.Emit(testEventName)
+	handler.Emit(testEventName)
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls))
+	require.Equal(t, 0, handler.ListenerCount(testEventName))
 }


### PR DESCRIPTION
## Problem

`eventRegister.callHandlers` holds the per-event mutex across the **entire** handler invocation:

```go
er.Lock()
defer er.Unlock()
for _, l := range er.listeners {
    if l.once { defer er.removeHandler(l.handler) }
    handle(l)   // arbitrary user code, lock held
}
```

Event handlers run arbitrary user code. If a handler calls back into the **same** event's registry — registering a listener, querying `ListenerCount`, etc. — it re-locks a non-reentrant mutex and **deadlocks**. Holding the lock across handlers also needlessly serializes otherwise-independent work.

## Fix

Snapshot the listener slice and remove one-shot listeners **while holding the lock**, then invoke the handlers **with the lock released**:

```go
er.Lock()
if len(er.listeners) == 0 {
    er.Unlock()
    return 0
}
snapshot := slices.Clone(er.listeners)
er.listeners = slices.DeleteFunc(er.listeners, func(l listener) bool { return l.once })
er.Unlock()
for _, l := range snapshot { handle(l) }
```

- Removal still happens under the lock, so the once-exactly-once guarantee is preserved.
- One-shot listeners are removed in a single `DeleteFunc` pass (O(n) instead of O(n·k)).
- The empty-listener case skips the snapshot allocation, keeping the common path allocation-free.
- The snapshot also fixes the set of handlers for a given dispatch — listeners added/removed by a handler take effect on the next `Emit`, matching Node's `EventEmitter` semantics.

## Why this is worth shipping on its own

This is a correctness/robustness fix that stands alone, independent of any larger event-dispatch rework. It is also a **prerequisite** for safely letting handlers make blocking server calls (the deadlock cluster #391/#481/#398/#574): any approach that re-enters or re-dispatches while a handler runs is impossible while this lock is held across handlers.

## Tests

- `TestEventEmitterHandlerCanReenter` — a handler that re-enters the emitter must complete, not deadlock (fails on `main`).
- `TestEventEmitterOnceRunsExactlyOnce` — one-shot listener still fires exactly once now that removal precedes invocation.
- Existing emitter tests unchanged. Stress: 100× sequential + 20 parallel × 50 under `-race`, all green; integration event/network/route/dialog/console/download tests pass. Additionally verified once-exactly-once under 16-way concurrent `Emit` × 500 iterations under `-race`.
