### PR TITLE
fix: resolve relative recordVideo.dir to absolute path (#565)

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -72,6 +72,11 @@ func (b *browserImpl) NewContext(options ...BrowserNewContextOptions) (BrowserCo
 		overrides["noDefaultViewport"] = true
 		options[0].NoViewport = nil
 	}
+	if option.RecordVideo != nil {
+		if err := resolveRecordVideoDir(options[0].RecordVideo); err != nil {
+			return nil, err
+		}
+	}
 	if option.RecordHarPath != nil {
 		overrides["recordHar"] = prepareRecordHarOptions(recordHarInputOptions{
 			Path:        *options[0].RecordHarPath,

--- a/browser_type.go
+++ b/browser_type.go
@@ -80,6 +80,11 @@ func (b *browserTypeImpl) LaunchPersistentContext(userDataDir string, options ..
 			overrides["noDefaultViewport"] = true
 			options[0].NoViewport = nil
 		}
+		if options[0].RecordVideo != nil {
+			if err := resolveRecordVideoDir(options[0].RecordVideo); err != nil {
+				return nil, err
+			}
+		}
 		if options[0].RecordHarPath != nil {
 			overrides["recordHar"] = prepareRecordHarOptions(recordHarInputOptions{
 				Path:        *options[0].RecordHarPath,

--- a/helpers.go
+++ b/helpers.go
@@ -3,6 +3,7 @@ package playwright
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strings"
@@ -605,6 +606,22 @@ type recordHarInputOptions struct {
 type harRecordingMetadata struct {
 	Path    string
 	Content *HarContentPolicy
+}
+
+// resolveRecordVideoDir resolves a relative recordVideo.dir to an absolute path,
+// mirroring the upstream JS/Python clients (path.resolve). Without this the driver
+// receives a relative directory and Video().Path() returns a path relative to the
+// process working directory, which breaks if the cwd changes before the file is read.
+func resolveRecordVideoDir(recordVideo *RecordVideo) error {
+	if recordVideo == nil || recordVideo.Dir == nil {
+		return nil
+	}
+	abs, err := filepath.Abs(*recordVideo.Dir)
+	if err != nil {
+		return err
+	}
+	recordVideo.Dir = String(abs)
+	return nil
 }
 
 func prepareRecordHarOptions(option recordHarInputOptions) recordHarOptions {

--- a/tests/video_test.go
+++ b/tests/video_test.go
@@ -214,6 +214,42 @@ func TestVideo(t *testing.T) {
 	})
 }
 
+func TestVideoRelativeDirShouldResolveToAbsolute(t *testing.T) {
+	// Regression test for https://github.com/playwright-community/playwright-go/issues/565
+	// A relative recordVideo.dir must be resolved to an absolute path client-side
+	// (matching upstream path.resolve), so Video().Path() does not depend on the
+	// process working directory at the time it is read.
+	recordVideoDir := t.TempDir()
+	relDir, err := filepath.Rel(mustGetwd(t), recordVideoDir)
+	require.NoError(t, err)
+	require.False(t, filepath.IsAbs(relDir))
+
+	BeforeEach(t, playwright.BrowserNewContextOptions{
+		RecordVideo: &playwright.RecordVideo{
+			Dir: playwright.String(relDir),
+		},
+	})
+
+	_, err = page.Goto(server.PREFIX + "/grid.html")
+	require.NoError(t, err)
+	//nolint:staticcheck
+	page.WaitForTimeout(500)
+	require.NoError(t, context.Close())
+
+	path, err := page.Video().Path()
+	require.NoError(t, err)
+	require.True(t, filepath.IsAbs(path), "Video().Path() should be absolute, got %q", path)
+	require.Equal(t, recordVideoDir, filepath.Dir(path))
+	require.FileExists(t, path)
+}
+
+func mustGetwd(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	return wd
+}
+
 func TestScreencastStartStop(t *testing.T) {
 	BeforeEach(t)
 


### PR DESCRIPTION
Fixes #565. A relative `RecordVideo.Dir` was passed to the driver verbatim, unlike the upstream JS/Python clients which resolve it via `path.resolve` (microsoft/playwright#27099, shipped in v1.39.0). This made `Video().Path()` return a relative path that breaks if the working directory changes before the file is read, and on older Firefox builds caused "Page did not produce any video frames" since Firefox requires absolute video paths. This PR resolves the directory with `filepath.Abs` in both `NewContext` and `LaunchPersistentContext`, and adds a regression test (verified to fail without the fix) that records into a relative dir and asserts the returned path is absolute and exists.