### PR TITLE
fix: prevent deadlock when reading request headers in route handler (#519)

### DIFF
--- a/request.go
+++ b/request.go
@@ -165,13 +165,11 @@ func (r *requestImpl) ActualHeaders() (*rawHeaders, error) {
 		return newRawHeaders(serializeMapToNameAndValue(r.fallbackOverrides.Headers)), nil
 	}
 	if r.allHeaders == nil {
-		response, err := r.Response()
-		if err != nil {
-			return nil, err
-		}
-		if response == nil {
-			return r.provisionalHeaders, nil
-		}
+		// Upstream reads the raw request headers from the channel directly. The
+		// previous code first called r.Response(), which blocks until the
+		// response arrives. Inside a route handler the response only arrives
+		// after the route is continued, so waiting on it deadlocked the handler
+		// and stalled the request (#519).
 		headers, err := r.channel.Send("rawRequestHeaders")
 		if err != nil {
 			return nil, err

--- a/tests/network_test.go
+++ b/tests/network_test.go
@@ -303,6 +303,37 @@ func TestBlockingServerCallInsideEventHandler(t *testing.T) {
 	}
 }
 
+// TestRequestHeadersArrayInsideRouteHandler reproduces #519: calling
+// Request().HeadersArray() (or any header accessor) from inside a route handler
+// must not stall the request. The accessor previously waited on Response(),
+// which only resolves after the route is continued, deadlocking the handler.
+func TestRequestHeadersArrayInsideRouteHandler(t *testing.T) {
+	BeforeEach(t)
+
+	headersCh := make(chan []playwright.NameValue, 1)
+	err := page.Route("**/*", func(route playwright.Route) {
+		headers, err := route.Request().HeadersArray()
+		require.NoError(t, err)
+		headersCh <- headers
+		require.NoError(t, route.Continue())
+	})
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := page.Goto(server.EMPTY_PAGE)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+		require.NotEmpty(t, <-headersCh)
+	case <-time.After(15 * time.Second):
+		t.Fatal("HeadersArray() inside a route handler deadlocked the request (#519)")
+	}
+}
+
 func TestRequestExistingResponse(t *testing.T) {
 	BeforeEach(t)
 


### PR DESCRIPTION
Calling `Request().HeadersArray()` (or `AllHeaders`/`HeaderValue`/`HeaderValues`) inside a route handler froze the request and timed out `Goto` (#519). `ActualHeaders()` first called `Response()`, which blocks until the response resolves on the server — but that only happens after the route is continued, which the blocked handler can never do. This fix drops the `Response()` gating so request headers are read directly via `rawRequestHeaders`, matching upstream `Request._actualHeaders`. Added a regression test that deadlocks on the old code and passes on the new.