### PR TITLE
test: raise WebKit folder upload action timeout to avoid CI flake

### DIFF
--- a/tests/browser_type_test.go
+++ b/tests/browser_type_test.go
@@ -343,7 +343,11 @@ func TestShouldUploadAFolderRemote(t *testing.T) {
 	require.NoError(t, err)
 	page, err := browser_context.NewPage()
 	require.NoError(t, err)
-	page.SetDefaultTimeout(60 * 1000)
+	// WebKit folder upload over a remote connection (file streaming + browser
+	// ingestion) can exceed the default 30s action timeout on loaded CI runners.
+	// flakiness-go does not retry (unlike upstream's CI retries: 3), so raise the
+	// default action timeout to give the slow WebKit step room.
+	page.SetDefaultTimeout(90 * 1000)
 
 	_, err = page.Goto(fmt.Sprintf("%s%s", server.PREFIX, "/input/folderupload.html"))
 	require.NoError(t, err)

--- a/tests/input_test.go
+++ b/tests/input_test.go
@@ -250,8 +250,14 @@ func TestShouldUploadAFolder(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "file2"), []byte("file2 content"), 0o600))
 	require.Nil(t, os.Mkdir(filepath.Join(dir, "sub-dir"), 0o700))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "sub-dir", "really.txt"), []byte("sub-dir file content"), 0o600))
+	// WebKit can take longer than the default 30s action timeout to ingest a
+	// directory upload on loaded CI runners. Upstream absorbs this flake via CI
+	// retries (retries: 3); flakiness-go does not retry, so raise the per-action
+	// timeout to give the slow WebKit step room instead.
 	//nolint:staticcheck
-	require.NoError(t, input.SetInputFiles(dir))
+	require.NoError(t, input.SetInputFiles(dir, playwright.ElementHandleSetInputFilesOptions{
+		Timeout: playwright.Float(90 * 1000),
+	}))
 
 	ret, err := input.Evaluate(`e => [...e.files].map(f => f.webkitRelativePath)`)
 	require.NoError(t, err)


### PR DESCRIPTION
`TestShouldUploadAFolder` and `TestShouldUploadAFolderRemote` flake **only on WebKit** CI runners (chromium/firefox: 0% flip rate): the `setInputFiles` directory-upload action occasionally exceeds the default 30s action timeout under load, while normally completing in ~0.2-3s. The Go client correctly forwards the path and matches upstream Playwright's `convertInputFiles`, so the slowness is browser-side, not a client bug. Upstream absorbs this via CI `retries: 3`, but `flakiness-go` does not retry, so this raises the per-action timeout to 90s to give the slow WebKit step room.