### PR TITLE
test: use default 5s expect timeout to avoid CI flake

### DIFF
--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -83,8 +83,8 @@ func BeforeAll() {
 	if err != nil {
 		log.Fatalf("could not launch: %v", err)
 	}
-	// init web-first assertions with 1s timeout instead of default 5s
-	expect = playwright.NewPlaywrightAssertions(1000)
+	// init web-first assertions with the default 5s timeout
+	expect = playwright.NewPlaywrightAssertions(5000)
 	isChromium = browserName == "chromium" || browserName == ""
 	isFirefox = browserName == "firefox"
 	isWebKit = browserName == "webkit"


### PR DESCRIPTION
The test suite globally overrode the web-first assertion timeout to 1s, while upstream Playwright uses the 5s default. On firefox/windows the interstitial close+re-render in `TestPageAddLocatorHandlerShouldWork` intermittently exceeded 1s (`page_add_locator_handler_test.go:59`), producing a ~20-40% flip rate ([example run](https://github.com/playwright-community/playwright-go/actions/runs/28153936495/job/83377854441)). This restores the upstream default timeout so the negative-path retry has the same headroom as upstream.