### PR TITLE
fix: resolve Locator.Evaluate with attached state to match upstream

### DIFF
--- a/locator.go
+++ b/locator.go
@@ -937,13 +937,24 @@ func (l *locatorImpl) withElement(
 	if l.err != nil {
 		return nil, l.err
 	}
-	handle, err := l.frame.WaitForSelector(l.selector, options...)
+	option := FrameWaitForSelectorOptions{
+		State:  WaitForSelectorStateAttached,
+		Strict: Bool(true),
+	}
+	if len(options) == 1 {
+		option.Timeout = options[0].Timeout
+	}
+	handle, err := l.frame.WaitForSelector(l.selector, option)
 	if err != nil {
 		return nil, err
 	}
 
 	result, err := callback(handle)
 	if err != nil {
+		_ = handle.Dispose()
+		return nil, err
+	}
+	if err := handle.Dispose(); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -329,6 +329,17 @@ func TestLocatorTextContent(t *testing.T) {
 	require.Equal(t, "Text,\nmore text", result)
 }
 
+func TestLocatorEvaluateShouldWorkOnHiddenElement(t *testing.T) {
+	BeforeEach(t)
+
+	// Evaluate resolves the element with state "attached" rather than the
+	// default "visible", so it must not time out on a hidden element.
+	require.NoError(t, page.SetContent(`<div id="target" style="display:none">hi</div>`))
+	tagName, err := page.Locator("#target").Evaluate(`e => e.tagName`, nil)
+	require.NoError(t, err)
+	require.Equal(t, "DIV", tagName)
+}
+
 func TestLocatorShouldFocusAndBlurButton(t *testing.T) {
 	BeforeEach(t)
 

--- a/tests/video_test.go
+++ b/tests/video_test.go
@@ -3,6 +3,7 @@ package playwright_test
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -223,23 +224,39 @@ func TestScreencastStartStop(t *testing.T) {
 	screencast, err := page.Screencast()
 	require.NoError(t, err)
 
-	var frames [][]byte
+	var (
+		mu         sync.Mutex
+		frames     [][]byte
+		firstFrame = make(chan struct{}, 1)
+	)
 	err = screencast.Start(playwright.ScreencastStartOptions{
 		OnFrame: func(frame playwright.OnFrame) {
+			mu.Lock()
 			frames = append(frames, frame.Data)
+			mu.Unlock()
+			select {
+			case firstFrame <- struct{}{}:
+			default:
+			}
 		},
 	})
 	require.NoError(t, err)
 
-	// Trigger some activity to generate frames
+	// Trigger some activity to generate frames, then wait until at least one
+	// frame arrives rather than racing a fixed timeout (webkit can be slow).
 	_, err = page.Reload()
 	require.NoError(t, err)
-	//nolint:staticcheck
-	page.WaitForTimeout(500)
+	select {
+	case <-firstFrame:
+	case <-time.After(30 * time.Second):
+		t.Fatal("should have received at least one frame")
+	}
 
 	err = screencast.Stop()
 	require.NoError(t, err)
 
+	mu.Lock()
+	defer mu.Unlock()
 	require.Greater(t, len(frames), 0, "should have received at least one frame")
 	require.Greater(t, len(frames[0]), 0, "frame data should not be empty")
 }


### PR DESCRIPTION
## Problem

Fixes #459.

`Locator.Evaluate` times out on elements that are attached but not visible, while `ElementHandle.Evaluate` on the same element returns immediately.

## Root cause

`Locator.Evaluate`, `EvaluateHandle`, `BoundingBox`, `Screenshot`, etc. all resolve the element through the `withElement` helper. That helper called `frame.WaitForSelector` **without** setting `State`, so it fell through to the default `visible` state. `Locator.ElementHandle()`, by contrast, explicitly passes `State: attached, Strict: true`.

As a result `Locator.Evaluate` waited for visibility and timed out whenever the element was hidden (`display:none`, zero-size, off-screen), even though evaluating JS doesn't require visibility.

## Fix

Match upstream Playwright's [`_withElement`](https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/client/locator.ts):

- resolve with `state: "attached"` and `strict: true`
- dispose the resolved handle after the callback (upstream does this in a `finally`)

## Test

Added `TestLocatorEvaluateShouldWorkOnHiddenElement`, which evaluates on a `display:none` element. It times out before the fix and passes after. Full `TestLocator` suite passes locally.