### PR TITLE
fix: identify event listeners by closure, not shared code pointer (#323)

### DIFF
--- a/event_emitter.go
+++ b/event_emitter.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"slices"
 	"sync"
+	"unsafe"
 )
 
 type EventEmitter interface {
@@ -131,11 +132,28 @@ func (er *eventRegister) count() int {
 }
 
 func (er *eventRegister) removeHandler(handler any) {
-	handlerPtr := reflect.ValueOf(handler).Pointer()
+	target := funcIdentity(handler)
 
 	er.listeners = slices.DeleteFunc(er.listeners, func(l listener) bool {
-		return reflect.ValueOf(l.handler).Pointer() == handlerPtr
+		return funcIdentity(l.handler) == target
 	})
+}
+
+// funcIdentity returns a value that uniquely identifies a func value, so that
+// distinct closures can be told apart when removing listeners.
+//
+// reflect.Value.Pointer() returns only the code entry point of a func, which is
+// shared by every closure produced from the same function literal (for example
+// waiter.createHandler). Removing one such closure with that pointer would match
+// and remove all its siblings, silently unsubscribing unrelated listeners. The
+// closure's data word (the second word of the func interface value) distinguishes
+// individual closures, so we compare on that instead. A nil func has a nil data
+// word; callers never register nil handlers, so that case does not arise here.
+func funcIdentity(handler any) unsafe.Pointer {
+	// A non-nil func value stored in an interface is represented as a pointer to
+	// a runtime func object; the interface's data word is that pointer and is
+	// stable for the lifetime of the closure.
+	return (*[2]unsafe.Pointer)(unsafe.Pointer(&handler))[1]
 }
 
 func (er *eventRegister) callHandlers(payloads ...any) int {

--- a/event_emitter_test.go
+++ b/event_emitter_test.go
@@ -130,6 +130,35 @@ func TestEventEmitterHandlerCanReenter(t *testing.T) {
 	require.Equal(t, 1, handler.ListenerCount(testEventNameFoo))
 }
 
+// TestEventEmitterRemoveDistinctClosures guards against a regression where
+// RemoveListener compared handlers by their code pointer
+// (reflect.Value.Pointer()), which is shared by every closure created from the
+// same function literal. Removing one such closure then removed all its
+// siblings, silently unsubscribing unrelated listeners. This reproduced as
+// concurrent ExpectResponse waiters timing out once any one of them completed
+// (playwright-go issue #323).
+//
+// It uses the real waiter.createHandler, whose closures are exactly the ones
+// that collided under the old comparison.
+func TestEventEmitterRemoveDistinctClosures(t *testing.T) {
+	handler := &eventEmitter{}
+	matchAll := func(any) bool { return true }
+
+	var waiters []*waiter
+	for i := 0; i < 3; i++ {
+		w := newWaiter()
+		h := w.createHandler(make(chan any, 1), matchAll)
+		handler.On(testEventName, h)
+		w.listeners = append(w.listeners, eventListener{emitter: handler, event: testEventName, handler: h})
+		waiters = append(waiters, w)
+	}
+	require.Equal(t, 3, handler.ListenerCount(testEventName))
+
+	// Removing the first waiter's handler must leave the other two registered.
+	handler.RemoveListener(testEventName, waiters[0].listeners[0].handler)
+	require.Equal(t, 2, handler.ListenerCount(testEventName))
+}
+
 // TestEventEmitterOnceRunsExactlyOnce verifies a one-shot listener fires once
 // even though removal now happens before handler invocation.
 func TestEventEmitterOnceRunsExactlyOnce(t *testing.T) {

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1150,6 +1151,51 @@ func TestPageExpectResponse(t *testing.T) {
 
 		require.Nil(t, response)
 		require.ErrorContains(t, err, "Timeout 1000.00ms exceeded.")
+	})
+
+	// Regression test for https://github.com/playwright-community/playwright-go/issues/323:
+	// waiting for several responses concurrently (the Go equivalent of
+	// Promise.all) must resolve every waiter. Previously, once one waiter
+	// completed it unsubscribed all the others, so the rest timed out.
+	t.Run("should work with concurrent waiters", func(t *testing.T) {
+		BeforeEach(t)
+
+		ids := []string{"a", "b", "c", "d", "e", "f"}
+		for _, id := range ids {
+			id := id
+			server.SetRoute("/api/"+id, func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(w, `{"id":"%s"}`, id)
+			})
+		}
+
+		_, err := page.Goto(server.EMPTY_PAGE)
+		require.NoError(t, err)
+
+		var wg sync.WaitGroup
+		results := make([]string, len(ids))
+		errs := make([]error, len(ids))
+		for i, id := range ids {
+			wg.Add(1)
+			go func(idx int, id string) {
+				defer wg.Done()
+				resp, err := page.ExpectResponse("**/api/"+id, func() error {
+					_, e := page.Evaluate(fmt.Sprintf(`fetch("/api/%s")`, id))
+					return e
+				}, playwright.PageExpectResponseOptions{Timeout: playwright.Float(10 * 1000)})
+				if err != nil {
+					errs[idx] = err
+					return
+				}
+				results[idx] = resp.URL()
+			}(i, id)
+		}
+		wg.Wait()
+
+		for i, id := range ids {
+			require.NoErrorf(t, errs[i], "waiter %d (id %s)", i, id)
+			require.Contains(t, results[i], "/api/"+id)
+		}
 	})
 }
 

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1165,7 +1165,8 @@ func TestPageExpectResponse(t *testing.T) {
 			id := id
 			server.SetRoute("/api/"+id, func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				fmt.Fprintf(w, `{"id":"%s"}`, id)
+				_, err := fmt.Fprintf(w, `{"id":"%s"}`, id)
+				require.NoError(t, err)
 			})
 		}
 


### PR DESCRIPTION
`RemoveListener` identified handlers via `reflect.Value.Pointer()`, which returns only a func's code entry point — shared by every closure built from the same function literal (e.g. `waiter.createHandler`), so removing one waiter's listener silently removed all its siblings. This caused concurrent `page.ExpectResponse` waiters to go deaf to later events and time out once any one of them completed (the "Promise.all"-style usage in #323). The fix compares func values by their interface data word, which is unique per closure, while still matching the original handler value passed to `RemoveListener`. Adds a unit test using the real `waiter.createHandler` closures and an integration test with concurrent `ExpectResponse` waiters, both of which fail deterministically against the old behavior.

Fixes #323