### PR TITLE
fix: align Go client with upstream Playwright TypeScript client (v1.60.0)

### DIFF
--- a/apiresponse_assertions.go
+++ b/apiresponse_assertions.go
@@ -48,7 +48,7 @@ func (ar *apiResponseAssertionsImpl) ToBeOK() error {
 	if isTextEncoding {
 		text, err := ar.actual.Text()
 		if err == nil {
-			message += fmt.Sprintf(`\n Response Text:\n %s`, subString(text, 0, 1000))
+			message += fmt.Sprintf("\nResponse text:\n%s", subString(text, 0, 1000))
 		}
 	}
 	return errors.New(message)

--- a/artifact.go
+++ b/artifact.go
@@ -18,7 +18,11 @@ func (a *artifactImpl) PathAfterFinished() (string, error) {
 		return "", errors.New("Path is not available when connecting remotely. Use SaveAs() to save a local copy")
 	}
 	path, err := a.channel.Send("pathAfterFinished")
-	return path.(string), err
+	if err != nil {
+		return "", err
+	}
+	s, _ := path.(string)
+	return s, nil
 }
 
 func (a *artifactImpl) SaveAs(path string) error {

--- a/assertions.go
+++ b/assertions.go
@@ -52,6 +52,7 @@ type frameExpectOptions struct {
 	UseInnerText   *bool               `json:"useInnerText,omitempty"`
 	IsNot          bool                `json:"isNot"`
 	Timeout        *float64            `json:"timeout"`
+	Pseudo         *PseudoElement      `json:"pseudo,omitempty"`
 }
 
 type frameExpectResult struct {

--- a/assertions.go
+++ b/assertions.go
@@ -101,6 +101,25 @@ func (b *assertionsBase) expect(
 	return nil
 }
 
+// parseExpectReceived unwraps the `received` object returned by the `expect`
+// channel call. The server emits `received` as `{ value?: SerializedValue,
+// ariaSnapshot?: string }` (see server frameDispatcher), so we must descend into
+// the nested `value` before parsing it, falling back to `ariaSnapshot`. This
+// mirrors upstream frame._expect (client/frame.ts).
+func parseExpectReceived(received any) any {
+	recv, ok := received.(map[string]any)
+	if !ok {
+		return nil
+	}
+	if value, ok := recv["value"]; ok {
+		return parseResult(value)
+	}
+	if ariaSnapshot, ok := recv["ariaSnapshot"]; ok {
+		return ariaSnapshot
+	}
+	return nil
+}
+
 func toExpectedTextValues(
 	items []any,
 	matchSubstring bool,

--- a/binding_call.go
+++ b/binding_call.go
@@ -31,10 +31,17 @@ type BindingCallFunction func(source *BindingSource, args ...any) any
 func (b *bindingCallImpl) Call(f BindingCallFunction) {
 	defer func() {
 		if r := recover(); r != nil {
-			if _, err := b.channel.Send("reject", map[string]any{
-				"error": serializeError(r.(error)),
-			}); err != nil {
-				logger.Error("could not reject BindingCall", "error", err)
+			// The recovered value may not be an error (e.g. panic("boom")); coerce
+			// it so we always reject instead of panicking again on a failed type
+			// assertion (which would crash the binding goroutine).
+			err, ok := r.(error)
+			if !ok {
+				err = fmt.Errorf("%v", r)
+			}
+			if _, sendErr := b.channel.Send("reject", map[string]any{
+				"error": serializeError(err),
+			}); sendErr != nil {
+				logger.Error("could not reject BindingCall", "error", sendErr)
 			}
 		}
 	}()

--- a/browser.go
+++ b/browser.go
@@ -218,6 +218,8 @@ func (b *browserImpl) StopTracing() ([]byte, error) {
 		if err != nil {
 			return binary, err
 		}
+		// Reset so a later pathless StartTracing/StopTracing doesn't reuse it.
+		b.chromiumTracingPath = nil
 	}
 	return binary, nil
 }

--- a/browser.go
+++ b/browser.go
@@ -187,10 +187,11 @@ func (b *browserImpl) StartTracing(options ...BrowserStartTracingOptions) error 
 		overrides["page"] = option.Page.(*pageImpl).channel
 		option.Page = nil
 	}
-	if option.Path != nil {
-		b.chromiumTracingPath = option.Path
-		option.Path = nil
-	}
+	// Set the path unconditionally (to nil when not provided), matching upstream
+	// `this._path = options.path`, so a later StopTracing doesn't reuse a stale
+	// path from an earlier StartTracing.
+	b.chromiumTracingPath = option.Path
+	option.Path = nil
 	_, err := b.channel.Send("startTracing", option, overrides)
 	return err
 }

--- a/browser_context.go
+++ b/browser_context.go
@@ -413,7 +413,11 @@ func (b *browserContextImpl) ExpectPage(cb func() error, options ...BrowserConte
 }
 
 func (b *browserContextImpl) Close(options ...BrowserContextCloseOptions) error {
-	if b.closeWasCalled.Load() {
+	// Mirror upstream's `if (this.isClosed()) return;` guard, where isClosed() is
+	// `_closingStatus !== 'none'` (true once closing OR closed). Guarding only on
+	// closeWasCalled would let a Close() after a server-driven close proceed into
+	// redundant request.Dispose / HAR export / close-on-dead-channel work.
+	if b.IsClosed() {
 		return nil
 	}
 	if len(options) == 1 {

--- a/browser_context.go
+++ b/browser_context.go
@@ -481,7 +481,7 @@ func (b *browserContextImpl) Close(options ...BrowserContextCloseOptions) error 
 				if err := artifact.SaveAs(tmpPath); err != nil {
 					return nil, err
 				}
-				err = b.connection.localUtils.HarUnzip(tmpPath, harMetaData.Path)
+				err = b.connection.localUtils.HarUnzip(tmpPath, harMetaData.Path, harMetaData.ResourcesDir)
 				if err != nil {
 					return nil, err
 				}

--- a/browser_context.go
+++ b/browser_context.go
@@ -1013,7 +1013,7 @@ func newBrowserContext(parent *channelOwner, objectType string, guid string, ini
 		"request":         "request",
 		"response":        "response",
 		"requestfinished": "requestFinished",
-		"responsefailed":  "responseFailed",
+		"requestfailed":   "requestFailed",
 	})
 	return bt
 }

--- a/browser_context.go
+++ b/browser_context.go
@@ -1019,7 +1019,10 @@ func newBrowserContext(parent *channelOwner, objectType string, guid string, ini
 }
 
 func (b *browserContextImpl) IsClosed() bool {
-	return b.isClosedFlag || b.closeReason != nil
+	// Matches upstream isClosed(): true as soon as Close() begins (closing),
+	// not only after the server confirms close (closed). closeWasCalled is the
+	// Go analog of upstream's 'closing' status.
+	return b.isClosedFlag || b.closeWasCalled.Load()
 }
 
 func (b *browserContextImpl) SetStorageState(storageStatePath string) error {

--- a/browser_context.go
+++ b/browser_context.go
@@ -30,7 +30,7 @@ type browserContextImpl struct {
 	bindings        *safe.SyncMap[string, BindingCallFunction]
 	tracing         *tracingImpl
 	debugger        *debuggerImpl
-	isClosedFlag    bool
+	isClosedFlag    atomic.Bool
 	request         *apiRequestContextImpl
 	harRecorders    map[string]harRecordingMetadata
 	closed          chan struct{}
@@ -577,7 +577,7 @@ func (b *browserContextImpl) onBinding(binding *bindingCallImpl) {
 }
 
 func (b *browserContextImpl) onClose() {
-	b.isClosedFlag = true
+	b.isClosedFlag.Store(true)
 	if b.browser != nil {
 		contexts := make([]BrowserContext, 0)
 		b.browser.Lock()
@@ -1071,7 +1071,7 @@ func (b *browserContextImpl) IsClosed() bool {
 	// Matches upstream isClosed(): true as soon as Close() begins (closing),
 	// not only after the server confirms close (closed). closeWasCalled is the
 	// Go analog of upstream's 'closing' status.
-	return b.isClosedFlag || b.closeWasCalled.Load()
+	return b.isClosedFlag.Load() || b.closeWasCalled.Load()
 }
 
 func (b *browserContextImpl) SetStorageState(storageStatePath string) error {

--- a/browser_context.go
+++ b/browser_context.go
@@ -481,7 +481,7 @@ func (b *browserContextImpl) Close(options ...BrowserContextCloseOptions) error 
 				if err := artifact.SaveAs(tmpPath); err != nil {
 					return nil, err
 				}
-				err = b.connection.localUtils.HarUnzip(tmpPath, harMetaData.Path, harMetaData.ResourcesDir)
+				err = b.connection.localUtils.HarUnzip(tmpPath, harMetaData.Path)
 				if err != nil {
 					return nil, err
 				}

--- a/browser_context.go
+++ b/browser_context.go
@@ -546,19 +546,13 @@ func (b *browserContextImpl) recordIntoHar(har string, options ...browserContext
 	return nil
 }
 
-func (b *browserContextImpl) StorageState(options ...BrowserContextStorageStateOptions) (*StorageState, error) {
-	params := map[string]any{}
-	var path *string
-	if len(options) == 1 {
-		params["indexedDB"] = options[0].IndexedDB
-		path = options[0].Path
-	}
-	result, err := b.channel.SendReturnAsDict("storageState", params)
+func (b *browserContextImpl) StorageState(paths ...string) (*StorageState, error) {
+	result, err := b.channel.SendReturnAsDict("storageState")
 	if err != nil {
 		return nil, err
 	}
-	if path != nil {
-		file, err := os.Create(*path)
+	if len(paths) == 1 {
+		file, err := os.Create(paths[0])
 		if err != nil {
 			return nil, err
 		}

--- a/browser_context.go
+++ b/browser_context.go
@@ -367,7 +367,10 @@ func (b *browserContextImpl) waiterForEvent(event string, options ...BrowserCont
 		predicate = options[0].Predicate
 	}
 	waiter := newWaiter().WithTimeout(timeout)
-	waiter.RejectOnEvent(b, "close", ErrTargetClosed)
+	// Don't reject on the very event being awaited.
+	if event != "close" {
+		waiter.RejectOnEvent(b, "close", ErrTargetClosed)
+	}
 	return waiter.WaitForEvent(b, event, predicate)
 }
 

--- a/browser_context.go
+++ b/browser_context.go
@@ -595,6 +595,11 @@ func (b *browserContextImpl) onClose() {
 		b.browser.contexts = contexts
 		b.browser.Unlock()
 	}
+	if b.tracing != nil {
+		// Reset the connection tracing counter so an un-stopped trace on a
+		// closing context doesn't keep every later API call collecting stacks.
+		b.tracing.resetStackCounter()
+	}
 	b.disposeHarRouters()
 	b.Emit("close", b)
 }

--- a/browser_context.go
+++ b/browser_context.go
@@ -546,13 +546,19 @@ func (b *browserContextImpl) recordIntoHar(har string, options ...browserContext
 	return nil
 }
 
-func (b *browserContextImpl) StorageState(paths ...string) (*StorageState, error) {
-	result, err := b.channel.SendReturnAsDict("storageState")
+func (b *browserContextImpl) StorageState(options ...BrowserContextStorageStateOptions) (*StorageState, error) {
+	params := map[string]any{}
+	var path *string
+	if len(options) == 1 {
+		params["indexedDB"] = options[0].IndexedDB
+		path = options[0].Path
+	}
+	result, err := b.channel.SendReturnAsDict("storageState", params)
 	if err != nil {
 		return nil, err
 	}
-	if len(paths) == 1 {
-		file, err := os.Create(paths[0])
+	if path != nil {
+		file, err := os.Create(*path)
 		if err != nil {
 			return nil, err
 		}

--- a/browser_context.go
+++ b/browser_context.go
@@ -48,10 +48,9 @@ func (b *browserContextImpl) SetDefaultNavigationTimeout(timeout float64) {
 }
 
 func (b *browserContextImpl) setDefaultNavigationTimeoutImpl(timeout *float64) {
+	// Upstream only updates the client-side timeout settings; there is no
+	// corresponding protocol method (the old *NoReply methods were removed).
 	b.timeoutSettings.SetDefaultNavigationTimeout(timeout)
-	b.channel.SendNoReplyInternal("setDefaultNavigationTimeoutNoReply", map[string]any{
-		"timeout": timeout,
-	})
 }
 
 func (b *browserContextImpl) SetDefaultTimeout(timeout float64) {
@@ -60,9 +59,6 @@ func (b *browserContextImpl) SetDefaultTimeout(timeout float64) {
 
 func (b *browserContextImpl) setDefaultTimeoutImpl(timeout *float64) {
 	b.timeoutSettings.SetDefaultTimeout(timeout)
-	b.channel.SendNoReplyInternal("setDefaultTimeoutNoReply", map[string]any{
-		"timeout": timeout,
-	})
 }
 
 func (b *browserContextImpl) Pages() []Page {

--- a/browser_context.go
+++ b/browser_context.go
@@ -367,7 +367,7 @@ func (b *browserContextImpl) waiterForEvent(event string, options ...BrowserCont
 	waiter := newWaiter().WithTimeout(timeout)
 	// Don't reject on the very event being awaited.
 	if event != "close" {
-		waiter.RejectOnEvent(b, "close", ErrTargetClosed)
+		waiter.RejectOnEvent(b, "close", targetClosedError(b.effectiveCloseReason()))
 	}
 	return waiter.WaitForEvent(b, event, predicate)
 }

--- a/browser_context.go
+++ b/browser_context.go
@@ -634,7 +634,7 @@ func (b *browserContextImpl) onRoute(route *routeImpl) {
 	url := route.Request().URL()
 	for _, handlerEntry := range routes {
 		// If the page or the context was closed we stall all requests right away.
-		if (page != nil && page.closeWasCalled.Load()) || b.closeWasCalled.Load() {
+		if (page != nil && page.closeWasCalled.Load()) || b.IsClosed() {
 			return
 		}
 		if !handlerEntry.Matches(url) {

--- a/browser_context.go
+++ b/browser_context.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -558,6 +559,9 @@ func (b *browserContextImpl) StorageState(options ...BrowserContextStorageStateO
 		return nil, err
 	}
 	if path != nil {
+		if err := os.MkdirAll(filepath.Dir(*path), 0o777); err != nil {
+			return nil, err
+		}
 		file, err := os.Create(*path)
 		if err != nil {
 			return nil, err

--- a/browser_context.go
+++ b/browser_context.go
@@ -235,7 +235,7 @@ func (b *browserContextImpl) AddInitScript(script Script) error {
 		if err != nil {
 			return err
 		}
-		source = string(content)
+		source = addSourceURLToScript(string(content), *script.Path)
 	}
 	_, err := b.channel.Send("addInitScript", map[string]any{
 		"source": source,

--- a/browser_context.go
+++ b/browser_context.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"regexp"
 	"slices"
@@ -694,6 +695,35 @@ func (b *browserContextImpl) onServiceWorker(worker *workerImpl) {
 	b.Emit("serviceworker", worker)
 }
 
+func (b *browserContextImpl) isServiceWorker(worker Worker) bool {
+	b.RLock()
+	defer b.RUnlock()
+	for _, sw := range b.serviceWorkers {
+		if sw == worker {
+			return true
+		}
+	}
+	return false
+}
+
+// serviceWorkerScope returns the scope URL of a service worker (the directory of
+// its script URL with a trailing slash), mirroring upstream _serviceWorkerScope.
+func serviceWorkerScope(worker Worker) string {
+	u, err := url.Parse(worker.URL())
+	if err != nil {
+		return ""
+	}
+	ref, err := u.Parse(".")
+	if err != nil {
+		return ""
+	}
+	scope := ref.String()
+	if !strings.HasSuffix(scope, "/") {
+		scope += "/"
+	}
+	return scope
+}
+
 func (b *browserContextImpl) setOptions(options *BrowserNewContextOptions, tracesDir *string) {
 	if options == nil {
 		options = &BrowserNewContextOptions{}
@@ -925,10 +955,24 @@ func newBrowserContext(parent *channelOwner, objectType string, guid string, ini
 	})
 	bt.channel.On("console", func(ev map[string]any) {
 		message := newConsoleMessage(ev)
-		bt.Emit("console", message)
+		if message.worker != nil {
+			message.worker.(*workerImpl).Emit("console", message)
+		}
 		if message.page != nil {
 			message.page.Emit("console", message)
 		}
+		// Service worker console messages flow through the context channel; fan
+		// them out to pages within the worker's scope, matching upstream.
+		if message.worker != nil && bt.isServiceWorker(message.worker) {
+			if scope := serviceWorkerScope(message.worker); scope != "" {
+				for _, page := range bt.Pages() {
+					if strings.HasPrefix(page.URL(), scope) {
+						page.(*pageImpl).Emit("console", message)
+					}
+				}
+			}
+		}
+		bt.Emit("console", message)
 	})
 	bt.channel.On("dialog", func(params map[string]any) {
 		dialog := fromChannel(params["dialog"]).(*dialogImpl)

--- a/browser_context.go
+++ b/browser_context.go
@@ -466,17 +466,19 @@ func (b *browserContextImpl) Close(options ...BrowserContextCloseOptions) error 
 				return nil, err
 			}
 			artifact := fromChannel(response["artifact"]).(*artifactImpl)
-			if !needCompressed && harMetaData.Content == HarContentPolicyAttach {
+			// Non-zip output is always unzipped into HAR JSON, regardless of the
+			// content policy (matching upstream _exportHAR which gates only on isZip).
+			if needCompressed {
+				if err := artifact.SaveAs(harMetaData.Path); err != nil {
+					return nil, err
+				}
+			} else {
 				tmpPath := harMetaData.Path + ".tmp"
 				if err := artifact.SaveAs(tmpPath); err != nil {
 					return nil, err
 				}
-				err = b.connection.localUtils.HarUnzip(tmpPath, harMetaData.Path)
+				err = b.connection.localUtils.HarUnzip(tmpPath, harMetaData.Path, harMetaData.ResourcesDir)
 				if err != nil {
-					return nil, err
-				}
-			} else {
-				if err := artifact.SaveAs(harMetaData.Path); err != nil {
 					return nil, err
 				}
 			}

--- a/browser_context.go
+++ b/browser_context.go
@@ -918,6 +918,10 @@ func newBrowserContext(parent *channelOwner, objectType string, guid string, ini
 		}
 	}
 	bt.request = fromChannel(initializer["requestContext"]).(*apiRequestContextImpl)
+	// Share the context's timeout settings with its owned request context so
+	// context.SetDefaultTimeout reaches context.Request() fetches, mirroring
+	// upstream (this.request._timeoutSettings = this._timeoutSettings).
+	bt.request.timeoutSettings = bt.timeoutSettings
 	bt.clock = newClock(bt)
 
 	// Register this context with the selectors manager for custom selector engines

--- a/browser_context.go
+++ b/browser_context.go
@@ -540,13 +540,19 @@ func (b *browserContextImpl) recordIntoHar(har string, options ...browserContext
 	return nil
 }
 
-func (b *browserContextImpl) StorageState(paths ...string) (*StorageState, error) {
-	result, err := b.channel.SendReturnAsDict("storageState")
+func (b *browserContextImpl) StorageState(options ...BrowserContextStorageStateOptions) (*StorageState, error) {
+	params := map[string]any{}
+	var path *string
+	if len(options) == 1 {
+		params["indexedDB"] = options[0].IndexedDB
+		path = options[0].Path
+	}
+	result, err := b.channel.SendReturnAsDict("storageState", params)
 	if err != nil {
 		return nil, err
 	}
-	if len(paths) == 1 {
-		file, err := os.Create(paths[0])
+	if path != nil {
+		file, err := os.Create(*path)
 		if err != nil {
 			return nil, err
 		}

--- a/browser_type.go
+++ b/browser_type.go
@@ -1,8 +1,12 @@
 package playwright
 
 import (
+	"errors"
 	"fmt"
 )
+
+// defaultLaunchTimeout matches DEFAULT_PLAYWRIGHT_LAUNCH_TIMEOUT upstream (3 minutes).
+const defaultLaunchTimeout = 3 * 60 * 1000
 
 type browserTypeImpl struct {
 	channelOwner
@@ -21,7 +25,7 @@ func (b *browserTypeImpl) Launch(options ...BrowserTypeLaunchOptions) (Browser, 
 	overrides := map[string]any{}
 	// timeout is required in Playwright v1.57+ protocol
 	if len(options) == 0 || options[0].Timeout == nil {
-		overrides["timeout"] = float64(30000) // default 30s
+		overrides["timeout"] = float64(defaultLaunchTimeout) // default 3 min
 	}
 	if len(options) == 1 && options[0].Env != nil {
 		overrides["env"] = serializeMapToNameAndValue(options[0].Env)
@@ -42,7 +46,7 @@ func (b *browserTypeImpl) LaunchPersistentContext(userDataDir string, options ..
 	}
 	// timeout is required in Playwright v1.57+ protocol
 	if len(options) == 0 || options[0].Timeout == nil {
-		overrides["timeout"] = float64(30000) // default 30s
+		overrides["timeout"] = float64(defaultLaunchTimeout) // default 3 min
 	}
 	option := &BrowserNewContextOptions{}
 	var tracesDir *string = nil
@@ -116,8 +120,7 @@ func (b *browserTypeImpl) Connect(wsEndpoint string, options ...BrowserTypeConne
 	overrides := map[string]any{
 		"endpoint": wsEndpoint,
 		"headers": map[string]string{
-			"x-playwright-browser":        b.Name(),
-			"x-playwright-launch-options": "{}",
+			"x-playwright-browser": b.Name(),
 		},
 	}
 	// timeout is required in Playwright v1.57+ protocol
@@ -145,7 +148,12 @@ func (b *browserTypeImpl) Connect(wsEndpoint string, options ...BrowserTypeConne
 		return nil, err
 	}
 	playwright.setSelectors(b.playwright.Selectors)
-	browser := fromChannel(playwright.initializer["preLaunchedBrowser"]).(*browserImpl)
+	preLaunchedBrowser := fromNullableChannel(playwright.initializer["preLaunchedBrowser"])
+	if preLaunchedBrowser == nil {
+		connection.cleanup()
+		return nil, errors.New("malformed endpoint. Did you use BrowserType.LaunchServer method?")
+	}
+	browser := preLaunchedBrowser.(*browserImpl)
 	browser.shouldCloseConnectionOnClose = true
 	pipeClosed := func() {
 		for _, context := range browser.Contexts() {

--- a/browser_type.go
+++ b/browser_type.go
@@ -117,6 +117,17 @@ func (b *browserTypeImpl) LaunchPersistentContext(userDataDir string, options ..
 		return nil, err
 	}
 	context := fromChannel(response["context"]).(*browserContextImpl)
+	// Wire the real browserType (whose playwright is non-nil) onto the persistent
+	// context's browser, then register the context with the selectors manager.
+	// newBrowserContext's own registration ran before this wiring (its browser's
+	// browserType has a nil playwright), so custom selector engines / testId would
+	// otherwise never reach a persistent context.
+	if context.browser != nil {
+		b.didLaunchBrowser(context.browser)
+	}
+	if b.playwright != nil {
+		b.playwright.Selectors.(*selectorsImpl).addContext(context)
+	}
 	b.didCreateContext(context, option, tracesDir)
 	if err := context.initializeHarFromOptions(); err != nil {
 		return nil, err

--- a/browser_type.go
+++ b/browser_type.go
@@ -216,6 +216,14 @@ func (b *browserTypeImpl) ConnectOverCDP(endpointURL string, options ...BrowserT
 	b.didLaunchBrowser(browser)
 	if defaultContext, ok := response["defaultContext"]; ok {
 		context := fromChannel(defaultContext).(*browserContextImpl)
+		// The default context arrives during dispatch, before didLaunchBrowser
+		// wires the real browserType (whose playwright is non-nil), so
+		// newBrowserContext's own selectors registration was skipped. Register
+		// it now, mirroring upstream's _connectToBrowserType -> _setupBrowserContext,
+		// so custom selector engines / testId reach the CDP default context.
+		if b.playwright != nil {
+			b.playwright.Selectors.(*selectorsImpl).addContext(context)
+		}
 		b.didCreateContext(context, nil, nil)
 	}
 	return browser, nil

--- a/browser_type.go
+++ b/browser_type.go
@@ -3,6 +3,7 @@ package playwright
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 )
 
 // defaultLaunchTimeout matches DEFAULT_PLAYWRIGHT_LAUNCH_TIMEOUT upstream (3 minutes).
@@ -41,6 +42,13 @@ func (b *browserTypeImpl) Launch(options ...BrowserTypeLaunchOptions) (Browser, 
 }
 
 func (b *browserTypeImpl) LaunchPersistentContext(userDataDir string, options ...BrowserTypeLaunchPersistentContextOptions) (BrowserContext, error) {
+	// Resolve a relative userDataDir to an absolute path, matching upstream, so
+	// the driver receives a path independent of the process working directory.
+	if userDataDir != "" && !filepath.IsAbs(userDataDir) {
+		if abs, err := filepath.Abs(userDataDir); err == nil {
+			userDataDir = abs
+		}
+	}
 	overrides := map[string]any{
 		"userDataDir": userDataDir,
 	}
@@ -173,6 +181,9 @@ func (b *browserTypeImpl) Connect(wsEndpoint string, options ...BrowserTypeConne
 }
 
 func (b *browserTypeImpl) ConnectOverCDP(endpointURL string, options ...BrowserTypeConnectOverCDPOptions) (Browser, error) {
+	if b.Name() != "chromium" {
+		return nil, errors.New("connecting over CDP is only supported in Chromium")
+	}
 	overrides := map[string]any{
 		"endpointURL": endpointURL,
 	}

--- a/browser_type.go
+++ b/browser_type.go
@@ -188,6 +188,17 @@ func (b *browserTypeImpl) Connect(wsEndpoint string, options ...BrowserTypeConne
 	jsonPipe.On("closed", pipeClosed)
 
 	b.didLaunchBrowser(browser)
+	// When connecting to a shared browser server, the browser's pre-existing
+	// contexts are dispatched before didLaunchBrowser wires the real browserType
+	// (whose playwright is non-nil), so newBrowserContext's own selectors
+	// registration was skipped for them. Register them now, mirroring upstream's
+	// _connectToBrowserType -> _setupBrowserContext loop over all existing
+	// contexts, so custom selector engines / testId reach pre-existing contexts.
+	if b.playwright != nil {
+		for _, context := range browser.Contexts() {
+			b.playwright.Selectors.(*selectorsImpl).addContext(context.(*browserContextImpl))
+		}
+	}
 	return browser, nil
 }
 

--- a/browser_type.go
+++ b/browser_type.go
@@ -125,9 +125,7 @@ func (b *browserTypeImpl) LaunchPersistentContext(userDataDir string, options ..
 	if context.browser != nil {
 		b.didLaunchBrowser(context.browser)
 	}
-	if b.playwright != nil {
-		b.playwright.Selectors.(*selectorsImpl).addContext(context)
-	}
+	b.registerContextSelectors(context)
 	b.didCreateContext(context, option, tracesDir)
 	if err := context.initializeHarFromOptions(); err != nil {
 		return nil, err
@@ -194,10 +192,8 @@ func (b *browserTypeImpl) Connect(wsEndpoint string, options ...BrowserTypeConne
 	// registration was skipped for them. Register them now, mirroring upstream's
 	// _connectToBrowserType -> _setupBrowserContext loop over all existing
 	// contexts, so custom selector engines / testId reach pre-existing contexts.
-	if b.playwright != nil {
-		for _, context := range browser.Contexts() {
-			b.playwright.Selectors.(*selectorsImpl).addContext(context.(*browserContextImpl))
-		}
+	for _, context := range browser.Contexts() {
+		b.registerContextSelectors(context.(*browserContextImpl))
 	}
 	return browser, nil
 }
@@ -232,9 +228,7 @@ func (b *browserTypeImpl) ConnectOverCDP(endpointURL string, options ...BrowserT
 		// newBrowserContext's own selectors registration was skipped. Register
 		// it now, mirroring upstream's _connectToBrowserType -> _setupBrowserContext,
 		// so custom selector engines / testId reach the CDP default context.
-		if b.playwright != nil {
-			b.playwright.Selectors.(*selectorsImpl).addContext(context)
-		}
+		b.registerContextSelectors(context)
 		b.didCreateContext(context, nil, nil)
 	}
 	return browser, nil
@@ -242,6 +236,17 @@ func (b *browserTypeImpl) ConnectOverCDP(endpointURL string, options ...BrowserT
 
 func (b *browserTypeImpl) didCreateContext(context *browserContextImpl, contextOptions *BrowserNewContextOptions, tracesDir *string) {
 	context.setOptions(contextOptions, tracesDir)
+}
+
+// registerContextSelectors registers a context with the selectors manager,
+// mirroring upstream _setupBrowserContext. Used for contexts that arrive during
+// dispatch (persistent/connect/CDP) before didLaunchBrowser wires the real
+// browserType, so newBrowserContext's own registration was skipped. addContext
+// is idempotent, so this is safe regardless of call ordering.
+func (b *browserTypeImpl) registerContextSelectors(context *browserContextImpl) {
+	if b.playwright != nil {
+		b.playwright.Selectors.(*selectorsImpl).addContext(context)
+	}
 }
 
 func (b *browserTypeImpl) didLaunchBrowser(browser *browserImpl) {

--- a/cdp_session.go
+++ b/cdp_session.go
@@ -37,6 +37,9 @@ func newCDPSession(parent *channelOwner, objectType string, guid string, initial
 	bt.channel.On("event", func(params map[string]any) {
 		bt.onEvent(params)
 	})
+	bt.channel.On("close", func() {
+		bt.Emit("close", bt)
+	})
 
 	return bt
 }

--- a/cdp_session.go
+++ b/cdp_session.go
@@ -27,6 +27,9 @@ func (c *cdpSessionImpl) Send(method string, params map[string]any) (any, error)
 
 func (c *cdpSessionImpl) onEvent(params map[string]any) {
 	c.Emit(params["method"].(string), params["params"])
+	// Also emit the generic "event" with the full {method, params} envelope,
+	// matching upstream cdpSession.ts.
+	c.Emit("event", params)
 }
 
 func newCDPSession(parent *channelOwner, objectType string, guid string, initializer map[string]any) *cdpSessionImpl {

--- a/connection.go
+++ b/connection.go
@@ -269,7 +269,11 @@ func (c *connection) sendMessageToServer(object *channelOwner, method string, pa
 	}
 
 	id := c.lastID.Add(1)
-	c.callbacks.Store(id, cb)
+	// The server never replies to noReply messages, so storing their callbacks
+	// would leak an entry per call for the connection's lifetime.
+	if !noReply {
+		c.callbacks.Store(id, cb)
+	}
 	var (
 		metadata = make(map[string]any, 0)
 		stack    = make([]map[string]any, 0)

--- a/connection.go
+++ b/connection.go
@@ -126,8 +126,12 @@ func (c *connection) Dispatch(msg *message) {
 		if cb.noReply {
 			return
 		}
-		if msg.Error != nil {
-			cb.SetError(parseError(msg.Error.Error))
+		if msg.Error != nil && msg.Result == nil {
+			err := parseError(msg.Error.Error)
+			if log := formatCallLog(msg.Log); log != "" {
+				err = fmt.Errorf("%w%s", err, log)
+			}
+			cb.SetError(err)
 		} else {
 			// Always resolve GUIDs in responses, regardless of connection type
 			// The protocol guarantees that __create__ events arrive before responses that reference those objects

--- a/console_message.go
+++ b/console_message.go
@@ -30,6 +30,10 @@ func (c *consoleMessageImpl) Args() []JSHandle {
 func (c *consoleMessageImpl) Location() *ConsoleMessageLocation {
 	location := &ConsoleMessageLocation{}
 	remapMapToStruct(c.event["location"], location)
+	// The wire only carries lineNumber/columnNumber; mirror upstream by
+	// populating the non-deprecated line/column aliases too.
+	location.Line = location.LineNumber
+	location.Column = location.ColumnNumber
 	return location
 }
 

--- a/dialog.go
+++ b/dialog.go
@@ -1,5 +1,7 @@
 package playwright
 
+import "errors"
+
 type dialogImpl struct {
 	channelOwner
 	page Page
@@ -30,6 +32,9 @@ func (d *dialogImpl) Accept(promptTextInput ...string) error {
 
 func (d *dialogImpl) Dismiss() error {
 	_, err := d.channel.Send("dismiss")
+	if errors.Is(err, ErrTargetClosed) {
+		return nil
+	}
 	return err
 }
 

--- a/disposable.go
+++ b/disposable.go
@@ -1,11 +1,16 @@
 package playwright
 
+import "errors"
+
 type disposableImpl struct {
 	channelOwner
 }
 
 func (d *disposableImpl) Dispose() error {
 	_, err := d.channel.Send("dispose")
+	if errors.Is(err, ErrTargetClosed) {
+		return nil
+	}
 	return err
 }
 

--- a/element_handle.go
+++ b/element_handle.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 type elementHandleImpl struct {
@@ -289,6 +290,9 @@ func (e *elementHandleImpl) Screenshot(options ...ElementHandleScreenshotOptions
 		return nil, fmt.Errorf("could not decode base64 :%w", err)
 	}
 	if path != nil {
+		if err := os.MkdirAll(filepath.Dir(*path), 0o777); err != nil {
+			return nil, err
+		}
 		if err := os.WriteFile(*path, image, 0o644); err != nil {
 			return nil, err
 		}

--- a/element_handle.go
+++ b/element_handle.go
@@ -256,6 +256,12 @@ func (e *elementHandleImpl) Screenshot(options ...ElementHandleScreenshotOptions
 	if len(options) == 1 {
 		path = options[0].Path
 		options[0].Path = nil
+		// Infer the image type from the path extension when not set, matching upstream.
+		typ, err := determineScreenshotType(path, options[0].Type)
+		if err != nil {
+			return nil, err
+		}
+		options[0].Type = typ
 		if options[0].Mask != nil {
 			masks := make([]map[string]any, 0)
 			for _, m := range options[0].Mask {

--- a/element_handle.go
+++ b/element_handle.go
@@ -75,8 +75,10 @@ func (e *elementHandleImpl) InnerHTML() (string, error) {
 }
 
 func (e *elementHandleImpl) DispatchEvent(typ string, initObjects ...any) error {
-	var initObject any
-	if len(initObjects) == 1 {
+	// Default eventInit to an empty object (not undefined), matching upstream's
+	// `eventInit: Object = {}`.
+	var initObject any = map[string]any{}
+	if len(initObjects) == 1 && initObjects[0] != nil {
 		initObject = initObjects[0]
 	}
 	_, err := e.channel.Send("dispatchEvent", map[string]any{

--- a/element_handle.go
+++ b/element_handle.go
@@ -409,6 +409,15 @@ func (e *elementHandleImpl) SetChecked(checked bool, options ...ElementHandleSet
 func newElementHandle(parent *channelOwner, objectType string, guid string, initializer map[string]any) *elementHandleImpl {
 	bt := &elementHandleImpl{}
 	bt.createChannelOwner(bt, parent, objectType, guid, initializer)
+	// ElementHandle extends JSHandle: initialize the preview from the initializer
+	// and keep it in sync, so String() returns the element preview (newJSHandle
+	// does this, but ElementHandle is constructed directly).
+	if preview, ok := initializer["preview"].(string); ok {
+		bt.preview = preview
+	}
+	bt.channel.On("previewUpdated", func(ev map[string]any) {
+		bt.preview = ev["preview"].(string)
+	})
 	return bt
 }
 

--- a/fetch.go
+++ b/fetch.go
@@ -299,13 +299,19 @@ func (r *apiRequestContextImpl) Post(url string, options ...APIRequestContextPos
 	return r.Fetch(url, opts)
 }
 
-func (r *apiRequestContextImpl) StorageState(path ...string) (*StorageState, error) {
-	result, err := r.channel.SendReturnAsDict("storageState")
+func (r *apiRequestContextImpl) StorageState(options ...APIRequestContextStorageStateOptions) (*StorageState, error) {
+	params := map[string]any{}
+	var path *string
+	if len(options) == 1 {
+		params["indexedDB"] = options[0].IndexedDB
+		path = options[0].Path
+	}
+	result, err := r.channel.SendReturnAsDict("storageState", params)
 	if err != nil {
 		return nil, err
 	}
-	if len(path) == 1 {
-		file, err := os.Create(path[0])
+	if path != nil {
+		file, err := os.Create(*path)
 		if err != nil {
 			return nil, err
 		}

--- a/fetch.go
+++ b/fetch.go
@@ -72,6 +72,13 @@ func (r *apiRequestContextImpl) Dispose(options ...APIRequestContextDisposeOptio
 	if len(options) == 1 {
 		r.closeReason = options[0].Reason
 	}
+	// Flush any HARs recorded via this request context before disposing,
+	// matching upstream dispose() which calls _exportAllHars().
+	if r.tracing != nil && len(r.tracing.harRecorders) > 0 {
+		if err := r.tracing.exportAllHars(); err != nil {
+			return err
+		}
+	}
 	_, err := r.channel.Send("dispose", map[string]any{
 		"reason": r.closeReason,
 	})

--- a/fetch.go
+++ b/fetch.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -334,6 +335,9 @@ func (r *apiRequestContextImpl) StorageState(options ...APIRequestContextStorage
 		return nil, err
 	}
 	if path != nil {
+		if err := os.MkdirAll(filepath.Dir(*path), 0o777); err != nil {
+			return nil, err
+		}
 		file, err := os.Create(*path)
 		if err != nil {
 			return nil, err

--- a/fetch.go
+++ b/fetch.go
@@ -385,7 +385,7 @@ func (r *apiResponseImpl) JSON(v any) error {
 }
 
 func (r *apiResponseImpl) Ok() bool {
-	return r.Status() == 0 || (r.Status() >= 200 && r.Status() <= 299)
+	return r.Status() >= 200 && r.Status() <= 299
 }
 
 func (r *apiResponseImpl) Status() int {

--- a/fetch.go
+++ b/fetch.go
@@ -319,13 +319,19 @@ func (r *apiRequestContextImpl) Post(url string, options ...APIRequestContextPos
 	return r.Fetch(url, opts)
 }
 
-func (r *apiRequestContextImpl) StorageState(path ...string) (*StorageState, error) {
-	result, err := r.channel.SendReturnAsDict("storageState")
+func (r *apiRequestContextImpl) StorageState(options ...APIRequestContextStorageStateOptions) (*StorageState, error) {
+	params := map[string]any{}
+	var path *string
+	if len(options) == 1 {
+		params["indexedDB"] = options[0].IndexedDB
+		path = options[0].Path
+	}
+	result, err := r.channel.SendReturnAsDict("storageState", params)
 	if err != nil {
 		return nil, err
 	}
-	if len(path) == 1 {
-		file, err := os.Create(path[0])
+	if path != nil {
+		file, err := os.Create(*path)
 		if err != nil {
 			return nil, err
 		}

--- a/fetch.go
+++ b/fetch.go
@@ -319,19 +319,13 @@ func (r *apiRequestContextImpl) Post(url string, options ...APIRequestContextPos
 	return r.Fetch(url, opts)
 }
 
-func (r *apiRequestContextImpl) StorageState(options ...APIRequestContextStorageStateOptions) (*StorageState, error) {
-	params := map[string]any{}
-	var path *string
-	if len(options) == 1 {
-		params["indexedDB"] = options[0].IndexedDB
-		path = options[0].Path
-	}
-	result, err := r.channel.SendReturnAsDict("storageState", params)
+func (r *apiRequestContextImpl) StorageState(path ...string) (*StorageState, error) {
+	result, err := r.channel.SendReturnAsDict("storageState")
 	if err != nil {
 		return nil, err
 	}
-	if path != nil {
-		file, err := os.Create(*path)
+	if len(path) == 1 {
+		file, err := os.Create(path[0])
 		if err != nil {
 			return nil, err
 		}

--- a/fetch.go
+++ b/fetch.go
@@ -117,7 +117,12 @@ func (r *apiRequestContextImpl) innerFetch(url string, request Request, options 
 		overrides["url"] = request.URL()
 	}
 
-	if len(options) == 1 {
+	// Always operate on a single options value so method/headers/body are derived
+	// from the request even when Fetch(request) is called with no options.
+	if len(options) == 0 {
+		options = []APIRequestContextFetchOptions{{}}
+	}
+	{
 		if options[0].MaxRedirects != nil && *options[0].MaxRedirects < 0 {
 			return nil, errors.New("maxRedirects must be non-negative")
 		}
@@ -137,10 +142,18 @@ func (r *apiRequestContextImpl) innerFetch(url string, request Request, options 
 		}
 		if options[0].Headers == nil {
 			if request != nil {
-				overrides["headers"] = serializeMapToNameAndValue(request.Headers())
+				headers := make(map[string]any)
+				for k, v := range request.Headers() {
+					headers[k] = v
+				}
+				overrides["headers"] = serializeMapToNameValue(headers)
 			}
 		} else {
-			overrides["headers"] = serializeMapToNameAndValue(options[0].Headers)
+			headers := make(map[string]any)
+			for k, v := range options[0].Headers {
+				headers[k] = v
+			}
+			overrides["headers"] = serializeMapToNameValue(headers)
 			options[0].Headers = nil
 		}
 		if options[0].Data != nil {

--- a/fetch.go
+++ b/fetch.go
@@ -64,9 +64,10 @@ func newApiRequestImpl(pw *Playwright) *apiRequestImpl {
 
 type apiRequestContextImpl struct {
 	channelOwner
-	tracing        *tracingImpl
-	closeReason    *string
-	defaultTimeout *float64
+	tracing         *tracingImpl
+	closeReason     *string
+	defaultTimeout  *float64
+	timeoutSettings *timeoutSettings
 }
 
 func (r *apiRequestContextImpl) Dispose(options ...APIRequestContextDisposeOptions) error {
@@ -239,9 +240,19 @@ func (r *apiRequestContextImpl) innerFetch(url string, request Request, options 
 			overrides["params"] = serializeMapToNameValue(options[0].Params)
 			options[0].Params = nil
 		}
-		// Use context-level timeout as default if no per-request timeout specified
-		if options[0].Timeout == nil && r.defaultTimeout != nil {
-			overrides["timeout"] = *r.defaultTimeout
+		// Use the context-level default timeout when no per-request timeout is
+		// given. A standalone request context seeds r.defaultTimeout directly; a
+		// browser-context-owned request shares the context's timeoutSettings
+		// (mirroring upstream, where context.request._timeoutSettings is the
+		// context's instance), so SetDefaultTimeout reaches these fetches too.
+		if options[0].Timeout == nil {
+			if r.defaultTimeout != nil {
+				overrides["timeout"] = *r.defaultTimeout
+			} else if r.timeoutSettings != nil {
+				if dt := r.timeoutSettings.DefaultTimeout(); dt != nil {
+					overrides["timeout"] = *dt
+				}
+			}
 		}
 	}
 

--- a/fetch.go
+++ b/fetch.go
@@ -226,8 +226,11 @@ func (r *apiRequestContextImpl) innerFetch(url string, request Request, options 
 			overrides["multipartData"] = multipartData
 			options[0].Multipart = nil
 		} else if request != nil {
+			// Only forward post data when the request actually has a body; an empty
+			// buffer would otherwise be sent as "" and add a spurious
+			// content-length: 0 header (upstream omits postData for body-less requests).
 			postDataBuf, err := request.PostDataBuffer()
-			if err == nil {
+			if err == nil && len(postDataBuf) > 0 {
 				overrides["postData"] = base64.StdEncoding.EncodeToString(postDataBuf)
 			}
 		}

--- a/frame.go
+++ b/frame.go
@@ -271,6 +271,12 @@ func (f *frameImpl) setNavigationWaiter(timeout *float64) (*waiter, error) {
 	} else {
 		waiter.WithTimeout(f.page.timeoutSettings.NavigationTimeout())
 	}
+	// If the page is already closed, fail immediately rather than waiting for the
+	// (already-fired) close event or the navigation timeout, matching upstream's
+	// rejectImmediately guard.
+	if f.page.IsClosed() {
+		waiter.reject(f.page.closeErrorWithReason())
+	}
 	waiter.RejectOnEvent(f.page, "close", f.page.closeErrorWithReason())
 	waiter.RejectOnEvent(f.page, "crash", fmt.Errorf("Navigation failed because page crashed!"))
 	waiter.RejectOnEvent(f.page, "framedetached", fmt.Errorf("Navigating frame was detached!"), func(payload any) bool {

--- a/frame.go
+++ b/frame.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
@@ -105,7 +106,9 @@ func (f *frameImpl) AddScriptTag(options FrameAddScriptTagOptions) (ElementHandl
 		if err != nil {
 			return nil, err
 		}
-		options.Content = String(string(file))
+		// Append a sourceURL so the injected script is attributed to its file
+		// path in DevTools/traces, matching upstream addSourceUrlToScript.
+		options.Content = String(string(file) + "\n//# sourceURL=" + strings.ReplaceAll(*options.Path, "\n", ""))
 		options.Path = nil
 	}
 	channel, err := f.channel.Send("addScriptTag", options)
@@ -121,7 +124,7 @@ func (f *frameImpl) AddStyleTag(options FrameAddStyleTagOptions) (ElementHandle,
 		if err != nil {
 			return nil, err
 		}
-		options.Content = String(string(file))
+		options.Content = String(string(file) + "/*# sourceURL=" + strings.ReplaceAll(*options.Path, "\n", "") + "*/")
 		options.Path = nil
 	}
 	channel, err := f.channel.Send("addStyleTag", options)

--- a/frame.go
+++ b/frame.go
@@ -22,12 +22,14 @@ type frameImpl struct {
 }
 
 func newFrame(parent *channelOwner, objectType string, guid string, initializer map[string]any) *frameImpl {
-	var loadStates mapset.Set[string]
-
-	if ls, ok := initializer["loadStates"].([]string); ok {
-		loadStates = mapset.NewSet[string](ls...)
-	} else {
-		loadStates = mapset.NewSet[string]()
+	loadStates := mapset.NewSet[string]()
+	// Initializers are JSON-decoded, so an array arrives as []any, never []string.
+	if ls, ok := initializer["loadStates"].([]any); ok {
+		for _, state := range ls {
+			if s, ok := state.(string); ok {
+				loadStates.Add(s)
+			}
+		}
 	}
 	f := &frameImpl{
 		name:        initializer["name"].(string),

--- a/frame.go
+++ b/frame.go
@@ -235,6 +235,12 @@ func (f *frameImpl) ExpectNavigation(cb func() error, options ...FrameExpectNavi
 		return nil, err
 	}
 
+	event := eventData.(map[string]any)
+	if errVal, ok := event["error"]; ok {
+		// Any failed navigation results in a rejection.
+		return nil, errors.New(errVal.(string))
+	}
+
 	t := time.Until(deadline).Milliseconds()
 	if t > 0 {
 		err = f.waitForLoadStateImpl(string(*option.WaitUntil), Float(float64(t)), nil)
@@ -242,7 +248,6 @@ func (f *frameImpl) ExpectNavigation(cb func() error, options ...FrameExpectNavi
 			return nil, err
 		}
 	}
-	event := eventData.(map[string]any)
 	if event["newDocument"] != nil && event["newDocument"].(map[string]any)["request"] != nil {
 		request := fromChannel(event["newDocument"].(map[string]any)["request"]).(*requestImpl)
 		return request.Response()
@@ -744,7 +749,7 @@ func (f *frameImpl) Locator(selector string, options ...FrameLocatorOptions) Loc
 func (f *frameImpl) GetByAltText(text any, options ...FrameGetByAltTextOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}
@@ -754,7 +759,7 @@ func (f *frameImpl) GetByAltText(text any, options ...FrameGetByAltTextOptions) 
 func (f *frameImpl) GetByLabel(text any, options ...FrameGetByLabelOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}
@@ -764,7 +769,7 @@ func (f *frameImpl) GetByLabel(text any, options ...FrameGetByLabelOptions) Loca
 func (f *frameImpl) GetByPlaceholder(text any, options ...FrameGetByPlaceholderOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}
@@ -785,7 +790,7 @@ func (f *frameImpl) GetByTestId(testId any) Locator {
 func (f *frameImpl) GetByText(text any, options ...FrameGetByTextOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}
@@ -795,7 +800,7 @@ func (f *frameImpl) GetByText(text any, options ...FrameGetByTextOptions) Locato
 func (f *frameImpl) GetByTitle(text any, options ...FrameGetByTitleOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}

--- a/frame.go
+++ b/frame.go
@@ -108,7 +108,7 @@ func (f *frameImpl) AddScriptTag(options FrameAddScriptTagOptions) (ElementHandl
 		}
 		// Append a sourceURL so the injected script is attributed to its file
 		// path in DevTools/traces, matching upstream addSourceUrlToScript.
-		options.Content = String(string(file) + "\n//# sourceURL=" + strings.ReplaceAll(*options.Path, "\n", ""))
+		options.Content = String(addSourceURLToScript(string(file), *options.Path))
 		options.Path = nil
 	}
 	channel, err := f.channel.Send("addScriptTag", options)
@@ -253,7 +253,8 @@ func (f *frameImpl) ExpectNavigation(cb func() error, options ...FrameExpectNavi
 	}
 	if event["newDocument"] != nil && event["newDocument"].(map[string]any)["request"] != nil {
 		request := fromChannel(event["newDocument"].(map[string]any)["request"]).(*requestImpl)
-		return request.Response()
+		// The response lives on the final request after following any redirects.
+		return request.finalRequest().Response()
 	}
 	return nil, nil
 }

--- a/frame.go
+++ b/frame.go
@@ -539,7 +539,17 @@ func (f *frameImpl) WaitForFunction(expression string, arg any, options ...Frame
 	overrides := map[string]any{
 		"expression": expression,
 		"arg":        serializeArgument(arg),
-		"polling":    option.Polling,
+	}
+	// The server expects a numeric `pollingInterval`; the string "raf" means
+	// "poll on requestAnimationFrame" and is conveyed by omitting the interval.
+	switch polling := option.Polling.(type) {
+	case string:
+		if polling != "raf" {
+			return nil, fmt.Errorf("Unknown polling option: %s", polling)
+		}
+	case nil:
+	default:
+		overrides["pollingInterval"] = option.Polling
 	}
 	// timeout is required in Playwright v1.57+ protocol
 	if option.Timeout == nil {

--- a/frame_locator.go
+++ b/frame_locator.go
@@ -26,7 +26,7 @@ func (fl *frameLocatorImpl) FrameLocator(selector string) FrameLocator {
 func (fl *frameLocatorImpl) GetByAltText(text any, options ...FrameLocatorGetByAltTextOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}
@@ -36,7 +36,7 @@ func (fl *frameLocatorImpl) GetByAltText(text any, options ...FrameLocatorGetByA
 func (fl *frameLocatorImpl) GetByLabel(text any, options ...FrameLocatorGetByLabelOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}
@@ -46,7 +46,7 @@ func (fl *frameLocatorImpl) GetByLabel(text any, options ...FrameLocatorGetByLab
 func (fl *frameLocatorImpl) GetByPlaceholder(text any, options ...FrameLocatorGetByPlaceholderOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}
@@ -67,7 +67,7 @@ func (fl *frameLocatorImpl) GetByTestId(testId any) Locator {
 func (fl *frameLocatorImpl) GetByText(text any, options ...FrameLocatorGetByTextOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}
@@ -77,7 +77,7 @@ func (fl *frameLocatorImpl) GetByText(text any, options ...FrameLocatorGetByText
 func (fl *frameLocatorImpl) GetByTitle(text any, options ...FrameLocatorGetByTitleOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}

--- a/frame_locator.go
+++ b/frame_locator.go
@@ -1,7 +1,6 @@
 package playwright
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 )
@@ -106,8 +105,7 @@ func (fl *frameLocatorImpl) Locator(selectorOrLocator any, options ...FrameLocat
 	locator, ok := selectorOrLocator.(*locatorImpl)
 	if ok {
 		if fl.frame != locator.frame {
-			locator.err = errors.Join(locator.err, ErrLocatorNotSameFrame)
-			return locator
+			return locator.withError(ErrLocatorNotSameFrame)
 		}
 		return newLocator(
 			locator.frame,

--- a/generated-interfaces.go
+++ b/generated-interfaces.go
@@ -87,7 +87,7 @@ type APIRequestContext interface {
 
 	// Returns storage state for this request context, contains current cookies and local storage snapshot if it was
 	// passed to the constructor.
-	StorageState(options ...APIRequestContextStorageStateOptions) (*StorageState, error)
+	StorageState(path ...string) (*StorageState, error)
 
 	Tracing() Tracing
 }
@@ -501,7 +501,7 @@ type BrowserContext interface {
 
 	// Returns storage state for this browser context, contains current cookies, local storage snapshot and IndexedDB
 	// snapshot.
-	StorageState(options ...BrowserContextStorageStateOptions) (*StorageState, error)
+	StorageState(path ...string) (*StorageState, error)
 
 	// Clears the existing cookies, local storage and IndexedDB entries for all origins and sets the new storage state.
 	//
@@ -3823,7 +3823,7 @@ type Page interface {
 	ConsoleMessages(options ...PageConsoleMessagesOptions) ([]ConsoleMessage, error)
 
 	// Returns up to (currently) 200 last page errors from this page. See [Page.OnPageError] for more details.
-	PageErrors(options ...PagePageErrorsOptions) ([]string, error)
+	PageErrors() ([]string, error)
 
 	// The method returns an element locator that can be used to perform actions on this page / frame. Locator is resolved
 	// to the element immediately before performing an action, so a series of actions on the same locator can in fact be

--- a/generated-interfaces.go
+++ b/generated-interfaces.go
@@ -87,7 +87,7 @@ type APIRequestContext interface {
 
 	// Returns storage state for this request context, contains current cookies and local storage snapshot if it was
 	// passed to the constructor.
-	StorageState(path ...string) (*StorageState, error)
+	StorageState(options ...APIRequestContextStorageStateOptions) (*StorageState, error)
 
 	Tracing() Tracing
 }
@@ -501,7 +501,7 @@ type BrowserContext interface {
 
 	// Returns storage state for this browser context, contains current cookies, local storage snapshot and IndexedDB
 	// snapshot.
-	StorageState(path ...string) (*StorageState, error)
+	StorageState(options ...BrowserContextStorageStateOptions) (*StorageState, error)
 
 	// Clears the existing cookies, local storage and IndexedDB entries for all origins and sets the new storage state.
 	//
@@ -3823,7 +3823,7 @@ type Page interface {
 	ConsoleMessages(options ...PageConsoleMessagesOptions) ([]ConsoleMessage, error)
 
 	// Returns up to (currently) 200 last page errors from this page. See [Page.OnPageError] for more details.
-	PageErrors() ([]string, error)
+	PageErrors(options ...PagePageErrorsOptions) ([]string, error)
 
 	// The method returns an element locator that can be used to perform actions on this page / frame. Locator is resolved
 	// to the element immediately before performing an action, so a series of actions on the same locator can in fact be

--- a/generated-interfaces.go
+++ b/generated-interfaces.go
@@ -3823,7 +3823,7 @@ type Page interface {
 	ConsoleMessages(options ...PageConsoleMessagesOptions) ([]ConsoleMessage, error)
 
 	// Returns up to (currently) 200 last page errors from this page. See [Page.OnPageError] for more details.
-	PageErrors(options ...PagePageErrorsOptions) ([]string, error)
+	PageErrors() ([]string, error)
 
 	// The method returns an element locator that can be used to perform actions on this page / frame. Locator is resolved
 	// to the element immediately before performing an action, so a series of actions on the same locator can in fact be

--- a/generated-structs.go
+++ b/generated-structs.go
@@ -727,23 +727,6 @@ type BrowserContextCloseOptions struct {
 	Reason *string `json:"reason"`
 }
 
-type BrowserContextStorageStateOptions struct {
-	// Set to `true` to include IndexedDB in the storage state snapshot. If your application uses IndexedDB to store
-	// authentication tokens, like Firebase Authentication, enable this.
-	IndexedDB *bool `json:"indexedDB"`
-	// The file path to save the storage state to. If `path` is a relative path, then it is resolved relative to current
-	// working directory. If no path is provided, storage state is still returned, but won't be saved to the disk.
-	Path *string `json:"path"`
-}
-
-type APIRequestContextStorageStateOptions struct {
-	// Set to `true` to include IndexedDB in the storage state snapshot.
-	IndexedDB *bool `json:"indexedDB"`
-	// The file path to save the storage state to. If `path` is a relative path, then it is resolved relative to current
-	// working directory. If no path is provided, storage state is still returned, but won't be saved to the disk.
-	Path *string `json:"path"`
-}
-
 type Cookie struct {
 	Name   string `json:"name"`
 	Value  string `json:"value"`
@@ -3736,11 +3719,6 @@ type PageConsoleMessagesOptions struct {
 	Filter *ConsoleMessagesFilter `json:"filter"`
 }
 
-type PagePageErrorsOptions struct {
-	// Controls which errors are returned:
-	Filter *ConsoleMessagesFilter `json:"filter"`
-}
-
 type PageLocatorOptions struct {
 	// Narrows down the results of the method to those which contain elements matching this relative locator. For example,
 	// `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
@@ -4486,9 +4464,6 @@ type TracingStartHarOptions struct {
 	// When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page,
 	// cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
 	Mode *HarMode `json:"mode"`
-	// If specified, resources referenced by the HAR will be saved as separate files in this directory and referenced from
-	// the HAR. Cannot be used with a `.zip` output file.
-	ResourcesDir *string `json:"resourcesDir"`
 	// A glob or regex pattern to filter requests that are stored in the HAR. Defaults to none.
 	URLFilter any `json:"urlFilter"`
 }

--- a/generated-structs.go
+++ b/generated-structs.go
@@ -727,6 +727,23 @@ type BrowserContextCloseOptions struct {
 	Reason *string `json:"reason"`
 }
 
+type BrowserContextStorageStateOptions struct {
+	// Set to `true` to include IndexedDB in the storage state snapshot. If your application uses IndexedDB to store
+	// authentication tokens, like Firebase Authentication, enable this.
+	IndexedDB *bool `json:"indexedDB"`
+	// The file path to save the storage state to. If `path` is a relative path, then it is resolved relative to current
+	// working directory. If no path is provided, storage state is still returned, but won't be saved to the disk.
+	Path *string `json:"path"`
+}
+
+type APIRequestContextStorageStateOptions struct {
+	// Set to `true` to include IndexedDB in the storage state snapshot.
+	IndexedDB *bool `json:"indexedDB"`
+	// The file path to save the storage state to. If `path` is a relative path, then it is resolved relative to current
+	// working directory. If no path is provided, storage state is still returned, but won't be saved to the disk.
+	Path *string `json:"path"`
+}
+
 type Cookie struct {
 	Name   string `json:"name"`
 	Value  string `json:"value"`
@@ -3719,6 +3736,11 @@ type PageConsoleMessagesOptions struct {
 	Filter *ConsoleMessagesFilter `json:"filter"`
 }
 
+type PagePageErrorsOptions struct {
+	// Controls which errors are returned:
+	Filter *ConsoleMessagesFilter `json:"filter"`
+}
+
 type PageLocatorOptions struct {
 	// Narrows down the results of the method to those which contain elements matching this relative locator. For example,
 	// `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
@@ -4464,6 +4486,9 @@ type TracingStartHarOptions struct {
 	// When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page,
 	// cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
 	Mode *HarMode `json:"mode"`
+	// If specified, resources referenced by the HAR will be saved as separate files in this directory and referenced from
+	// the HAR. Cannot be used with a `.zip` output file.
+	ResourcesDir *string `json:"resourcesDir"`
 	// A glob or regex pattern to filter requests that are stored in the HAR. Defaults to none.
 	URLFilter any `json:"urlFilter"`
 }

--- a/generated-structs.go
+++ b/generated-structs.go
@@ -334,6 +334,15 @@ type StorageState struct {
 	Origins []Origin `json:"origins"`
 }
 
+type APIRequestContextStorageStateOptions struct {
+	// Set to `true` to include IndexedDB in the storage state snapshot.
+	IndexedDB *bool `json:"indexedDB"`
+	// The file path to save the storage state to. If “[object Object]” is a relative path, then it is resolved relative
+	// to current working directory. If no path is provided, storage state is still returned, but won't be saved to the
+	// disk.
+	Path *string `json:"path"`
+}
+
 type NameValue struct {
 	// Name of the header.
 	Name string `json:"name"`
@@ -727,23 +736,6 @@ type BrowserContextCloseOptions struct {
 	Reason *string `json:"reason"`
 }
 
-type BrowserContextStorageStateOptions struct {
-	// Set to `true` to include IndexedDB in the storage state snapshot. If your application uses IndexedDB to store
-	// authentication tokens, like Firebase Authentication, enable this.
-	IndexedDB *bool `json:"indexedDB"`
-	// The file path to save the storage state to. If `path` is a relative path, then it is resolved relative to current
-	// working directory. If no path is provided, storage state is still returned, but won't be saved to the disk.
-	Path *string `json:"path"`
-}
-
-type APIRequestContextStorageStateOptions struct {
-	// Set to `true` to include IndexedDB in the storage state snapshot.
-	IndexedDB *bool `json:"indexedDB"`
-	// The file path to save the storage state to. If `path` is a relative path, then it is resolved relative to current
-	// working directory. If no path is provided, storage state is still returned, but won't be saved to the disk.
-	Path *string `json:"path"`
-}
-
 type Cookie struct {
 	Name   string `json:"name"`
 	Value  string `json:"value"`
@@ -789,6 +781,19 @@ type Geolocation struct {
 	Longitude float64 `json:"longitude"`
 	// Non-negative accuracy value. Defaults to `0`.
 	Accuracy *float64 `json:"accuracy"`
+}
+
+type BrowserContextStorageStateOptions struct {
+	// Set to `true` to include [IndexedDB] in the storage
+	// state snapshot. If your application uses IndexedDB to store authentication tokens, like Firebase Authentication,
+	// enable this.
+	//
+	// [IndexedDB]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
+	IndexedDB *bool `json:"indexedDB"`
+	// The file path to save the storage state to. If “[object Object]” is a relative path, then it is resolved relative
+	// to current working directory. If no path is provided, storage state is still returned, but won't be saved to the
+	// disk.
+	Path *string `json:"path"`
 }
 
 type BrowserContextUnrouteAllOptions struct {
@@ -3736,11 +3741,6 @@ type PageConsoleMessagesOptions struct {
 	Filter *ConsoleMessagesFilter `json:"filter"`
 }
 
-type PagePageErrorsOptions struct {
-	// Controls which errors are returned:
-	Filter *ConsoleMessagesFilter `json:"filter"`
-}
-
 type PageLocatorOptions struct {
 	// Narrows down the results of the method to those which contain elements matching this relative locator. For example,
 	// `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
@@ -4486,8 +4486,8 @@ type TracingStartHarOptions struct {
 	// When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page,
 	// cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
 	Mode *HarMode `json:"mode"`
-	// If specified, resources referenced by the HAR will be saved as separate files in this directory and referenced from
-	// the HAR. Cannot be used with a `.zip` output file.
+	// Only used together with `content: 'attach'`. When set, response bodies are placed in this directory instead of next
+	// to the HAR file. Not compatible with a `.zip` HAR file.
 	ResourcesDir *string `json:"resourcesDir"`
 	// A glob or regex pattern to filter requests that are stored in the HAR. Defaults to none.
 	URLFilter any `json:"urlFilter"`

--- a/glob.go
+++ b/glob.go
@@ -148,7 +148,7 @@ func resolveGlobBase(baseURL *string, match string) string {
 				relativePath[i] = mapToken(token, "$_"+strconv.Itoa(i)+"_$")
 			} else {
 				newPrefix := mapToken(token[:questionIndex], "$_"+strconv.Itoa(i)+"_$")
-				newSuffix := mapToken(token[questionIndex:], "?$"+strconv.Itoa(i)+"_$")
+				newSuffix := mapToken(token[questionIndex:], "?$_"+strconv.Itoa(i)+"_$")
 				relativePath[i] = newPrefix + newSuffix
 			}
 		}

--- a/glob.go
+++ b/glob.go
@@ -28,10 +28,13 @@ func globMustToRegex(glob string) *regexp.Regexp {
 	tokens := []string{"^"}
 	inGroup := false
 
-	for i := 0; i < len(glob); i++ {
-		c := rune(glob[i])
-		if c == '\\' && i+1 < len(glob) {
-			char := rune(glob[i+1])
+	// Iterate by rune (not byte) so multibyte UTF-8 characters survive intact,
+	// matching upstream which iterates UTF-16 code units.
+	runes := []rune(glob)
+	for i := 0; i < len(runes); i++ {
+		c := runes[i]
+		if c == '\\' && i+1 < len(runes) {
+			char := runes[i+1]
 			if _, ok := escapedChars[char]; ok {
 				tokens = append(tokens, "\\"+string(char))
 			} else {
@@ -41,17 +44,17 @@ func globMustToRegex(glob string) *regexp.Regexp {
 		} else if c == '*' {
 			charBefore := rune(0)
 			if i > 0 {
-				charBefore = rune(glob[i-1])
+				charBefore = runes[i-1]
 			}
 			starCount := 1
-			for i+1 < len(glob) && glob[i+1] == '*' {
+			for i+1 < len(runes) && runes[i+1] == '*' {
 				starCount++
 				i++
 			}
 			if starCount > 1 {
 				charAfter := rune(0)
-				if i+1 < len(glob) {
-					charAfter = rune(glob[i+1])
+				if i+1 < len(runes) {
+					charAfter = runes[i+1]
 				}
 				// Match either /..something../ or /.
 				if charAfter == '/' {

--- a/glob.go
+++ b/glob.go
@@ -39,23 +39,31 @@ func globMustToRegex(glob string) *regexp.Regexp {
 			}
 			i++
 		} else if c == '*' {
-			beforeDeep := rune(0)
+			charBefore := rune(0)
 			if i > 0 {
-				beforeDeep = rune(glob[i-1])
+				charBefore = rune(glob[i-1])
 			}
 			starCount := 1
 			for i+1 < len(glob) && glob[i+1] == '*' {
 				starCount++
 				i++
 			}
-			afterDeep := rune(0)
-			if i+1 < len(glob) {
-				afterDeep = rune(glob[i+1])
-			}
-			isDeep := starCount > 1 && (beforeDeep == '/' || beforeDeep == 0) && (afterDeep == '/' || afterDeep == 0)
-			if isDeep {
-				tokens = append(tokens, "((?:[^/]*(?:/|$))*)")
-				i++
+			if starCount > 1 {
+				charAfter := rune(0)
+				if i+1 < len(glob) {
+					charAfter = rune(glob[i+1])
+				}
+				// Match either /..something../ or /.
+				if charAfter == '/' {
+					if charBefore == '/' {
+						tokens = append(tokens, "((.+/)|)")
+					} else {
+						tokens = append(tokens, "(.*/)")
+					}
+					i++
+				} else {
+					tokens = append(tokens, "(.*)")
+				}
 			} else {
 				tokens = append(tokens, "([^/]*)")
 			}
@@ -110,6 +118,12 @@ func resolveGlobBase(baseURL *string, match string) string {
 	}
 	// Escaped `\\?` behaves the same as `?` in our glob patterns.
 	match = strings.ReplaceAll(match, `\\?`, "?")
+	// Special case about:/data:/chrome:/edge:/file: URLs as they are not relative to baseURL.
+	if strings.HasPrefix(match, "about:") || strings.HasPrefix(match, "data:") ||
+		strings.HasPrefix(match, "chrome:") || strings.HasPrefix(match, "edge:") ||
+		strings.HasPrefix(match, "file:") {
+		return match
+	}
 	// Glob symbols may be escaped in the URL and some of them such as ? affect resolution,
 	// so we replace them with safe components first.
 	relativePath := strings.Split(match, "/")
@@ -120,7 +134,11 @@ func resolveGlobBase(baseURL *string, match string) string {
 		// Handle special case of http*://, note that the new schema has to be
 		// a web schema so that slashes are properly inserted after domain.
 		if i == 0 && strings.HasSuffix(token, ":") {
-			relativePath[i] = mapToken(token, "http:")
+			// Replace any pattern with http:; preserve an explicit schema as-is as
+			// it may affect trailing slashes after the domain.
+			if strings.ContainsAny(token, "*{") {
+				relativePath[i] = mapToken(token, "http:")
+			}
 		} else {
 			questionIndex := strings.Index(token, "?")
 			if questionIndex == -1 {

--- a/glob.go
+++ b/glob.go
@@ -150,29 +150,43 @@ func resolveGlobBase(baseURL *string, match string) string {
 			}
 		}
 	}
-	resolved := constructURLBasedOnBaseURL(baseURL, strings.Join(relativePath, "/"))
+	resolved, origin := constructURLBasedOnBaseURL(baseURL, strings.Join(relativePath, "/"))
 	for token, original := range tokenMap {
-		resolved = strings.ReplaceAll(resolved, token, original)
+		// Scheme and domain are case-insensitive: when a token resolves inside the
+		// URL origin, restore it lowercased so a mixed-case host still matches the
+		// (always-lowercased) request URL. Matches upstream resolveBaseURL.
+		replacement := original
+		if origin != "" && strings.Contains(origin, token) {
+			replacement = strings.ToLower(original)
+		}
+		resolved = strings.Replace(resolved, token, replacement, 1)
 	}
 	return resolved
 }
 
-func constructURLBasedOnBaseURL(baseURL *string, givenURL string) string {
+// constructURLBasedOnBaseURL resolves givenURL against baseURL (new URL(given,
+// base) semantics) and also returns the resolved URL's origin (scheme://host[:port]),
+// which is case-insensitive.
+func constructURLBasedOnBaseURL(baseURL *string, givenURL string) (string, string) {
 	u, err := url.Parse(givenURL)
 	if err != nil {
-		return givenURL
+		return givenURL, ""
 	}
 	if baseURL != nil {
 		base, err := url.Parse(*baseURL)
 		if err != nil {
-			return givenURL
+			return givenURL, ""
 		}
 		u = base.ResolveReference(u)
 	}
 	if u.Path == "" { // In Node.js, new URL('http://localhost') returns 'http://localhost/'.
 		u.Path = "/"
 	}
-	return u.String()
+	origin := ""
+	if u.Scheme != "" && u.Host != "" {
+		origin = u.Scheme + "://" + u.Host
+	}
+	return u.String(), origin
 }
 
 func toWebSocketBaseURL(baseURL *string) *string {

--- a/glob_test.go
+++ b/glob_test.go
@@ -31,6 +31,30 @@ func Test_globMustToRegex(t *testing.T) {
 			want: false,
 		},
 		{
+			// `**/` must match zero or more path segments including the scheme/host,
+			// matching upstream `((.+/)|)`. It must NOT match a bare relative path.
+			args: args{
+				glob:   "**/foo.png",
+				target: "foo.png",
+			},
+			want: false,
+		},
+		{
+			args: args{
+				glob:   "**/foo.png",
+				target: "https://localhost:8080/a/b/foo.png",
+			},
+			want: true,
+		},
+		{
+			// Embedded `**` not bounded by `/` becomes `(.*)` and may cross `/`.
+			args: args{
+				glob:   "https://example.com/a**b",
+				target: "https://example.com/a/x/y/b",
+			},
+			want: true,
+		},
+		{
 			args: args{
 				glob:   "*.js",
 				target: "https://localhost:8080/foo.js",

--- a/glob_test.go
+++ b/glob_test.go
@@ -225,4 +225,11 @@ func TestURLMatches(t *testing.T) {
 	require.True(t, newURLMatcher("\\\\?bar", String("http://playwright.dev/foo")).Matches("http://playwright.dev/foo?bar"))
 	require.True(t, newURLMatcher("**/foo", String("http://first.host/")).Matches("http://second.host/foo"))
 	require.True(t, newURLMatcher("*//localhost/", String("http://playwright.dev/")).Matches("http://localhost/"))
+
+	// Scheme and host are case-insensitive (the request URL is always lowercased).
+	require.True(t, newURLMatcher("HTTPS://EXAMPLE.COM/Foo", nil).Matches("https://example.com/Foo"))
+	require.False(t, newURLMatcher("HTTPS://EXAMPLE.COM/FOO", nil).Matches("https://example.com/foo-bar"))
+
+	// about:/data: URLs are not resolved against the base URL.
+	require.True(t, newURLMatcher("about:blank", String("http://playwright.dev/")).Matches("about:blank"))
 }

--- a/glob_test.go
+++ b/glob_test.go
@@ -232,4 +232,8 @@ func TestURLMatches(t *testing.T) {
 
 	// about:/data: URLs are not resolved against the base URL.
 	require.True(t, newURLMatcher("about:blank", String("http://playwright.dev/")).Matches("about:blank"))
+
+	// Non-ASCII characters in a glob must survive (rune, not byte, iteration).
+	require.True(t, newURLMatcher("https://example.com/ä", nil).Matches("https://example.com/ä"))
+	require.True(t, newURLMatcher("https://example.com/*/ä", nil).Matches("https://example.com/x/ä"))
 }

--- a/har_router.go
+++ b/har_router.go
@@ -63,14 +63,19 @@ func (r *harRouter) handle(route Route) error {
 	if err != nil {
 		return err
 	}
-	response, err := r.localUtils.HarLookup(harLookupOptions{
+	lookup := harLookupOptions{
 		HarId:               r.harId,
 		URL:                 request.URL(),
 		Method:              request.Method(),
 		Headers:             headers,
 		IsNavigationRequest: request.IsNavigationRequest(),
-		PostData:            postData,
-	})
+	}
+	// Omit postData for body-less requests; an empty buffer would otherwise be
+	// sent as "" and fail to match HAR entries that have no recorded body.
+	if len(postData) > 0 {
+		lookup.PostData = postData
+	}
+	response, err := r.localUtils.HarLookup(lookup)
 	if err != nil {
 		return err
 	}

--- a/har_router.go
+++ b/har_router.go
@@ -57,11 +57,17 @@ func (r *harRouter) handle(route Route) error {
 	if err != nil {
 		return err
 	}
+	// Use the actual on-wire headers (ordered, with duplicates) for matching,
+	// mirroring upstream which passes request.headersArray().
+	headers, err := request.HeadersArray()
+	if err != nil {
+		return err
+	}
 	response, err := r.localUtils.HarLookup(harLookupOptions{
 		HarId:               r.harId,
 		URL:                 request.URL(),
 		Method:              request.Method(),
-		Headers:             request.Headers(),
+		Headers:             headers,
 		IsNavigationRequest: request.IsNavigationRequest(),
 		PostData:            postData,
 	})

--- a/har_router.go
+++ b/har_router.go
@@ -75,16 +75,24 @@ func (r *harRouter) handle(route Route) error {
 		}
 		return route.(*routeImpl).redirectedNavigationRequest(*response.RedirectURL)
 	case "fulfill":
+		// If the response status is -1, the request was canceled or stalled, so we just stall it here.
+		// See https://github.com/microsoft/playwright/issues/29311.
+		if response.Status != nil && *response.Status == -1 {
+			return nil
+		}
 		if response.Body == nil {
 			return errors.New("fulfill body is null")
 		}
 		return route.Fulfill(RouteFulfillOptions{
-			Body:    *response.Body,
-			Status:  response.Status,
-			Headers: deserializeNameAndValueToMap(response.Headers),
+			Body:   *response.Body,
+			Status: response.Status,
+			// route.Fulfill does not support multiple set-cookie headers, so we merge them into one.
+			Headers: mergeHeaders(response.Headers),
 		})
 	case "error":
-		logger.Error("har action error", "error", *response.Message)
+		if response.Message != nil {
+			logger.Error("har action error", "error", *response.Message)
+		}
 		fallthrough
 	case "noentry":
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -586,6 +586,27 @@ func deserializeNameAndValueToMap(headersArray []map[string]string) map[string]s
 	return unserialized
 }
 
+// mergeHeaders converts a name/value header array into a map, merging multiple
+// set-cookie headers into a single newline-separated value (route.Fulfill does
+// not support multiple set-cookie headers).
+func mergeHeaders(headersArray []map[string]string) map[string]string {
+	headers := make(map[string]string)
+	for _, item := range headersArray {
+		name := item["name"]
+		value := item["value"]
+		if strings.ToLower(name) == "set-cookie" {
+			if existing, ok := headers["set-cookie"]; ok {
+				headers["set-cookie"] = existing + "\n" + value
+			} else {
+				headers["set-cookie"] = value
+			}
+		} else {
+			headers[name] = value
+		}
+	}
+	return headers
+}
+
 type recordHarOptions struct {
 	Path           string            `json:"harPath,omitempty"`
 	Content        *HarContentPolicy `json:"content,omitempty"`

--- a/helpers.go
+++ b/helpers.go
@@ -586,6 +586,30 @@ func deserializeNameAndValueToMap(headersArray []map[string]string) map[string]s
 	return unserialized
 }
 
+// addSourceURLToScript appends a sourceURL comment so scripts loaded from a file
+// path are attributed to that path in stack traces and DevTools, mirroring
+// upstream addSourceUrlToScript.
+func addSourceURLToScript(source string, path string) string {
+	return source + "\n//# sourceURL=" + strings.ReplaceAll(path, "\n", "")
+}
+
+// formatCallLog renders the server-provided call log appended to command error
+// messages, mirroring upstream formatCallLog. Returns an empty string when the
+// log is absent or contains only empty entries.
+func formatCallLog(log []string) string {
+	hasContent := false
+	for _, l := range log {
+		if l != "" {
+			hasContent = true
+			break
+		}
+	}
+	if !hasContent {
+		return ""
+	}
+	return "\nCall log:\n" + strings.Join(log, "\n")
+}
+
 // mergeHeaders converts a name/value header array into a map, merging multiple
 // set-cookie headers into a single newline-separated value (route.Fulfill does
 // not support multiple set-cookie headers).

--- a/helpers.go
+++ b/helpers.go
@@ -614,19 +614,22 @@ type recordHarOptions struct {
 	UrlGlob        *string           `json:"urlGlob,omitempty"`
 	UrlRegexSource *string           `json:"urlRegexSource,omitempty"`
 	UrlRegexFlags  *string           `json:"urlRegexFlags,omitempty"`
+	ResourcesDir   *string           `json:"resourcesDir,omitempty"`
 }
 
 type recordHarInputOptions struct {
-	Path        string
-	URL         any
-	Mode        *HarMode
-	Content     *HarContentPolicy
-	OmitContent *bool
+	Path         string
+	URL          any
+	Mode         *HarMode
+	Content      *HarContentPolicy
+	OmitContent  *bool
+	ResourcesDir *string
 }
 
 type harRecordingMetadata struct {
-	Path    string
-	Content *HarContentPolicy
+	Path         string
+	Content      *HarContentPolicy
+	ResourcesDir *string
 }
 
 // resolveRecordVideoDir resolves a relative recordVideo.dir to an absolute path,
@@ -668,6 +671,7 @@ func prepareRecordHarOptions(option recordHarInputOptions) recordHarOptions {
 	} else if option.OmitContent != nil && *option.OmitContent {
 		out.Content = HarContentPolicyOmit
 	}
+	out.ResourcesDir = option.ResourcesDir
 	return out
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -630,19 +630,22 @@ type recordHarOptions struct {
 	UrlGlob        *string           `json:"urlGlob,omitempty"`
 	UrlRegexSource *string           `json:"urlRegexSource,omitempty"`
 	UrlRegexFlags  *string           `json:"urlRegexFlags,omitempty"`
+	ResourcesDir   *string           `json:"resourcesDir,omitempty"`
 }
 
 type recordHarInputOptions struct {
-	Path        string
-	URL         any
-	Mode        *HarMode
-	Content     *HarContentPolicy
-	OmitContent *bool
+	Path         string
+	URL          any
+	Mode         *HarMode
+	Content      *HarContentPolicy
+	OmitContent  *bool
+	ResourcesDir *string
 }
 
 type harRecordingMetadata struct {
-	Path    string
-	Content *HarContentPolicy
+	Path         string
+	Content      *HarContentPolicy
+	ResourcesDir *string
 }
 
 // resolveRecordVideoDir resolves a relative recordVideo.dir to an absolute path,
@@ -684,6 +687,7 @@ func prepareRecordHarOptions(option recordHarInputOptions) recordHarOptions {
 	} else if option.OmitContent != nil && *option.OmitContent {
 		out.Content = HarContentPolicyOmit
 	}
+	out.ResourcesDir = option.ResourcesDir
 	return out
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -638,22 +638,19 @@ type recordHarOptions struct {
 	UrlGlob        *string           `json:"urlGlob,omitempty"`
 	UrlRegexSource *string           `json:"urlRegexSource,omitempty"`
 	UrlRegexFlags  *string           `json:"urlRegexFlags,omitempty"`
-	ResourcesDir   *string           `json:"resourcesDir,omitempty"`
 }
 
 type recordHarInputOptions struct {
-	Path         string
-	URL          any
-	Mode         *HarMode
-	Content      *HarContentPolicy
-	OmitContent  *bool
-	ResourcesDir *string
+	Path        string
+	URL         any
+	Mode        *HarMode
+	Content     *HarContentPolicy
+	OmitContent *bool
 }
 
 type harRecordingMetadata struct {
-	Path         string
-	Content      *HarContentPolicy
-	ResourcesDir *string
+	Path    string
+	Content *HarContentPolicy
 }
 
 // resolveRecordVideoDir resolves a relative recordVideo.dir to an absolute path,
@@ -695,7 +692,6 @@ func prepareRecordHarOptions(option recordHarInputOptions) recordHarOptions {
 	} else if option.OmitContent != nil && *option.OmitContent {
 		out.Content = HarContentPolicyOmit
 	}
-	out.ResourcesDir = option.ResourcesDir
 	return out
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -578,14 +578,6 @@ func assignStructFields(dest, src any, omitExtra bool) error {
 	return nil
 }
 
-func deserializeNameAndValueToMap(headersArray []map[string]string) map[string]string {
-	unserialized := make(map[string]string)
-	for _, item := range headersArray {
-		unserialized[item["name"]] = item["value"]
-	}
-	return unserialized
-}
-
 // addSourceURLToScript appends a sourceURL comment so scripts loaded from a file
 // path are attributed to that path in stack traces and DevTools, mirroring
 // upstream addSourceUrlToScript.

--- a/input.go
+++ b/input.go
@@ -88,7 +88,7 @@ func (m *keyboardImpl) InsertText(text string) error {
 }
 
 func (m *keyboardImpl) Type(text string, options ...KeyboardTypeOptions) error {
-	_, err := m.channel.Send("keyboardInsertText", map[string]any{
+	_, err := m.channel.Send("keyboardType", map[string]any{
 		"text": text,
 	}, options)
 	return err

--- a/input_files_helper.go
+++ b/input_files_helper.go
@@ -40,12 +40,16 @@ func convertInputFiles(files any, context *browserContextImpl) (*inputFiles, err
 		if sizeOfInputFiles([]InputFile{items}) >= fileSizeLimitInBytes {
 			return nil, ErrInputFilesSizeExceeded
 		}
+		// Buffers are passed as payloads regardless of local/remote connection,
+		// matching upstream which returns { payloads } without calling createTempFiles.
 		converted.Payloads = normalizeFilePayloads([]InputFile{items})
+		return converted, nil
 	case []InputFile:
 		if sizeOfInputFiles(items) >= fileSizeLimitInBytes {
 			return nil, ErrInputFilesSizeExceeded
 		}
 		converted.Payloads = normalizeFilePayloads(items)
+		return converted, nil
 	case string: // local file path
 		paths = []string{items}
 	case []string:

--- a/input_files_helper.go
+++ b/input_files_helper.go
@@ -37,12 +37,12 @@ func convertInputFiles(files any, context *browserContextImpl) (*inputFiles, err
 	)
 	switch items := files.(type) {
 	case InputFile:
-		if sizeOfInputFiles([]InputFile{items}) > fileSizeLimitInBytes {
+		if sizeOfInputFiles([]InputFile{items}) >= fileSizeLimitInBytes {
 			return nil, ErrInputFilesSizeExceeded
 		}
 		converted.Payloads = normalizeFilePayloads([]InputFile{items})
 	case []InputFile:
-		if sizeOfInputFiles(items) > fileSizeLimitInBytes {
+		if sizeOfInputFiles(items) >= fileSizeLimitInBytes {
 			return nil, ErrInputFilesSizeExceeded
 		}
 		converted.Payloads = normalizeFilePayloads(items)

--- a/js_handle.go
+++ b/js_handle.go
@@ -328,6 +328,14 @@ func serializeValue(value any, handles *[]*channel, depth int) any {
 	refV := reflect.ValueOf(value)
 
 	switch refV.Kind() {
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return map[string]any{
+			"n": refV.Int(),
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return map[string]any{
+			"n": refV.Uint(),
+		}
 	case reflect.Float32, reflect.Float64:
 		floatV := refV.Float()
 		if math.IsInf(floatV, 1) {

--- a/js_handle.go
+++ b/js_handle.go
@@ -10,6 +10,8 @@ import (
 	"math/big"
 	"net/url"
 	"reflect"
+	"regexp"
+	"strings"
 	"time"
 )
 
@@ -156,6 +158,30 @@ func parseValue(result any, refs map[float64]any) any {
 	if v, ok := vMap["d"]; ok {
 		t, _ := time.Parse(time.RFC3339Nano, v.(string))
 		return t
+	}
+	if v, ok := vMap["r"]; ok {
+		// A RegExp result from page evaluation, e.g. `() => /foo/i`. Translate the
+		// JS pattern + flags into a Go *regexp.Regexp, mapping the i/m/s flags to
+		// an inline (?ims) prefix. Mirrors upstream serializers.ts which returns
+		// `new RegExp(value.r.p, value.r.f)`.
+		r := v.(map[string]any)
+		pattern, _ := r["p"].(string)
+		flags, _ := r["f"].(string)
+		var inline strings.Builder
+		for _, f := range flags {
+			switch f {
+			case 'i', 'm', 's':
+				inline.WriteRune(f)
+			}
+		}
+		if inline.Len() > 0 {
+			pattern = "(?" + inline.String() + ")" + pattern
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil
+		}
+		return re
 	}
 	if v, ok := vMap["a"]; ok {
 		aV := v.([]any)

--- a/local_utils.go
+++ b/local_utils.go
@@ -110,13 +110,15 @@ func (l *localUtilsImpl) HarClose(harId string) error {
 	return err
 }
 
-func (l *localUtilsImpl) HarUnzip(zipFile, harFile string) error {
-	_, err := l.channel.Send("harUnzip", []map[string]any{
-		{
-			"zipFile": zipFile,
-			"harFile": harFile,
-		},
-	})
+func (l *localUtilsImpl) HarUnzip(zipFile, harFile string, resourcesDir ...*string) error {
+	params := map[string]any{
+		"zipFile": zipFile,
+		"harFile": harFile,
+	}
+	if len(resourcesDir) > 0 && resourcesDir[0] != nil {
+		params["resourcesDir"] = *resourcesDir[0]
+	}
+	_, err := l.channel.Send("harUnzip", []map[string]any{params})
 	return err
 }
 

--- a/local_utils.go
+++ b/local_utils.go
@@ -13,11 +13,12 @@ type localUtilsImpl struct {
 
 type (
 	localUtilsZipOptions struct {
-		ZipFile        string `json:"zipFile"`
-		Entries        []any  `json:"entries"`
-		StacksId       string `json:"stacksId"`
-		Mode           string `json:"mode"`
-		IncludeSources bool   `json:"includeSources"`
+		ZipFile           string   `json:"zipFile"`
+		Entries           []any    `json:"entries"`
+		StacksId          string   `json:"stacksId"`
+		Mode              string   `json:"mode"`
+		IncludeSources    bool     `json:"includeSources"`
+		AdditionalSources []string `json:"additionalSources"`
 	}
 
 	harLookupOptions struct {
@@ -119,9 +120,10 @@ func (l *localUtilsImpl) HarUnzip(zipFile, harFile string) error {
 	return err
 }
 
-func (l *localUtilsImpl) TracingStarted(traceName string, tracesDir ...string) (string, error) {
+func (l *localUtilsImpl) TracingStarted(traceName string, live bool, tracesDir ...string) (string, error) {
 	overrides := make(map[string]any)
 	overrides["traceName"] = traceName
+	overrides["live"] = live
 	if len(tracesDir) > 0 {
 		overrides["tracesDir"] = tracesDir[0]
 	}

--- a/local_utils.go
+++ b/local_utils.go
@@ -110,15 +110,13 @@ func (l *localUtilsImpl) HarClose(harId string) error {
 	return err
 }
 
-func (l *localUtilsImpl) HarUnzip(zipFile, harFile string, resourcesDir ...*string) error {
-	params := map[string]any{
-		"zipFile": zipFile,
-		"harFile": harFile,
-	}
-	if len(resourcesDir) > 0 && resourcesDir[0] != nil {
-		params["resourcesDir"] = *resourcesDir[0]
-	}
-	_, err := l.channel.Send("harUnzip", []map[string]any{params})
+func (l *localUtilsImpl) HarUnzip(zipFile, harFile string) error {
+	_, err := l.channel.Send("harUnzip", []map[string]any{
+		{
+			"zipFile": zipFile,
+			"harFile": harFile,
+		},
+	})
 	return err
 }
 

--- a/local_utils.go
+++ b/local_utils.go
@@ -22,12 +22,12 @@ type (
 	}
 
 	harLookupOptions struct {
-		HarId               string            `json:"harId"`
-		URL                 string            `json:"url"`
-		Method              string            `json:"method"`
-		Headers             map[string]string `json:"headers"`
-		IsNavigationRequest bool              `json:"isNavigationRequest"`
-		PostData            any               `json:"postData,omitempty"`
+		HarId               string      `json:"harId"`
+		URL                 string      `json:"url"`
+		Method              string      `json:"method"`
+		Headers             []NameValue `json:"headers"`
+		IsNavigationRequest bool        `json:"isNavigationRequest"`
+		PostData            any         `json:"postData,omitempty"`
 	}
 
 	harLookupResult struct {
@@ -67,7 +67,7 @@ func (l *localUtilsImpl) HarLookup(option harLookupOptions) (*harLookupResult, e
 	overrides["url"] = option.URL
 	overrides["method"] = option.Method
 	if option.Headers != nil {
-		overrides["headers"] = serializeMapToNameAndValue(option.Headers)
+		overrides["headers"] = option.Headers
 	}
 	overrides["isNavigationRequest"] = option.IsNavigationRequest
 	if option.PostData != nil {

--- a/locator.go
+++ b/locator.go
@@ -978,8 +978,10 @@ func (l *locatorImpl) withElement(
 	var remaining *float64
 	if deadline != nil {
 		ms := float64(time.Until(*deadline).Milliseconds())
-		if ms < 0 {
-			ms = 0
+		// Floor at 1ms, not 0: the protocol treats timeout 0 as "disable timeout"
+		// (infinite), so an exhausted budget must still fail fast rather than hang.
+		if ms <= 0 {
+			ms = 1
 		}
 		remaining = Float(ms)
 	}

--- a/locator.go
+++ b/locator.go
@@ -452,7 +452,7 @@ func (l *locatorImpl) GetAttribute(name string, options ...LocatorGetAttributeOp
 func (l *locatorImpl) GetByAltText(text any, options ...LocatorGetByAltTextOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}
@@ -462,7 +462,7 @@ func (l *locatorImpl) GetByAltText(text any, options ...LocatorGetByAltTextOptio
 func (l *locatorImpl) GetByLabel(text any, options ...LocatorGetByLabelOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}
@@ -472,7 +472,7 @@ func (l *locatorImpl) GetByLabel(text any, options ...LocatorGetByLabelOptions) 
 func (l *locatorImpl) GetByPlaceholder(text any, options ...LocatorGetByPlaceholderOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}
@@ -490,7 +490,7 @@ func (l *locatorImpl) GetByTestId(testId any) Locator {
 func (l *locatorImpl) GetByText(text any, options ...LocatorGetByTextOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}
@@ -500,7 +500,7 @@ func (l *locatorImpl) GetByText(text any, options ...LocatorGetByTextOptions) Lo
 func (l *locatorImpl) GetByTitle(text any, options ...LocatorGetByTitleOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}

--- a/locator.go
+++ b/locator.go
@@ -338,8 +338,13 @@ func (l *locatorImpl) Drop(payload Payload, options ...LocatorDropOptions) error
 		params["data"] = data
 	}
 	if len(options) == 1 {
-		if err := assignStructFields(&params, options[0], false); err != nil {
-			return err
+		// params is a map, so assignStructFields (which requires a struct dest)
+		// cannot be used here; set the option keys directly.
+		if options[0].Position != nil {
+			params["position"] = options[0].Position
+		}
+		if options[0].Timeout != nil {
+			params["timeout"] = options[0].Timeout
 		}
 	}
 	if _, ok := params["timeout"]; !ok {

--- a/locator.go
+++ b/locator.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 )
 
 var (
@@ -187,7 +188,7 @@ func (l *locatorImpl) BoundingBox(options ...LocatorBoundingBoxOptions) (*Rect, 
 		option.Timeout = options[0].Timeout
 	}
 
-	result, err := l.withElement(func(handle ElementHandle) (any, error) {
+	result, err := l.withElement(func(handle ElementHandle, _ *float64) (any, error) {
 		return handle.BoundingBox()
 	}, option)
 	if err != nil {
@@ -377,7 +378,7 @@ func (l *locatorImpl) Evaluate(expression string, arg any, options ...LocatorEva
 		option.Timeout = options[0].Timeout
 	}
 
-	return l.withElement(func(handle ElementHandle) (any, error) {
+	return l.withElement(func(handle ElementHandle, _ *float64) (any, error) {
 		return handle.Evaluate(expression, arg)
 	}, option)
 }
@@ -398,7 +399,7 @@ func (l *locatorImpl) EvaluateHandle(expression string, arg any, options ...Loca
 		option.Timeout = options[0].Timeout
 	}
 
-	h, err := l.withElement(func(handle ElementHandle) (any, error) {
+	h, err := l.withElement(func(handle ElementHandle, _ *float64) (any, error) {
 		return handle.EvaluateHandle(expression, arg)
 	}, option)
 	if err != nil {
@@ -771,11 +772,12 @@ func (l *locatorImpl) Screenshot(options ...LocatorScreenshotOptions) ([]byte, e
 		option.Timeout = options[0].Timeout
 	}
 
-	result, err := l.withElement(func(handle ElementHandle) (any, error) {
+	result, err := l.withElement(func(handle ElementHandle, timeout *float64) (any, error) {
 		var screenshotOption ElementHandleScreenshotOptions
 		if len(options) == 1 {
 			screenshotOption = ElementHandleScreenshotOptions(options[0])
 		}
+		screenshotOption.Timeout = timeout
 		return handle.Screenshot(screenshotOption)
 	}, option)
 	if err != nil {
@@ -794,11 +796,9 @@ func (l *locatorImpl) ScrollIntoViewIfNeeded(options ...LocatorScrollIntoViewIfN
 		option.Timeout = options[0].Timeout
 	}
 
-	_, err := l.withElement(func(handle ElementHandle) (any, error) {
+	_, err := l.withElement(func(handle ElementHandle, timeout *float64) (any, error) {
 		var opt ElementHandleScrollIntoViewIfNeededOptions
-		if len(options) == 1 {
-			opt.Timeout = options[0].Timeout
-		}
+		opt.Timeout = timeout
 		return nil, handle.ScrollIntoViewIfNeeded(opt)
 	}, option)
 
@@ -829,11 +829,12 @@ func (l *locatorImpl) SelectText(options ...LocatorSelectTextOptions) error {
 		option.Timeout = options[0].Timeout
 	}
 
-	_, err := l.withElement(func(handle ElementHandle) (any, error) {
+	_, err := l.withElement(func(handle ElementHandle, timeout *float64) (any, error) {
 		var opt ElementHandleSelectTextOptions
 		if len(options) == 1 {
 			opt = ElementHandleSelectTextOptions(options[0])
 		}
+		opt.Timeout = timeout
 		return nil, handle.SelectText(opt)
 	}, option)
 
@@ -947,7 +948,7 @@ func (l *locatorImpl) WaitFor(options ...LocatorWaitForOptions) error {
 }
 
 func (l *locatorImpl) withElement(
-	callback func(handle ElementHandle) (any, error),
+	callback func(handle ElementHandle, timeout *float64) (any, error),
 	options ...FrameWaitForSelectorOptions,
 ) (any, error) {
 	if l.err != nil {
@@ -960,12 +961,29 @@ func (l *locatorImpl) withElement(
 	if len(options) == 1 {
 		option.Timeout = options[0].Timeout
 	}
+	// Mirror upstream `_withElement`: when an explicit timeout is provided, the
+	// total budget for waitForSelector plus the inner action is bounded by that
+	// single timeout. Compute a deadline up front and hand the inner action the
+	// remaining budget instead of repeating the full timeout.
+	var deadline *time.Time
+	if option.Timeout != nil {
+		d := time.Now().Add(time.Duration(*option.Timeout) * time.Millisecond)
+		deadline = &d
+	}
 	handle, err := l.frame.WaitForSelector(l.selector, option)
 	if err != nil {
 		return nil, err
 	}
 
-	result, err := callback(handle)
+	var remaining *float64
+	if deadline != nil {
+		ms := float64(time.Until(*deadline).Milliseconds())
+		if ms < 0 {
+			ms = 0
+		}
+		remaining = Float(ms)
+	}
+	result, err := callback(handle, remaining)
 	if err != nil {
 		_ = handle.Dispose()
 		return nil, err

--- a/locator.go
+++ b/locator.go
@@ -998,9 +998,7 @@ func (l *locatorImpl) expect(expression string, options frameExpectOptions) (*fr
 		log      []string
 	)
 
-	if v, ok := result["received"]; ok {
-		received = parseResult(v)
-	}
+	received = parseExpectReceived(result["received"])
 	if v, ok := result["matches"]; ok {
 		matches = v.(bool)
 	}

--- a/locator.go
+++ b/locator.go
@@ -172,6 +172,9 @@ func (l *locatorImpl) Blur(options ...LocatorBlurOptions) error {
 }
 
 func (l *locatorImpl) AriaSnapshot(options ...LocatorAriaSnapshotOptions) (string, error) {
+	if l.err != nil {
+		return "", l.err
+	}
 	var option LocatorAriaSnapshotOptions
 	if len(options) == 1 {
 		option = options[0]

--- a/locator.go
+++ b/locator.go
@@ -62,6 +62,19 @@ func (l *locatorImpl) equals(locator Locator) bool {
 	return l.frame == locator.(*locatorImpl).frame && l.err == locator.(*locatorImpl).err && l.selector == locator.(*locatorImpl).selector
 }
 
+// withError returns a copy of the locator carrying an additional error, without
+// mutating the receiver. Upstream throws on these conditions; the Go API surfaces
+// the error lazily via the returned locator's Err().
+func (l *locatorImpl) withError(err error) *locatorImpl {
+	return &locatorImpl{
+		frame:       l.frame,
+		selector:    l.selector,
+		options:     l.options,
+		description: l.description,
+		err:         errors.Join(l.err, err),
+	}
+}
+
 func (l *locatorImpl) Err() error {
 	return l.err
 }
@@ -128,10 +141,16 @@ func (l *locatorImpl) AllTextContents() ([]string, error) {
 }
 
 func (l *locatorImpl) And(locator Locator) Locator {
+	if l.frame != locator.(*locatorImpl).frame {
+		return l.withError(ErrLocatorNotSameFrame)
+	}
 	return newLocator(l.frame, l.selector+` >> internal:and=`+escapeText(locator.(*locatorImpl).selector))
 }
 
 func (l *locatorImpl) Or(locator Locator) Locator {
+	if l.frame != locator.(*locatorImpl).frame {
+		return l.withError(ErrLocatorNotSameFrame)
+	}
 	return newLocator(l.frame, l.selector+` >> internal:or=`+escapeText(locator.(*locatorImpl).selector))
 }
 
@@ -696,8 +715,7 @@ func (l *locatorImpl) Locator(selectorOrLocator any, options ...LocatorLocatorOp
 	locator, ok := selectorOrLocator.(*locatorImpl)
 	if ok {
 		if l.frame != locator.frame {
-			l.err = errors.Join(l.err, ErrLocatorNotSameFrame)
-			return l
+			return l.withError(ErrLocatorNotSameFrame)
 		}
 		return newLocator(
 			l.frame,
@@ -705,8 +723,7 @@ func (l *locatorImpl) Locator(selectorOrLocator any, options ...LocatorLocatorOp
 			option,
 		)
 	}
-	l.err = errors.Join(l.err, fmt.Errorf("invalid locator parameter: %v", selectorOrLocator))
-	return l
+	return l.withError(fmt.Errorf("invalid locator parameter: %v", selectorOrLocator))
 }
 
 func (l *locatorImpl) Nth(index int) Locator {

--- a/locator.go
+++ b/locator.go
@@ -12,11 +12,10 @@ var (
 )
 
 type locatorImpl struct {
-	frame       *frameImpl
-	selector    string
-	options     *LocatorOptions
-	err         error
-	description *string
+	frame    *frameImpl
+	selector string
+	options  *LocatorOptions
+	err      error
 }
 
 type LocatorOptions LocatorFilterOptions
@@ -67,11 +66,10 @@ func (l *locatorImpl) equals(locator Locator) bool {
 // the error lazily via the returned locator's Err().
 func (l *locatorImpl) withError(err error) *locatorImpl {
 	return &locatorImpl{
-		frame:       l.frame,
-		selector:    l.selector,
-		options:     l.options,
-		description: l.description,
-		err:         errors.Join(l.err, err),
+		frame:    l.frame,
+		selector: l.selector,
+		options:  l.options,
+		err:      errors.Join(l.err, err),
 	}
 }
 
@@ -80,20 +78,13 @@ func (l *locatorImpl) Err() error {
 }
 
 func (l *locatorImpl) Describe(description string) Locator {
-	return &locatorImpl{
-		frame:       l.frame,
-		selector:    l.selector,
-		options:     l.options,
-		err:         l.err,
-		description: &description,
-	}
+	// Embed the description into the selector via the internal:describe engine so
+	// it reaches the server (traces, error messages, call logs), matching upstream.
+	return newLocator(l.frame, l.selector+" >> internal:describe="+escapeText(description))
 }
 
 func (l *locatorImpl) Description() (string, error) {
-	if l.description == nil {
-		return "", nil
-	}
-	return *l.description, nil
+	return locatorCustomDescription(l.selector), nil
 }
 
 func (l *locatorImpl) All() ([]Locator, error) {

--- a/locator_assertions.go
+++ b/locator_assertions.go
@@ -397,8 +397,10 @@ func (la *locatorAssertionsImpl) ToHaveCount(count int, options ...LocatorAssert
 
 func (la *locatorAssertionsImpl) ToHaveCSS(name string, value any, options ...LocatorAssertionsToHaveCSSOptions) error {
 	var timeout *float64
+	var pseudo *PseudoElement
 	if len(options) == 1 {
 		timeout = options[0].Timeout
+		pseudo = options[0].Pseudo
 	}
 	expectedText, err := toExpectedTextValues([]any{value}, false, false, nil)
 	if err != nil {
@@ -410,6 +412,7 @@ func (la *locatorAssertionsImpl) ToHaveCSS(name string, value any, options ...Lo
 			ExpressionArg: name,
 			ExpectedText:  expectedText,
 			Timeout:       timeout,
+			Pseudo:        pseudo,
 		},
 		value,
 		"Locator expected to have CSS",

--- a/locator_assertions.go
+++ b/locator_assertions.go
@@ -43,18 +43,18 @@ func (la *locatorAssertionsImpl) ToBeChecked(options ...LocatorAssertionsToBeChe
 	expected := "checked"
 
 	if len(options) == 1 {
+		// Always forward both keys (matching upstream), and derive the label:
+		// indeterminate (if truthy), else unchecked/checked from `checked`.
+		if options[0].Checked != nil {
+			expectedValue["checked"] = *options[0].Checked
+		}
 		if options[0].Indeterminate != nil {
 			expectedValue["indeterminate"] = *options[0].Indeterminate
-			if *options[0].Indeterminate {
-				expected = "indeterminate"
-			}
-		} else {
-			if options[0].Checked != nil {
-				expectedValue["checked"] = *options[0].Checked
-				if !*options[0].Checked {
-					expected = "unchecked"
-				}
-			}
+		}
+		if options[0].Indeterminate != nil && *options[0].Indeterminate {
+			expected = "indeterminate"
+		} else if options[0].Checked != nil && !*options[0].Checked {
+			expected = "unchecked"
 		}
 		timeout = options[0].Timeout
 	}
@@ -83,15 +83,21 @@ func (la *locatorAssertionsImpl) ToBeDisabled(options ...LocatorAssertionsToBeDi
 }
 
 func (la *locatorAssertionsImpl) ToBeEditable(options ...LocatorAssertionsToBeEditableOptions) error {
+	expression := "to.be.editable"
+	message := "Locator expected to be editable"
 	var timeout *float64
 	if len(options) == 1 {
+		if options[0].Editable != nil && !*options[0].Editable {
+			expression = "to.be.readonly"
+			message = "Locator expected to be readOnly"
+		}
 		timeout = options[0].Timeout
 	}
 	return la.expect(
-		"to.be.editable",
+		expression,
 		frameExpectOptions{Timeout: timeout},
 		nil,
-		"Locator expected to be editable",
+		message,
 	)
 }
 
@@ -109,15 +115,21 @@ func (la *locatorAssertionsImpl) ToBeEmpty(options ...LocatorAssertionsToBeEmpty
 }
 
 func (la *locatorAssertionsImpl) ToBeEnabled(options ...LocatorAssertionsToBeEnabledOptions) error {
+	expression := "to.be.enabled"
+	message := "Locator expected to be enabled"
 	var timeout *float64
 	if len(options) == 1 {
+		if options[0].Enabled != nil && !*options[0].Enabled {
+			expression = "to.be.disabled"
+			message = "Locator expected to be disabled"
+		}
 		timeout = options[0].Timeout
 	}
 	return la.expect(
-		"to.be.enabled",
+		expression,
 		frameExpectOptions{Timeout: timeout},
 		nil,
-		"Locator expected to be enabled",
+		message,
 	)
 }
 
@@ -168,15 +180,21 @@ func (la *locatorAssertionsImpl) ToBeInViewport(options ...LocatorAssertionsToBe
 }
 
 func (la *locatorAssertionsImpl) ToBeVisible(options ...LocatorAssertionsToBeVisibleOptions) error {
+	expression := "to.be.visible"
+	message := "Locator expected to be visible"
 	var timeout *float64
 	if len(options) == 1 {
+		if options[0].Visible != nil && !*options[0].Visible {
+			expression = "to.be.hidden"
+			message = "Locator expected to be hidden"
+		}
 		timeout = options[0].Timeout
 	}
 	return la.expect(
-		"to.be.visible",
+		expression,
 		frameExpectOptions{Timeout: timeout},
 		nil,
-		"Locator expected to be visible",
+		message,
 	)
 }
 

--- a/locator_assertions.go
+++ b/locator_assertions.go
@@ -272,7 +272,7 @@ func (la *locatorAssertionsImpl) ToHaveAccessibleDescription(description any, op
 		timeout = options[0].Timeout
 		ignoreCase = options[0].IgnoreCase
 	}
-	expectedText, err := toExpectedTextValues([]any{description}, false, false, ignoreCase)
+	expectedText, err := toExpectedTextValues([]any{description}, false, true, ignoreCase)
 	if err != nil {
 		return err
 	}
@@ -291,7 +291,7 @@ func (la *locatorAssertionsImpl) ToHaveAccessibleErrorMessage(errorMessage any, 
 		timeout = options[0].Timeout
 		ignoreCase = options[0].IgnoreCase
 	}
-	expectedText, err := toExpectedTextValues([]any{errorMessage}, false, false, ignoreCase)
+	expectedText, err := toExpectedTextValues([]any{errorMessage}, false, true, ignoreCase)
 	if err != nil {
 		return err
 	}
@@ -310,7 +310,7 @@ func (la *locatorAssertionsImpl) ToHaveAccessibleName(name any, options ...Locat
 		timeout = options[0].Timeout
 		ignoreCase = options[0].IgnoreCase
 	}
-	expectedText, err := toExpectedTextValues([]any{name}, false, false, ignoreCase)
+	expectedText, err := toExpectedTextValues([]any{name}, false, true, ignoreCase)
 	if err != nil {
 		return err
 	}

--- a/locator_helpers.go
+++ b/locator_helpers.go
@@ -46,7 +46,33 @@ func escapeForTextSelector(text any, exact bool) string {
 
 func escapeRegexForSelector(re *regexp.Regexp) string {
 	pattern, flag := convertRegexp(re)
+	// Escape any unescaped quote characters so a regex containing a quote does
+	// not break the selector tokenizer when the locator is chained (`>>`).
+	// Mirrors upstream's /(^|[^\\])(\\\\)*(["'`])/g → '$1$2\\$3' replacement.
+	pattern = escapeQuotesInRegexSource(pattern)
 	return fmt.Sprintf(`/%s/%s`, strings.ReplaceAll(pattern, `>>`, `\>\>`), flag)
+}
+
+// escapeQuotesInRegexSource backslash-escapes ", ' and ` characters that are not
+// already escaped by a preceding (even-length run of) backslashes.
+func escapeQuotesInRegexSource(s string) string {
+	var b strings.Builder
+	backslashes := 0
+	for _, r := range s {
+		if r == '"' || r == '\'' || r == '`' {
+			// Already escaped only if preceded by an odd number of backslashes.
+			if backslashes%2 == 0 {
+				b.WriteByte('\\')
+			}
+		}
+		if r == '\\' {
+			backslashes++
+		} else {
+			backslashes = 0
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }
 
 // locatorCustomDescription extracts the description embedded by Describe via the

--- a/locator_helpers.go
+++ b/locator_helpers.go
@@ -74,40 +74,45 @@ func getByPlaceholderSelector(text any, exact bool) string {
 }
 
 func getByRoleSelector(role AriaRole, options ...LocatorGetByRoleOptions) string {
-	props := make(map[string]string)
+	// Keep the property ordering stable and identical to upstream, since the
+	// produced selector string must be deterministic.
+	props := make([][2]string, 0)
 	if len(options) == 1 {
+		exact := false
+		if options[0].Exact != nil {
+			exact = *options[0].Exact
+		}
 		if options[0].Checked != nil {
-			props["checked"] = fmt.Sprintf("%t", *options[0].Checked)
+			props = append(props, [2]string{"checked", fmt.Sprintf("%t", *options[0].Checked)})
 		}
 		if options[0].Disabled != nil {
-			props["disabled"] = fmt.Sprintf("%t", *options[0].Disabled)
+			props = append(props, [2]string{"disabled", fmt.Sprintf("%t", *options[0].Disabled)})
 		}
 		if options[0].Selected != nil {
-			props["selected"] = fmt.Sprintf("%t", *options[0].Selected)
+			props = append(props, [2]string{"selected", fmt.Sprintf("%t", *options[0].Selected)})
 		}
 		if options[0].Expanded != nil {
-			props["expanded"] = fmt.Sprintf("%t", *options[0].Expanded)
+			props = append(props, [2]string{"expanded", fmt.Sprintf("%t", *options[0].Expanded)})
 		}
 		if options[0].IncludeHidden != nil {
-			props["include-hidden"] = fmt.Sprintf("%t", *options[0].IncludeHidden)
+			props = append(props, [2]string{"include-hidden", fmt.Sprintf("%t", *options[0].IncludeHidden)})
 		}
 		if options[0].Level != nil {
-			props["level"] = fmt.Sprintf("%d", *options[0].Level)
+			props = append(props, [2]string{"level", fmt.Sprintf("%d", *options[0].Level)})
 		}
 		if options[0].Name != nil {
-			exact := false
-			if options[0].Exact != nil {
-				exact = *options[0].Exact
-			}
-			props["name"] = escapeForAttributeSelector(options[0].Name, exact)
+			props = append(props, [2]string{"name", escapeForAttributeSelector(options[0].Name, exact)})
+		}
+		if options[0].Description != nil {
+			props = append(props, [2]string{"description", escapeForAttributeSelector(options[0].Description, exact)})
 		}
 		if options[0].Pressed != nil {
-			props["pressed"] = fmt.Sprintf("%t", *options[0].Pressed)
+			props = append(props, [2]string{"pressed", fmt.Sprintf("%t", *options[0].Pressed)})
 		}
 	}
 	var propsStr strings.Builder
-	for k, v := range props {
-		propsStr.WriteString("[" + k + "=" + v + "]")
+	for _, p := range props {
+		propsStr.WriteString("[" + p[0] + "=" + p[1] + "]")
 	}
 	return fmt.Sprintf("internal:role=%s%s", role, propsStr.String())
 }

--- a/locator_helpers.go
+++ b/locator_helpers.go
@@ -49,6 +49,24 @@ func escapeRegexForSelector(re *regexp.Regexp) string {
 	return fmt.Sprintf(`/%s/%s`, strings.ReplaceAll(pattern, `>>`, `\>\>`), flag)
 }
 
+// locatorCustomDescription extracts the description embedded by Describe via the
+// trailing `internal:describe=<json>` selector segment, mirroring upstream
+// locatorCustomDescription. Returns "" when no description is present.
+func locatorCustomDescription(selector string) string {
+	const marker = " >> internal:describe="
+	idx := strings.LastIndex(selector, marker)
+	if idx == -1 {
+		return ""
+	}
+	// The describe segment is always the last one (Describe appends it).
+	jsonValue := selector[idx+len(marker):]
+	var description string
+	if err := json.Unmarshal([]byte(jsonValue), &description); err != nil {
+		return ""
+	}
+	return description
+}
+
 func escapeText(s string) string {
 	builder := &strings.Builder{}
 	encoder := json.NewEncoder(builder)

--- a/mime_types.go
+++ b/mime_types.go
@@ -1,0 +1,83 @@
+package playwright
+
+import (
+	"fmt"
+	"strings"
+)
+
+// mimeTypesByExtension mirrors the common subset of upstream's
+// getMimeTypeForPath table (packages/isomorphic/mimeType.ts), using the exact
+// MIME strings Playwright sends. We intentionally avoid Go's stdlib
+// mime.TypeByExtension because it is platform-dependent and appends a charset.
+var mimeTypesByExtension = map[string]string{
+	"html":  "text/html",
+	"htm":   "text/html",
+	"css":   "text/css",
+	"js":    "application/javascript",
+	"mjs":   "application/javascript",
+	"json":  "application/json",
+	"xml":   "application/xml",
+	"txt":   "text/plain",
+	"csv":   "text/csv",
+	"md":    "text/markdown",
+	"ts":    "application/typescript",
+	"jsx":   "text/jsx",
+	"svg":   "image/svg+xml",
+	"png":   "image/png",
+	"jpg":   "image/jpeg",
+	"jpeg":  "image/jpeg",
+	"gif":   "image/gif",
+	"webp":  "image/webp",
+	"bmp":   "image/bmp",
+	"ico":   "image/x-icon",
+	"pdf":   "application/pdf",
+	"zip":   "application/zip",
+	"wasm":  "application/wasm",
+	"woff":  "font/woff",
+	"woff2": "font/woff2",
+	"ttf":   "font/ttf",
+	"otf":   "font/otf",
+	"mp4":   "video/mp4",
+	"webm":  "video/webm",
+	"ogv":   "video/ogg",
+	"mov":   "video/quicktime",
+	"mpeg":  "video/mpeg",
+	"mp3":   "audio/mpeg",
+	"wav":   "audio/wav",
+	"ogg":   "audio/ogg",
+	"oga":   "audio/ogg",
+	"m4a":   "audio/mp4",
+}
+
+// getMimeTypeForPath returns the MIME type for a file path based on its
+// extension, mirroring upstream getMimeTypeForPath. Returns an empty string
+// when the extension is unknown so callers can fall back to
+// "application/octet-stream".
+func getMimeTypeForPath(path string) string {
+	dotIndex := strings.LastIndex(path, ".")
+	if dotIndex == -1 {
+		return ""
+	}
+	extension := strings.ToLower(path[dotIndex+1:])
+	return mimeTypesByExtension[extension]
+}
+
+// determineScreenshotType infers the screenshot type from the output path's
+// extension when no explicit type is set, mirroring upstream
+// determineScreenshotType. It errors on an unsupported extension.
+func determineScreenshotType(path *string, typ *ScreenshotType) (*ScreenshotType, error) {
+	if typ != nil {
+		return typ, nil
+	}
+	if path == nil {
+		return nil, nil
+	}
+	switch getMimeTypeForPath(*path) {
+	case "image/png":
+		return ScreenshotTypePng, nil
+	case "image/jpeg":
+		return ScreenshotTypeJpeg, nil
+	default:
+		return nil, fmt.Errorf("path: unsupported mime type %q", getMimeTypeForPath(*path))
+	}
+}

--- a/mime_types.go
+++ b/mime_types.go
@@ -75,12 +75,13 @@ func determineScreenshotType(path *string, typ *ScreenshotType) (*ScreenshotType
 	if path == nil {
 		return nil, nil
 	}
-	switch getMimeTypeForPath(*path) {
+	mimeType := getMimeTypeForPath(*path)
+	switch mimeType {
 	case "image/png":
 		return ScreenshotTypePng, nil
 	case "image/jpeg":
 		return ScreenshotTypeJpeg, nil
 	default:
-		return nil, fmt.Errorf("path: unsupported mime type %q", getMimeTypeForPath(*path))
+		return nil, fmt.Errorf("path: unsupported mime type %q", mimeType)
 	}
 }

--- a/mime_types.go
+++ b/mime_types.go
@@ -58,7 +58,10 @@ func getMimeTypeForPath(path string) string {
 	if dotIndex == -1 {
 		return ""
 	}
-	extension := strings.ToLower(path[dotIndex+1:])
+	// Case-sensitive lookup, matching upstream getMimeTypeForPath (its table is
+	// all-lowercase, so a ".PNG" extension yields no match → octet-stream, and
+	// determineScreenshotType errors on it rather than silently inferring png).
+	extension := path[dotIndex+1:]
 	return mimeTypesByExtension[extension]
 }
 

--- a/page.go
+++ b/page.go
@@ -1442,8 +1442,8 @@ func (p *pageImpl) ClearPageErrors() error {
 	return err
 }
 
-func (p *pageImpl) PageErrors() ([]string, error) {
-	result, err := p.channel.Send("pageErrors")
+func (p *pageImpl) PageErrors(options ...PagePageErrorsOptions) ([]string, error) {
+	result, err := p.channel.Send("pageErrors", options)
 	if err != nil {
 		return nil, err
 	}

--- a/page.go
+++ b/page.go
@@ -877,6 +877,9 @@ func newPage(parent *channelOwner, objectType string, guid string, initializer m
 		locatorHandlers: make(map[float64]*locatorHandlerEntry, 0),
 	}
 	bt.createChannelOwner(bt, parent, objectType, guid, initializer)
+	if closed, ok := initializer["isClosed"].(bool); ok {
+		bt.isClosed = closed
+	}
 	bt.browserContext = fromChannel(parent.channel).(*browserContextImpl)
 	bt.timeoutSettings = newTimeoutSettings(bt.browserContext.timeoutSettings)
 	mainframe := fromChannel(initializer["mainFrame"]).(*frameImpl)

--- a/page.go
+++ b/page.go
@@ -1482,8 +1482,8 @@ func (p *pageImpl) ClearPageErrors() error {
 	return err
 }
 
-func (p *pageImpl) PageErrors(options ...PagePageErrorsOptions) ([]string, error) {
-	result, err := p.channel.Send("pageErrors", options)
+func (p *pageImpl) PageErrors() ([]string, error) {
+	result, err := p.channel.Send("pageErrors")
 	if err != nil {
 		return nil, err
 	}

--- a/page.go
+++ b/page.go
@@ -1002,6 +1002,18 @@ func (p *pageImpl) onFrameDetached(frame *frameImpl) {
 	if len(frames) != len(p.frames) {
 		p.frames = frames
 	}
+	// Remove the frame from its parent's childFrames so ChildFrames() doesn't
+	// keep returning a detached ghost frame (matches upstream).
+	if frame.parentFrame != nil {
+		parent := frame.parentFrame.(*frameImpl)
+		childFrames := make([]Frame, 0, len(parent.childFrames))
+		for _, child := range parent.childFrames {
+			if child != frame {
+				childFrames = append(childFrames, child)
+			}
+		}
+		parent.childFrames = childFrames
+	}
 	p.Emit("framedetached", frame)
 	p.browserContext.Emit("framedetached", frame)
 }

--- a/page.go
+++ b/page.go
@@ -102,13 +102,14 @@ func (p *pageImpl) onLocatorHandlerTriggered(uid float64) {
 }
 
 func (p *pageImpl) RemoveLocatorHandler(locator Locator) error {
+	// Remove every handler whose locator matches, not just the first one,
+	// matching upstream removeLocatorHandler.
 	for uid := range p.locatorHandlers {
 		if p.locatorHandlers[uid].locator.equals(locator) {
 			delete(p.locatorHandlers, uid)
 			p.channel.SendNoReply("unregisterLocatorHandler", map[string]any{
 				"uid": uid,
 			})
-			return nil
 		}
 	}
 	return nil
@@ -746,7 +747,7 @@ func (p *pageImpl) AddInitScript(script Script) error {
 		if err != nil {
 			return err
 		}
-		source = string(content)
+		source = addSourceURLToScript(string(content), *script.Path)
 	}
 	_, err := p.channel.Send("addInitScript", map[string]any{
 		"source": source,

--- a/page.go
+++ b/page.go
@@ -911,7 +911,7 @@ func newPage(parent *channelOwner, objectType string, guid string, initializer m
 		"request":         "request",
 		"response":        "response",
 		"requestfinished": "requestFinished",
-		"responsefailed":  "responseFailed",
+		"requestfailed":   "requestFailed",
 		"filechooser":     "fileChooser",
 	})
 
@@ -945,7 +945,7 @@ func (p *pageImpl) onFrameDetached(frame *frameImpl) {
 	frames := make([]Frame, 0)
 	for i := 0; i < len(p.frames); i++ {
 		if p.frames[i] != frame {
-			frames = append(frames, frame)
+			frames = append(frames, p.frames[i])
 		}
 	}
 	if len(frames) != len(p.frames) {
@@ -1244,7 +1244,7 @@ func (p *pageImpl) Locator(selector string, options ...PageLocatorOptions) Locat
 func (p *pageImpl) GetByAltText(text any, options ...PageGetByAltTextOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}
@@ -1254,7 +1254,7 @@ func (p *pageImpl) GetByAltText(text any, options ...PageGetByAltTextOptions) Lo
 func (p *pageImpl) GetByLabel(text any, options ...PageGetByLabelOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}
@@ -1264,7 +1264,7 @@ func (p *pageImpl) GetByLabel(text any, options ...PageGetByLabelOptions) Locato
 func (p *pageImpl) GetByPlaceholder(text any, options ...PageGetByPlaceholderOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}
@@ -1285,7 +1285,7 @@ func (p *pageImpl) GetByTestId(testId any) Locator {
 func (p *pageImpl) GetByText(text any, options ...PageGetByTextOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}
@@ -1295,7 +1295,7 @@ func (p *pageImpl) GetByText(text any, options ...PageGetByTextOptions) Locator 
 func (p *pageImpl) GetByTitle(text any, options ...PageGetByTitleOptions) Locator {
 	exact := false
 	if len(options) == 1 {
-		if *options[0].Exact {
+		if options[0].Exact != nil && *options[0].Exact {
 			exact = true
 		}
 	}

--- a/page.go
+++ b/page.go
@@ -358,14 +358,24 @@ func (p *pageImpl) Goto(url string, options ...PageGotoOptions) (Response, error
 	return p.mainFrame.Goto(url)
 }
 
-func (p *pageImpl) Reload(options ...PageReloadOptions) (Response, error) {
+// navigationTimeoutOverride returns the channel overrides that resolve the
+// configured navigation timeout when the caller supplied no per-call timeout.
+// The protocol requires a timeout on the navigation methods, so without this the
+// serializer would inject a hardcoded 30s instead of honoring SetDefaultNavigationTimeout.
+func (p *pageImpl) navigationTimeoutOverride(timeout *float64) map[string]any {
 	overrides := map[string]any{}
-	// timeout is required by the protocol; resolve the configured navigation
-	// timeout when the caller didn't supply one (matches upstream).
-	if len(options) == 0 || options[0].Timeout == nil {
+	if timeout == nil {
 		overrides["timeout"] = p.timeoutSettings.NavigationTimeout()
 	}
-	channel, err := p.channel.Send("reload", options, overrides)
+	return overrides
+}
+
+func (p *pageImpl) Reload(options ...PageReloadOptions) (Response, error) {
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
+	}
+	channel, err := p.channel.Send("reload", options, p.navigationTimeoutOverride(timeout))
 	if err != nil {
 		return nil, err
 	}
@@ -384,11 +394,11 @@ func (p *pageImpl) WaitForLoadState(options ...PageWaitForLoadStateOptions) erro
 }
 
 func (p *pageImpl) GoBack(options ...PageGoBackOptions) (Response, error) {
-	overrides := map[string]any{}
-	if len(options) == 0 || options[0].Timeout == nil {
-		overrides["timeout"] = p.timeoutSettings.NavigationTimeout()
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
 	}
-	channel, err := p.channel.Send("goBack", options, overrides)
+	channel, err := p.channel.Send("goBack", options, p.navigationTimeoutOverride(timeout))
 	if err != nil {
 		return nil, err
 	}
@@ -401,11 +411,11 @@ func (p *pageImpl) GoBack(options ...PageGoBackOptions) (Response, error) {
 }
 
 func (p *pageImpl) GoForward(options ...PageGoForwardOptions) (Response, error) {
-	overrides := map[string]any{}
-	if len(options) == 0 || options[0].Timeout == nil {
-		overrides["timeout"] = p.timeoutSettings.NavigationTimeout()
+	var timeout *float64
+	if len(options) == 1 {
+		timeout = options[0].Timeout
 	}
-	channel, err := p.channel.Send("goForward", options, overrides)
+	channel, err := p.channel.Send("goForward", options, p.navigationTimeoutOverride(timeout))
 	if err != nil {
 		return nil, err
 	}

--- a/page.go
+++ b/page.go
@@ -605,6 +605,9 @@ func (p *pageImpl) waiterForRequest(url any, options ...PageExpectRequestOptions
 	}
 
 	waiter := newWaiter().WithTimeout(*option.Timeout)
+	// Fail fast if the page crashes or closes while waiting, matching upstream.
+	waiter.RejectOnEvent(p, "crash", errors.New("page crashed"))
+	waiter.RejectOnEvent(p, "close", p.closeErrorWithReason())
 	return waiter.WaitForEvent(p, "request", predicate)
 }
 
@@ -628,6 +631,9 @@ func (p *pageImpl) waiterForResponse(url any, options ...PageExpectResponseOptio
 	}
 
 	waiter := newWaiter().WithTimeout(*option.Timeout)
+	// Fail fast if the page crashes or closes while waiting, matching upstream.
+	waiter.RejectOnEvent(p, "crash", errors.New("page crashed"))
+	waiter.RejectOnEvent(p, "close", p.closeErrorWithReason())
 	return waiter.WaitForEvent(p, "response", predicate)
 }
 
@@ -1063,8 +1069,10 @@ func (p *pageImpl) onRoute(route *routeImpl) {
 
 	url := route.Request().URL()
 	for _, handlerEntry := range routes {
-		// If the page was closed we stall all requests right away.
-		if p.closeWasCalled.Load() || p.browserContext.closeWasCalled.Load() {
+		// If the page or context was closed we stall all requests right away.
+		// Use IsClosed() for the context so a server-driven close is covered too,
+		// matching page.ts (this._closeWasCalled || this._browserContext.isClosed()).
+		if p.closeWasCalled.Load() || p.browserContext.IsClosed() {
 			return
 		}
 		if !handlerEntry.Matches(url) {

--- a/page.go
+++ b/page.go
@@ -816,9 +816,18 @@ func (p *pageImpl) RouteFromHAR(har string, options ...PageRouteFromHAROptions) 
 		opt = options[0]
 	}
 	if opt.Update != nil && *opt.Update {
+		var updateContent *HarContentPolicy
+		switch opt.UpdateContent {
+		case RouteFromHarUpdateContentPolicyAttach:
+			updateContent = HarContentPolicyAttach
+		case RouteFromHarUpdateContentPolicyEmbed:
+			updateContent = HarContentPolicyEmbed
+		}
 		return p.browserContext.recordIntoHar(har, browserContextRecordIntoHarOptions{
-			Page: p,
-			URL:  opt.URL,
+			Page:          p,
+			URL:           opt.URL,
+			UpdateContent: updateContent,
+			UpdateMode:    opt.UpdateMode,
 		})
 	}
 	notFound := opt.NotFound

--- a/page.go
+++ b/page.go
@@ -807,7 +807,12 @@ func (p *pageImpl) ConsoleMessages(options ...PageConsoleMessagesOptions) ([]Con
 	messages := result.([]any)
 	consoleMessages := make([]ConsoleMessage, len(messages))
 	for i, m := range messages {
-		consoleMessages[i] = newConsoleMessage(m.(map[string]any))
+		cm := newConsoleMessage(m.(map[string]any))
+		// The consoleMessages result entries do not carry a page channel
+		// (unlike the live `console` event), so set the owning page
+		// explicitly to mirror upstream behavior.
+		cm.page = p
+		consoleMessages[i] = cm
 	}
 	return consoleMessages, nil
 }

--- a/page.go
+++ b/page.go
@@ -75,19 +75,12 @@ func (p *pageImpl) AddLocatorHandler(locator Locator, handler func(Locator), opt
 }
 
 func (p *pageImpl) onLocatorHandlerTriggered(uid float64) {
-	var remove *bool
-	handler, ok := p.locatorHandlers[uid]
-	if !ok {
-		return
-	}
-	if handler.times != nil {
-		*handler.times--
-		if *handler.times == 0 {
-			remove = Bool(true)
-		}
-	}
+	remove := false
+	// The server blocks the intercepted action until we resolve, so this must
+	// always fire — even for an unknown uid (e.g. removed while a trigger was in
+	// flight). Mirrors the upstream try/finally.
 	defer func() {
-		if remove != nil && *remove {
+		if remove {
 			delete(p.locatorHandlers, uid)
 		}
 		_, _ = p.connection.WrapAPICall(func() (any, error) {
@@ -99,7 +92,14 @@ func (p *pageImpl) onLocatorHandlerTriggered(uid float64) {
 		}, true)
 	}()
 
-	handler.handler(handler.locator)
+	handler, ok := p.locatorHandlers[uid]
+	if ok && (handler.times == nil || *handler.times != 0) {
+		if handler.times != nil {
+			*handler.times--
+		}
+		handler.handler(handler.locator)
+	}
+	remove = ok && handler.times != nil && *handler.times == 0
 }
 
 func (p *pageImpl) RemoveLocatorHandler(locator Locator) error {
@@ -213,17 +213,13 @@ func (p *pageImpl) Frames() []Frame {
 }
 
 func (p *pageImpl) SetDefaultNavigationTimeout(timeout float64) {
+	// Upstream only updates the client-side timeout settings; there is no
+	// corresponding protocol method (the old *NoReply methods were removed).
 	p.timeoutSettings.SetDefaultNavigationTimeout(&timeout)
-	p.channel.SendNoReplyInternal("setDefaultNavigationTimeoutNoReply", map[string]any{
-		"timeout": timeout,
-	})
 }
 
 func (p *pageImpl) SetDefaultTimeout(timeout float64) {
 	p.timeoutSettings.SetDefaultTimeout(&timeout)
-	p.channel.SendNoReplyInternal("setDefaultTimeoutNoReply", map[string]any{
-		"timeout": timeout,
-	})
 }
 
 func (p *pageImpl) QuerySelector(selector string, options ...PageQuerySelectorOptions) (ElementHandle, error) {

--- a/page.go
+++ b/page.go
@@ -870,6 +870,15 @@ func newPage(parent *channelOwner, objectType string, guid string, initializer m
 	bt.channel.On("frameDetached", func(ev map[string]any) {
 		bt.onFrameDetached(fromChannel(ev["frame"]).(*frameImpl))
 	})
+	bt.channel.On("viewportSizeChanged", func(ev map[string]any) {
+		// Keep viewportSize in sync with server-driven changes (e.g. a sized popup).
+		if vs, ok := ev["viewportSize"].(map[string]any); ok {
+			bt.viewportSize = &Size{
+				Width:  int(vs["width"].(float64)),
+				Height: int(vs["height"].(float64)),
+			}
+		}
+	})
 	bt.channel.On("locatorHandlerTriggered", func(ev map[string]any) {
 		bt.channel.CreateTask(func() {
 			bt.onLocatorHandlerTriggered(ev["uid"].(float64))

--- a/page.go
+++ b/page.go
@@ -166,10 +166,15 @@ func (p *pageImpl) Opener() (Page, error) {
 	channel := p.initializer["opener"]
 	channelOwner := fromNullableChannel(channel)
 	if channelOwner == nil {
-		// not popup page or opener has been closed
+		// not a popup page
 		return nil, nil
 	}
-	return channelOwner.(*pageImpl), nil
+	opener := channelOwner.(*pageImpl)
+	if opener.IsClosed() {
+		// Opener has been closed; upstream returns null in this case.
+		return nil, nil
+	}
+	return opener, nil
 }
 
 func (p *pageImpl) MainFrame() Frame {
@@ -187,11 +192,15 @@ func (p *pageImpl) Frame(options ...PageFrameOptions) Frame {
 	}
 
 	for _, f := range p.frames {
-		if option.Name != nil && f.Name() == *option.Name {
-			return f
+		// When a name is specified, match strictly by name and never consult the
+		// URL, matching upstream.
+		if option.Name != nil {
+			if f.Name() == *option.Name {
+				return f
+			}
+			continue
 		}
-
-		if option.URL != nil && matcher != nil && matcher.Matches(f.URL()) {
+		if matcher != nil && matcher.Matches(f.URL()) {
 			return f
 		}
 	}

--- a/page.go
+++ b/page.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -500,6 +501,9 @@ func (p *pageImpl) Screenshot(options ...PageScreenshotOptions) ([]byte, error) 
 		return nil, fmt.Errorf("could not decode base64 :%w", err)
 	}
 	if path != nil {
+		if err := os.MkdirAll(filepath.Dir(*path), 0o777); err != nil {
+			return nil, err
+		}
 		if err := os.WriteFile(*path, image, 0o644); err != nil {
 			return nil, err
 		}
@@ -521,6 +525,9 @@ func (p *pageImpl) PDF(options ...PagePdfOptions) ([]byte, error) {
 		return nil, fmt.Errorf("could not decode base64 :%w", err)
 	}
 	if path != nil {
+		if err := os.MkdirAll(filepath.Dir(*path), 0o777); err != nil {
+			return nil, err
+		}
 		if err := os.WriteFile(*path, pdf, 0o644); err != nil {
 			return nil, err
 		}

--- a/page.go
+++ b/page.go
@@ -124,15 +124,24 @@ func (b *pageImpl) Clock() Clock {
 }
 
 func (p *pageImpl) Close(options ...PageCloseOptions) error {
+	runBeforeUnload := false
 	if len(options) == 1 {
 		p.closeReason = options[0].Reason
+		runBeforeUnload = options[0].RunBeforeUnload != nil && *options[0].RunBeforeUnload
 	}
-	p.closeWasCalled.Store(true)
-	_, err := p.channel.Send("close", options)
-	if err == nil && p.ownedContext != nil {
+	// Only mark the page as being closed when it is actually torn down. With
+	// runBeforeUnload the page is not necessarily closing, so route handling
+	// must keep working.
+	if !runBeforeUnload {
+		p.closeWasCalled.Store(true)
+	}
+	var err error
+	if p.ownedContext != nil {
 		err = p.ownedContext.Close()
+	} else {
+		_, err = p.channel.Send("close", options)
 	}
-	if errors.Is(err, ErrTargetClosed) || (len(options) == 1 && options[0].RunBeforeUnload != nil && *options[0].RunBeforeUnload) {
+	if errors.Is(err, ErrTargetClosed) && !runBeforeUnload {
 		return nil
 	}
 	return err
@@ -540,8 +549,13 @@ func (p *pageImpl) waiterForEvent(event string, options ...PageWaitForEventOptio
 		predicate = options[0].Predicate
 	}
 	waiter := newWaiter().WithTimeout(timeout)
-	waiter.RejectOnEvent(p, "close", p.closeErrorWithReason())
-	waiter.RejectOnEvent(p, "crash", errors.New("page crashed"))
+	// Don't reject on the very event being awaited.
+	if event != "crash" {
+		waiter.RejectOnEvent(p, "crash", errors.New("page crashed"))
+	}
+	if event != "close" {
+		waiter.RejectOnEvent(p, "close", p.closeErrorWithReason())
+	}
 	return waiter.WaitForEvent(p, event, predicate)
 }
 

--- a/page.go
+++ b/page.go
@@ -359,7 +359,13 @@ func (p *pageImpl) Goto(url string, options ...PageGotoOptions) (Response, error
 }
 
 func (p *pageImpl) Reload(options ...PageReloadOptions) (Response, error) {
-	channel, err := p.channel.Send("reload", options)
+	overrides := map[string]any{}
+	// timeout is required by the protocol; resolve the configured navigation
+	// timeout when the caller didn't supply one (matches upstream).
+	if len(options) == 0 || options[0].Timeout == nil {
+		overrides["timeout"] = p.timeoutSettings.NavigationTimeout()
+	}
+	channel, err := p.channel.Send("reload", options, overrides)
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +384,11 @@ func (p *pageImpl) WaitForLoadState(options ...PageWaitForLoadStateOptions) erro
 }
 
 func (p *pageImpl) GoBack(options ...PageGoBackOptions) (Response, error) {
-	channel, err := p.channel.Send("goBack", options)
+	overrides := map[string]any{}
+	if len(options) == 0 || options[0].Timeout == nil {
+		overrides["timeout"] = p.timeoutSettings.NavigationTimeout()
+	}
+	channel, err := p.channel.Send("goBack", options, overrides)
 	if err != nil {
 		return nil, err
 	}
@@ -391,7 +401,11 @@ func (p *pageImpl) GoBack(options ...PageGoBackOptions) (Response, error) {
 }
 
 func (p *pageImpl) GoForward(options ...PageGoForwardOptions) (Response, error) {
-	channel, err := p.channel.Send("goForward", options)
+	overrides := map[string]any{}
+	if len(options) == 0 || options[0].Timeout == nil {
+		overrides["timeout"] = p.timeoutSettings.NavigationTimeout()
+	}
+	channel, err := p.channel.Send("goForward", options, overrides)
 	if err != nil {
 		return nil, err
 	}

--- a/page.go
+++ b/page.go
@@ -458,6 +458,12 @@ func (p *pageImpl) Screenshot(options ...PageScreenshotOptions) ([]byte, error) 
 	if len(options) == 1 {
 		path = options[0].Path
 		options[0].Path = nil
+		// Infer the image type from the path extension when not set, matching upstream.
+		typ, err := determineScreenshotType(path, options[0].Type)
+		if err != nil {
+			return nil, err
+		}
+		options[0].Type = typ
 		if options[0].Mask != nil {
 			masks := make([]map[string]any, 0)
 			for _, m := range options[0].Mask {
@@ -753,7 +759,7 @@ func (p *pageImpl) Keyboard() Keyboard {
 }
 
 func (p *pageImpl) ConsoleMessages(options ...PageConsoleMessagesOptions) ([]ConsoleMessage, error) {
-	result, err := p.channel.Send("consoleMessages", nil)
+	result, err := p.channel.Send("consoleMessages", options)
 	if err != nil {
 		return nil, err
 	}

--- a/page_assertions.go
+++ b/page_assertions.go
@@ -3,7 +3,6 @@ package playwright
 import (
 	"fmt"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -109,9 +108,14 @@ func (pa *pageAssertionsImpl) ToHaveURL(urlOrRegExp any, options ...PageAssertio
 
 	baseURL := pa.actualPage.Context().(*browserContextImpl).options.BaseURL
 	if urlPath, ok := urlOrRegExp.(string); ok && baseURL != nil {
-		u, _ := url.Parse(*baseURL)
-		u.Path = path.Join(u.Path, urlPath)
-		urlOrRegExp = u.String()
+		// Resolve against the base URL the same way the browser's `new URL(given,
+		// base)` does, rather than naive path joining (matching upstream
+		// constructURLBasedOnBaseURL).
+		if base, err := url.Parse(*baseURL); err == nil {
+			if given, err := url.Parse(urlPath); err == nil {
+				urlOrRegExp = base.ResolveReference(given).String()
+			}
+		}
 	}
 
 	expectedValues, err := toExpectedTextValues([]any{urlOrRegExp}, false, false, ignoreCase)

--- a/page_assertions.go
+++ b/page_assertions.go
@@ -54,9 +54,7 @@ func (pa *pageAssertionsImpl) expectOnFrame(
 		log      []string
 	)
 
-	if v, ok := result["received"]; ok {
-		received = parseResult(v)
-	}
+	received = parseExpectReceived(result["received"])
 	if v, ok := result["matches"]; ok {
 		matches = v.(bool)
 	}

--- a/patches/main.patch
+++ b/patches/main.patch
@@ -20,7 +20,7 @@ index d27e22b03..fd06a0784 100644
      - `origin` <[string]>
      - `localStorage` <[Array]<[Object]>>
 diff --git a/docs/src/api/class-apirequestcontext.md b/docs/src/api/class-apirequestcontext.md
-index 2ddc3815f..7ee170ba1 100644
+index 2ddc3815f..6e80f44c0 100644
 --- a/docs/src/api/class-apirequestcontext.md
 +++ b/docs/src/api/class-apirequestcontext.md
 @@ -163,6 +163,9 @@ context cookies from the response. The method will automatically follow redirect
@@ -254,7 +254,7 @@ index 2ddc3815f..7ee170ba1 100644
  
  ### option: APIRequestContext.storageState.indexedDB
  * since: v1.51
-+* langs: js, python, java, csharp
++* langs: js, python, java, csharp, go
  - `indexedDB` ?<boolean>
  
  Set to `true` to include IndexedDB in the storage state snapshot.
@@ -346,7 +346,7 @@ index b676c64dc..4a8c9b4a1 100644
  
  :::note
 diff --git a/docs/src/api/class-browsercontext.md b/docs/src/api/class-browsercontext.md
-index e839f13a0..2acef1c13 100644
+index e839f13a0..0fb881677 100644
 --- a/docs/src/api/class-browsercontext.md
 +++ b/docs/src/api/class-browsercontext.md
 @@ -433,7 +433,7 @@ The order of evaluation of multiple scripts installed via [`method: BrowserConte
@@ -406,7 +406,7 @@ index e839f13a0..2acef1c13 100644
  
  ### option: BrowserContext.storageState.indexedDB
  * since: v1.51
-+* langs: js, python, java, csharp
++* langs: js, python, java, csharp, go
  - `indexedDB` ?<boolean>
  
  Set to `true` to include [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) in the storage state snapshot.
@@ -1258,7 +1258,7 @@ index 4c3011430..4ced2d60d 100644
    - `path` ?<[path]> Path to the JavaScript file. If `path` is a relative path, then it is resolved relative to the
      current working directory. Optional.
 diff --git a/docs/src/api/class-tracing.md b/docs/src/api/class-tracing.md
-index 1af0427bf..2c7016e92 100644
+index 1af0427bf..4f54c91e9 100644
 --- a/docs/src/api/class-tracing.md
 +++ b/docs/src/api/class-tracing.md
 @@ -156,7 +156,7 @@ If this option is true tracing will
@@ -1270,6 +1270,15 @@ index 1af0427bf..2c7016e92 100644
  - `sources` <[boolean]>
  
  Whether to include source files for trace actions.
+@@ -374,7 +374,7 @@ A glob or regex pattern to filter requests that are stored in the HAR. Defaults
+ 
+ ### option: Tracing.startHar.resourcesDir
+ * since: v1.60
+-* langs: js
++* langs: js, go
+ - `resourcesDir` <[path]>
+ 
+ Only used together with `content: 'attach'`. When set, response bodies are placed in this directory instead of next to
 diff --git a/docs/src/api/class-websocket.md b/docs/src/api/class-websocket.md
 index e33740eac..d89648d91 100644
 --- a/docs/src/api/class-websocket.md

--- a/request.go
+++ b/request.go
@@ -211,7 +211,9 @@ func (r *requestImpl) applyFallbackOverrides(options RouteFallbackOptions) {
 	if options.Method != nil {
 		r.fallbackOverrides.Method = options.Method
 	}
-	r.fallbackOverrides.Headers = options.Headers
+	if options.Headers != nil {
+		r.fallbackOverrides.Headers = options.Headers
+	}
 	if options.PostData != nil {
 		switch v := options.PostData.(type) {
 		case string:

--- a/request.go
+++ b/request.go
@@ -250,6 +250,10 @@ func (r *requestImpl) applyFallbackOverrides(options RouteFallbackOptions) {
 			r.fallbackOverrides.PostDataBuffer = []byte(v)
 		case []byte:
 			r.fallbackOverrides.PostDataBuffer = v
+		default:
+			if data, err := json.Marshal(v); err == nil {
+				r.fallbackOverrides.PostDataBuffer = data
+			}
 		}
 	}
 }

--- a/request.go
+++ b/request.go
@@ -67,8 +67,13 @@ func (r *requestImpl) PostDataJSON(v any) error {
 			return err
 		}
 		entries := make(map[string]string, len(parsed))
-		for k := range parsed {
-			entries[k] = parsed.Get(k)
+		for k, vs := range parsed {
+			// Keep the last value for a repeated key, matching upstream which
+			// iterates URLSearchParams.entries() (last write wins). url.Values.Get
+			// would return the first value instead.
+			if len(vs) > 0 {
+				entries[k] = vs[len(vs)-1]
+			}
 		}
 		data, err := json.Marshal(entries)
 		if err != nil {

--- a/request.go
+++ b/request.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"strings"
 )
 
 type serializedFallbackOverrides struct {
@@ -55,6 +57,24 @@ func (r *requestImpl) PostDataJSON(v any) error {
 	body, err := r.PostDataBuffer()
 	if err != nil {
 		return err
+	}
+	// When the request is form-urlencoded, parse it into a key/value object,
+	// matching upstream postDataJSON.
+	contentType := r.Headers()["content-type"]
+	if strings.Contains(contentType, "application/x-www-form-urlencoded") {
+		parsed, err := url.ParseQuery(string(body))
+		if err != nil {
+			return err
+		}
+		entries := make(map[string]string, len(parsed))
+		for k := range parsed {
+			entries[k] = parsed.Get(k)
+		}
+		data, err := json.Marshal(entries)
+		if err != nil {
+			return err
+		}
+		return json.Unmarshal(data, v)
 	}
 	return json.Unmarshal(body, v)
 }

--- a/request.go
+++ b/request.go
@@ -96,6 +96,16 @@ func (r *requestImpl) Headers() map[string]string {
 	return r.provisionalHeaders.Headers()
 }
 
+// finalRequest walks the redirect chain to the final request, mirroring
+// upstream _finalRequest. The response of a redirected navigation lives on the
+// final request, not the initial 3xx one.
+func (r *requestImpl) finalRequest() *requestImpl {
+	if r.redirectedTo != nil {
+		return r.redirectedTo.(*requestImpl).finalRequest()
+	}
+	return r
+}
+
 func (r *requestImpl) Response() (Response, error) {
 	channel, err := r.channel.Send("response")
 	if err != nil {

--- a/route.go
+++ b/route.go
@@ -120,11 +120,19 @@ func (r *routeImpl) innerFulfill(options ...RouteFulfillOptions) error {
 	if option.Response != nil {
 		overrides["status"] = option.Response.Status()
 		headers = option.Response.Headers()
-		response, ok := option.Response.(*apiResponseImpl)
-		if option.Body == nil && option.Path == nil && ok && response.request.connection == r.connection {
-			overrides["fetchResponseUid"] = response.fetchUid()
-		} else {
-			option.Body, _ = option.Response.Body()
+		// Only derive the body from the response when the caller did not supply
+		// their own body/path (those are explicit overrides), matching upstream.
+		if option.Body == nil && option.Path == nil {
+			response, ok := option.Response.(*apiResponseImpl)
+			if ok && response.request.connection == r.connection {
+				overrides["fetchResponseUid"] = response.fetchUid()
+			} else {
+				body, err := option.Response.Body()
+				if err != nil {
+					return err
+				}
+				option.Body = body
+			}
 		}
 		option.Response = nil
 	}

--- a/route.go
+++ b/route.go
@@ -3,7 +3,6 @@ package playwright
 import (
 	"encoding/base64"
 	"errors"
-	"net/http"
 	"os"
 	"reflect"
 	"strconv"
@@ -136,22 +135,21 @@ func (r *routeImpl) innerFulfill(options ...RouteFulfillOptions) error {
 
 	length := 0
 	isBase64 := false
-	var fileContentType string
-	if _, ok := option.Body.(string); ok {
-		isBase64 = false
-	} else if body, ok := option.Body.([]byte); ok {
-		option.Body = base64.StdEncoding.EncodeToString(body)
-		length = len(body)
-		isBase64 = true
-	} else if option.Path != nil {
+	if option.Path != nil {
 		content, err := os.ReadFile(*option.Path)
 		if err != nil {
 			return err
 		}
-		fileContentType = http.DetectContentType(content)
 		option.Body = base64.StdEncoding.EncodeToString(content)
 		isBase64 = true
 		length = len(content)
+	} else if body, ok := option.Body.(string); ok {
+		isBase64 = false
+		length = len(body)
+	} else if body, ok := option.Body.([]byte); ok {
+		option.Body = base64.StdEncoding.EncodeToString(body)
+		length = len(body)
+		isBase64 = true
 	}
 
 	if option.Headers != nil {
@@ -165,7 +163,12 @@ func (r *routeImpl) innerFulfill(options ...RouteFulfillOptions) error {
 		headers["content-type"] = *option.ContentType
 		option.ContentType = nil
 	} else if option.Path != nil {
-		headers["content-type"] = fileContentType
+		// Content type is inferred from the file extension, matching upstream.
+		if contentType := getMimeTypeForPath(*option.Path); contentType != "" {
+			headers["content-type"] = contentType
+		} else {
+			headers["content-type"] = "application/octet-stream"
+		}
 	}
 	if _, ok := headers["content-length"]; !ok && length > 0 {
 		headers["content-length"] = strconv.Itoa(length)

--- a/screencast.go
+++ b/screencast.go
@@ -1,34 +1,70 @@
 package playwright
 
-import "encoding/base64"
+import (
+	"encoding/base64"
+	"errors"
+)
 
 type screencastImpl struct {
-	page *pageImpl
+	page     *pageImpl
+	started  bool
+	savePath *string
+	artifact *artifactImpl
 }
 
 func (s *screencastImpl) Start(options ...ScreencastStartOptions) error {
+	if s.started {
+		return errors.New("Screencast is already started")
+	}
+	s.started = true
 	overrides := map[string]any{}
 	if len(options) == 1 {
 		if options[0].OnFrame != nil {
 			onFrame := options[0].OnFrame
 			s.page.channel.On("screencastFrame", func(params map[string]any) {
 				data, _ := base64.StdEncoding.DecodeString(params["data"].(string))
-				onFrame(OnFrame{Data: data})
+				frame := OnFrame{Data: data}
+				if vw, ok := params["viewportWidth"].(float64); ok {
+					frame.ViewportWidth = int(vw)
+				}
+				if vh, ok := params["viewportHeight"].(float64); ok {
+					frame.ViewportHeight = int(vh)
+				}
+				onFrame(frame)
 			})
 			overrides["sendFrames"] = true
 			options[0].OnFrame = nil // don't serialize the callback
 		}
 		if options[0].Path != nil {
 			overrides["record"] = true
+			s.savePath = options[0].Path
 		}
 	}
-	_, err := s.page.channel.Send("screencastStart", options, overrides)
-	return err
+	result, err := s.page.channel.Send("screencastStart", options, overrides)
+	if err != nil {
+		return err
+	}
+	if resultMap, ok := result.(map[string]any); ok {
+		if artifactChannel := fromNullableChannel(resultMap["artifact"]); artifactChannel != nil {
+			s.artifact = artifactChannel.(*artifactImpl)
+		}
+	}
+	return nil
 }
 
 func (s *screencastImpl) Stop() error {
-	_, err := s.page.channel.Send("screencastStop")
-	return err
+	s.started = false
+	if _, err := s.page.channel.Send("screencastStop"); err != nil {
+		return err
+	}
+	if s.savePath != nil && s.artifact != nil {
+		if err := s.artifact.SaveAs(*s.savePath); err != nil {
+			return err
+		}
+	}
+	s.artifact = nil
+	s.savePath = nil
+	return nil
 }
 
 func (s *screencastImpl) ShowActions(options ...ScreencastShowActionsOptions) error {

--- a/screencast.go
+++ b/screencast.go
@@ -6,10 +6,12 @@ import (
 )
 
 type screencastImpl struct {
-	page     *pageImpl
-	started  bool
-	savePath *string
-	artifact *artifactImpl
+	page      *pageImpl
+	started   bool
+	savePath  *string
+	artifact  *artifactImpl
+	onFrame   func(OnFrame)
+	listening bool
 }
 
 func (s *screencastImpl) Start(options ...ScreencastStartOptions) error {
@@ -20,18 +22,27 @@ func (s *screencastImpl) Start(options ...ScreencastStartOptions) error {
 	overrides := map[string]any{}
 	if len(options) == 1 {
 		if options[0].OnFrame != nil {
-			onFrame := options[0].OnFrame
-			s.page.channel.On("screencastFrame", func(params map[string]any) {
-				data, _ := base64.StdEncoding.DecodeString(params["data"].(string))
-				frame := OnFrame{Data: data}
-				if vw, ok := params["viewportWidth"].(float64); ok {
-					frame.ViewportWidth = int(vw)
-				}
-				if vh, ok := params["viewportHeight"].(float64); ok {
-					frame.ViewportHeight = int(vh)
-				}
-				onFrame(frame)
-			})
+			s.onFrame = options[0].OnFrame
+			// Register the channel listener once and dispatch through the
+			// mutable onFrame field, mirroring upstream. This avoids leaking a
+			// listener (and duplicate dispatch) on every Start/Stop cycle.
+			if !s.listening {
+				s.listening = true
+				s.page.channel.On("screencastFrame", func(params map[string]any) {
+					if s.onFrame == nil {
+						return
+					}
+					data, _ := base64.StdEncoding.DecodeString(params["data"].(string))
+					frame := OnFrame{Data: data}
+					if vw, ok := params["viewportWidth"].(float64); ok {
+						frame.ViewportWidth = int(vw)
+					}
+					if vh, ok := params["viewportHeight"].(float64); ok {
+						frame.ViewportHeight = int(vh)
+					}
+					s.onFrame(frame)
+				})
+			}
 			overrides["sendFrames"] = true
 			options[0].OnFrame = nil // don't serialize the callback
 		}
@@ -54,6 +65,7 @@ func (s *screencastImpl) Start(options ...ScreencastStartOptions) error {
 
 func (s *screencastImpl) Stop() error {
 	s.started = false
+	s.onFrame = nil
 	if _, err := s.page.channel.Send("screencastStop"); err != nil {
 		return err
 	}

--- a/selectors.go
+++ b/selectors.go
@@ -105,7 +105,14 @@ func (s *selectorsImpl) removeChannel(channel *selectorsOwnerImpl) {
 }
 
 func (s *selectorsImpl) addContext(context *browserContextImpl) {
-	s.contexts.Store(context.guid, context)
+	// Idempotent, mirroring upstream's _contextsForSelectors Set membership: a
+	// context is set up at most once, so re-adding the same context is a no-op
+	// rather than re-sending registerSelectorEngine/setTestIdAttributeName. This
+	// lets every context-creation path call addContext without relying on a
+	// brittle "registered exactly once elsewhere" invariant.
+	if _, loaded := s.contexts.LoadOrStore(context.guid, context); loaded {
+		return
+	}
 	s.mu.RLock()
 	for _, selectorEngine := range s.registrations {
 		params := map[string]any{

--- a/selectors.go
+++ b/selectors.go
@@ -2,6 +2,7 @@ package playwright
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"sync"
 )
@@ -29,6 +30,14 @@ type selectorsImpl struct {
 }
 
 func (s *selectorsImpl) Register(name string, script Script, options ...SelectorsRegisterOptions) error {
+	s.mu.RLock()
+	for _, reg := range s.registrations {
+		if reg["name"] == name {
+			s.mu.RUnlock()
+			return fmt.Errorf("selectors.register: %q selector engine has been already registered", name)
+		}
+	}
+	s.mu.RUnlock()
 	if script.Path == nil && script.Content == nil {
 		return errors.New("Either source or path should be specified")
 	}
@@ -83,9 +92,11 @@ func (s *selectorsImpl) addChannel(channel *selectorsOwnerImpl) {
 			"selectorEngine": selectorEngine,
 		}
 		channel.channel.SendNoReply("registerSelectorEngine", params)
-		channel.setTestIdAttributeName(getTestIdAttributeName())
 	}
 	s.mu.RUnlock()
+	if testIdAttr := getTestIdAttributeName(); testIdAttr != "" {
+		channel.setTestIdAttributeName(testIdAttr)
+	}
 }
 
 func (s *selectorsImpl) removeChannel(channel *selectorsOwnerImpl) {

--- a/selectors_internal_test.go
+++ b/selectors_internal_test.go
@@ -1,0 +1,41 @@
+package playwright
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSelectorsAddContextIsIdempotent verifies that addContext registers a
+// context at most once: re-adding the same context (same guid) is a no-op,
+// mirroring upstream's _contextsForSelectors Set semantics. This guards against
+// double registration if a context-creation path ever calls addContext more
+// than once for the same context.
+func TestSelectorsAddContextIsIdempotent(t *testing.T) {
+	// Clear the testId attribute for this test so addContext has no engines and
+	// no testId to push, and therefore never touches context.channel — only the
+	// LoadOrStore membership logic runs. Restore the global afterwards.
+	prevTestID := testIdAttributeName
+	testIdAttributeName = ""
+	t.Cleanup(func() { testIdAttributeName = prevTestID })
+
+	s := newSelectorsImpl()
+	ctx := &browserContextImpl{channelOwner: channelOwner{guid: "context@idempotent"}}
+
+	s.addContext(ctx)
+	first, ok := s.contexts.Load("context@idempotent")
+	require.True(t, ok)
+	require.Same(t, ctx, first)
+
+	// Re-adding the same context must be a no-op and must not replace the stored
+	// value (LoadOrStore keeps the first).
+	other := &browserContextImpl{channelOwner: channelOwner{guid: "context@idempotent"}}
+	s.addContext(other)
+	stored, ok := s.contexts.Load("context@idempotent")
+	require.True(t, ok)
+	require.Same(t, ctx, stored, "second addContext must not overwrite the stored context")
+
+	count := 0
+	s.contexts.Range(func(_, _ any) bool { count++; return true })
+	require.Equal(t, 1, count)
+}

--- a/tests/apiresponse_assertions_test.go
+++ b/tests/apiresponse_assertions_test.go
@@ -41,7 +41,7 @@ func TestAssertionsShouldPrintResponseWithTextContentTypeIfToBeOKFails(t *testin
 	err = expect.APIResponse(response).ToBeOK()
 	require.ErrorContains(t, err, "→ GET "+server.PREFIX+"/text-content-type")
 	require.ErrorContains(t, err, "← 404 Not Found")
-	require.ErrorContains(t, err, "Response Text:")
+	require.ErrorContains(t, err, "Response text:")
 	require.ErrorContains(t, err, "Text error")
 
 	response, err = page.Request().Get(server.PREFIX + "/no-content-type")
@@ -50,7 +50,7 @@ func TestAssertionsShouldPrintResponseWithTextContentTypeIfToBeOKFails(t *testin
 	err = expect.APIResponse(response).ToBeOK()
 	require.ErrorContains(t, err, "→ GET "+server.PREFIX+"/no-content-type")
 	require.ErrorContains(t, err, "← 404 Not Found")
-	require.NotContains(t, err.Error(), "Response Text:")
+	require.NotContains(t, err.Error(), "Response text:")
 	require.NotContains(t, err.Error(), "No content type error")
 
 	response, err = page.Request().Get(server.PREFIX + "/binary-content-type")
@@ -58,6 +58,6 @@ func TestAssertionsShouldPrintResponseWithTextContentTypeIfToBeOKFails(t *testin
 	err = expect.APIResponse(response).ToBeOK()
 	require.ErrorContains(t, err, "→ GET "+server.PREFIX+"/binary-content-type")
 	require.ErrorContains(t, err, "← 404 Not Found")
-	require.NotContains(t, err.Error(), "Response Text:")
+	require.NotContains(t, err.Error(), "Response text:")
 	require.NotContains(t, err.Error(), "Image content type error")
 }

--- a/tests/binding_test.go
+++ b/tests/binding_test.go
@@ -124,6 +124,28 @@ func TestPageExposeBindingPanic(t *testing.T) {
 	require.Contains(t, stack[4], "binding_test.go")
 }
 
+// TestPageExposeBindingPanicNonError verifies a binding that panics with a
+// non-error value (e.g. a string) rejects cleanly instead of crashing the
+// process on a failed type assertion in the recover handler.
+func TestPageExposeBindingPanicNonError(t *testing.T) {
+	BeforeEach(t)
+
+	err := page.ExposeBinding("woofString", func(source *playwright.BindingSource, args ...interface{}) interface{} {
+		panic("WOOF STRING")
+	})
+	require.NoError(t, err)
+	result, err := page.Evaluate(`async () => {
+		try {
+		  await window['woofString']();
+		} catch (e) {
+		  return {message: e.message};
+		}
+	  }`)
+	require.NoError(t, err)
+	innerError := result.(map[string]interface{})
+	require.Equal(t, "WOOF STRING", innerError["message"])
+}
+
 func TestPageBindingsNoRace(t *testing.T) {
 	BeforeEach(t)
 

--- a/tests/browser_context_storage_state_test.go
+++ b/tests/browser_context_storage_state_test.go
@@ -54,6 +54,64 @@ func TestBrowserContextStorageStateShouldCaptureLocalStorage(t *testing.T) {
 	})
 }
 
+// TestBrowserContextStorageStateCaptureIndexedDB mirrors the upstream
+// "should capture cookies, local storage and IndexedDB" test
+// (browsercontext-storage-state.spec.ts): the indexedDB option must include
+// IndexedDB contents in the saved storage state.
+func TestBrowserContextStorageStateCaptureIndexedDB(t *testing.T) {
+	BeforeEach(t)
+
+	page1, err := context.NewPage()
+	require.NoError(t, err)
+	require.NoError(t, page1.Route("**/*", func(route playwright.Route) {
+		require.NoError(t, route.Fulfill(playwright.RouteFulfillOptions{
+			Body: "<html></html>",
+		}))
+	}))
+	_, err = page1.Goto("https://www.example.com")
+	require.NoError(t, err)
+	_, err = page1.Evaluate(`async () => {
+		await new Promise((resolve, reject) => {
+			const openRequest = indexedDB.open('db', 42);
+			openRequest.onupgradeneeded = () => {
+				openRequest.result.createObjectStore('store', { keyPath: 'name' });
+			};
+			openRequest.onsuccess = () => {
+				const transaction = openRequest.result.transaction(['store'], 'readwrite');
+				transaction.objectStore('store').put({ name: 'foo', value: 'bar' });
+				transaction.addEventListener('complete', resolve);
+				transaction.addEventListener('error', reject);
+			};
+		});
+	}`)
+	require.NoError(t, err)
+
+	tempfile, err := os.CreateTemp(t.TempDir(), "storage-state*.json")
+	require.NoError(t, err)
+	require.NoError(t, tempfile.Close())
+	_, err = context.StorageState(playwright.BrowserContextStorageStateOptions{
+		Path:      playwright.String(tempfile.Name()),
+		IndexedDB: playwright.Bool(true),
+	})
+	require.NoError(t, err)
+	written, err := os.ReadFile(tempfile.Name())
+	require.NoError(t, err)
+	require.Contains(t, string(written), "indexedDB")
+	require.Contains(t, string(written), "foo")
+
+	// Without the option, IndexedDB must NOT be captured.
+	tempfile2, err := os.CreateTemp(t.TempDir(), "storage-state*.json")
+	require.NoError(t, err)
+	require.NoError(t, tempfile2.Close())
+	_, err = context.StorageState(playwright.BrowserContextStorageStateOptions{
+		Path: playwright.String(tempfile2.Name()),
+	})
+	require.NoError(t, err)
+	writtenWithout, err := os.ReadFile(tempfile2.Name())
+	require.NoError(t, err)
+	require.NotContains(t, string(writtenWithout), "indexedDB")
+}
+
 func TestBrowserContextStorageStateSetLocalStorage(t *testing.T) {
 	BeforeEach(t, playwright.BrowserNewContextOptions{
 		StorageState: &playwright.OptionalStorageState{
@@ -103,7 +161,7 @@ func TestBrowserContextStorageStateRoundTripThroughTheFile(t *testing.T) {
 	require.NoError(t, err)
 	tempfile, err := os.CreateTemp(os.TempDir(), "storage-state*.json")
 	require.NoError(t, err)
-	state, err := context.StorageState(tempfile.Name())
+	state, err := context.StorageState(playwright.BrowserContextStorageStateOptions{Path: playwright.String(tempfile.Name())})
 	require.NoError(t, err)
 	stateWritten, err := os.ReadFile(tempfile.Name())
 	require.NoError(t, err)

--- a/tests/browser_context_storage_state_test.go
+++ b/tests/browser_context_storage_state_test.go
@@ -54,64 +54,6 @@ func TestBrowserContextStorageStateShouldCaptureLocalStorage(t *testing.T) {
 	})
 }
 
-// TestBrowserContextStorageStateCaptureIndexedDB mirrors the upstream
-// "should capture cookies, local storage and IndexedDB" test
-// (browsercontext-storage-state.spec.ts): the indexedDB option must include
-// IndexedDB contents in the saved storage state.
-func TestBrowserContextStorageStateCaptureIndexedDB(t *testing.T) {
-	BeforeEach(t)
-
-	page1, err := context.NewPage()
-	require.NoError(t, err)
-	require.NoError(t, page1.Route("**/*", func(route playwright.Route) {
-		require.NoError(t, route.Fulfill(playwright.RouteFulfillOptions{
-			Body: "<html></html>",
-		}))
-	}))
-	_, err = page1.Goto("https://www.example.com")
-	require.NoError(t, err)
-	_, err = page1.Evaluate(`async () => {
-		await new Promise((resolve, reject) => {
-			const openRequest = indexedDB.open('db', 42);
-			openRequest.onupgradeneeded = () => {
-				openRequest.result.createObjectStore('store', { keyPath: 'name' });
-			};
-			openRequest.onsuccess = () => {
-				const transaction = openRequest.result.transaction(['store'], 'readwrite');
-				transaction.objectStore('store').put({ name: 'foo', value: 'bar' });
-				transaction.addEventListener('complete', resolve);
-				transaction.addEventListener('error', reject);
-			};
-		});
-	}`)
-	require.NoError(t, err)
-
-	tempfile, err := os.CreateTemp(t.TempDir(), "storage-state*.json")
-	require.NoError(t, err)
-	require.NoError(t, tempfile.Close())
-	_, err = context.StorageState(playwright.BrowserContextStorageStateOptions{
-		Path:      playwright.String(tempfile.Name()),
-		IndexedDB: playwright.Bool(true),
-	})
-	require.NoError(t, err)
-	written, err := os.ReadFile(tempfile.Name())
-	require.NoError(t, err)
-	require.Contains(t, string(written), "indexedDB")
-	require.Contains(t, string(written), "foo")
-
-	// Without the option, IndexedDB must NOT be captured.
-	tempfile2, err := os.CreateTemp(t.TempDir(), "storage-state*.json")
-	require.NoError(t, err)
-	require.NoError(t, tempfile2.Close())
-	_, err = context.StorageState(playwright.BrowserContextStorageStateOptions{
-		Path: playwright.String(tempfile2.Name()),
-	})
-	require.NoError(t, err)
-	writtenWithout, err := os.ReadFile(tempfile2.Name())
-	require.NoError(t, err)
-	require.NotContains(t, string(writtenWithout), "indexedDB")
-}
-
 func TestBrowserContextStorageStateSetLocalStorage(t *testing.T) {
 	BeforeEach(t, playwright.BrowserNewContextOptions{
 		StorageState: &playwright.OptionalStorageState{
@@ -161,7 +103,7 @@ func TestBrowserContextStorageStateRoundTripThroughTheFile(t *testing.T) {
 	require.NoError(t, err)
 	tempfile, err := os.CreateTemp(os.TempDir(), "storage-state*.json")
 	require.NoError(t, err)
-	state, err := context.StorageState(playwright.BrowserContextStorageStateOptions{Path: playwright.String(tempfile.Name())})
+	state, err := context.StorageState(tempfile.Name())
 	require.NoError(t, err)
 	stateWritten, err := os.ReadFile(tempfile.Name())
 	require.NoError(t, err)

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -447,6 +447,23 @@ func TestDialogEventShouldWorkInImmdiatelyClosedPopup(t *testing.T) {
 	require.Equal(t, popup, msg.Page())
 }
 
+// TestBrowserContextExpectCloseEventResolves verifies that awaiting the "close"
+// event resolves rather than rejecting with TargetClosed (the reject-on-close
+// guard must not apply to the very event being awaited).
+func TestBrowserContextExpectCloseEventResolves(t *testing.T) {
+	BeforeEach(t)
+
+	browser1, err := browserType.Launch()
+	require.NoError(t, err)
+	defer browser1.Close() //nolint:errcheck
+	context1, err := browser1.NewContext()
+	require.NoError(t, err)
+	_, err = context1.ExpectEvent("close", func() error {
+		return context1.Close()
+	})
+	require.NoError(t, err)
+}
+
 func TestBrowserContextCloseShouldAbortWaitForEvent(t *testing.T) {
 	BeforeEach(t)
 

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -447,23 +447,6 @@ func TestDialogEventShouldWorkInImmdiatelyClosedPopup(t *testing.T) {
 	require.Equal(t, popup, msg.Page())
 }
 
-// TestBrowserContextExpectCloseEventResolves verifies that awaiting the "close"
-// event resolves rather than rejecting with TargetClosed (the reject-on-close
-// guard must not apply to the very event being awaited).
-func TestBrowserContextExpectCloseEventResolves(t *testing.T) {
-	BeforeEach(t)
-
-	browser1, err := browserType.Launch()
-	require.NoError(t, err)
-	defer browser1.Close() //nolint:errcheck
-	context1, err := browser1.NewContext()
-	require.NoError(t, err)
-	_, err = context1.ExpectEvent("close", func() error {
-		return context1.Close()
-	})
-	require.NoError(t, err)
-}
-
 func TestBrowserContextCloseShouldAbortWaitForEvent(t *testing.T) {
 	BeforeEach(t)
 

--- a/tests/browser_type_test.go
+++ b/tests/browser_type_test.go
@@ -67,6 +67,30 @@ func TestBrowserTypeLaunchPersistentContext(t *testing.T) {
 	require.NoError(t, browser_context3.Close())
 }
 
+// TestLaunchPersistentContextAppliesSelectorEngines verifies that a custom
+// selector engine registered before LaunchPersistentContext is applied to the
+// persistent context (previously addContext was skipped for persistent contexts).
+func TestLaunchPersistentContextAppliesSelectorEngines(t *testing.T) {
+	BeforeEach(t)
+
+	tagSelector := `(() => ({
+		query(root, selector) { return root.querySelector(selector); },
+		queryAll(root, selector) { return Array.from(root.querySelectorAll(selector)); }
+	}))()`
+	engineName := fmt.Sprintf("ptag_%s_%d", browserName, time.Now().UnixNano())
+	require.NoError(t, pw.Selectors.Register(engineName, playwright.Script{Content: &tagSelector}))
+
+	ctx, err := browserType.LaunchPersistentContext(t.TempDir())
+	require.NoError(t, err)
+	defer ctx.Close() //nolint:errcheck
+	p, err := ctx.NewPage()
+	require.NoError(t, err)
+	require.NoError(t, p.SetContent(`<div><span></span></div>`))
+	name, err := p.EvalOnSelector(engineName+"=DIV", "e => e.nodeName", nil)
+	require.NoError(t, err)
+	require.Equal(t, "DIV", name)
+}
+
 func TestBrowserTypeConnect(t *testing.T) {
 	BeforeEach(t)
 

--- a/tests/browser_type_test.go
+++ b/tests/browser_type_test.go
@@ -86,7 +86,7 @@ func TestLaunchPersistentContextAppliesSelectorEngines(t *testing.T) {
 	p, err := ctx.NewPage()
 	require.NoError(t, err)
 	require.NoError(t, p.SetContent(`<div><span></span></div>`))
-	name, err := p.EvalOnSelector(engineName+"=DIV", "e => e.nodeName", nil)
+	name, err := p.Locator(engineName+"=DIV").Evaluate("e => e.nodeName", nil)
 	require.NoError(t, err)
 	require.Equal(t, "DIV", name)
 }

--- a/tests/browser_type_test.go
+++ b/tests/browser_type_test.go
@@ -260,11 +260,28 @@ func TestBrowserTypeConnectOverCDP(t *testing.T) {
 	})
 	require.NoError(t, err)
 	defer browserServer.Close() //nolint:errcheck
+	// Register a custom selector engine before connecting; it must reach the
+	// CDP default context (it was previously never registered there).
+	tagSelector := `(() => ({
+		query(root, selector) { return root.querySelector(selector); },
+		queryAll(root, selector) { return Array.from(root.querySelectorAll(selector)); }
+	}))()`
+	engineName := fmt.Sprintf("cdptag_%d", time.Now().UnixNano())
+	require.NoError(t, pw.Selectors.Register(engineName, playwright.Script{Content: &tagSelector}))
+
 	browser, err := browserType.ConnectOverCDP(fmt.Sprintf("http://localhost:%d", port))
 	require.NoError(t, err)
 	require.NotNil(t, browser)
 	defer browser.Close() //nolint:errcheck
 	require.Len(t, browser.Contexts(), 1)
+
+	ctx := browser.Contexts()[0]
+	p, err := ctx.NewPage()
+	require.NoError(t, err)
+	require.NoError(t, p.SetContent(`<div><span></span></div>`))
+	name, err := p.Locator(engineName+"=DIV").Evaluate("e => e.nodeName", nil)
+	require.NoError(t, err)
+	require.Equal(t, "DIV", name)
 }
 
 func TestBrowserTypeConnectOverCDPTwice(t *testing.T) {

--- a/tests/console_message_test.go
+++ b/tests/console_message_test.go
@@ -166,4 +166,8 @@ func TestConsoleShouldHaveLocationForConsoleAPICalls(t *testing.T) {
 	require.Equal(t, message.Type(), "log")
 	require.Equal(t, server.PREFIX+"/consolelog.html", message.Location().URL)
 	require.Equal(t, 7, message.Location().LineNumber)
+	// The non-deprecated Line/Column aliases must be populated too (upstream
+	// maps lineNumber/columnNumber onto line/column).
+	require.Equal(t, message.Location().LineNumber, message.Location().Line)
+	require.Equal(t, message.Location().ColumnNumber, message.Location().Column)
 }

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -298,6 +298,14 @@ func TestElementHandleString(t *testing.T) {
 	stringHandle, err := page.EvaluateHandle("() => 'a'")
 	require.NoError(t, err)
 	require.Equal(t, "a", stringHandle.String())
+
+	// A real ElementHandle renders its server-provided preview (not an empty
+	// string) — newElementHandle must initialize preview like newJSHandle.
+	require.NoError(t, page.SetContent(`<button>Submit</button>`))
+	//nolint:staticcheck
+	elementHandle, err := page.QuerySelector("button")
+	require.NoError(t, err)
+	require.NotEmpty(t, elementHandle.String())
 }
 
 func TestElementHandleCheck(t *testing.T) {

--- a/tests/fetch_test.go
+++ b/tests/fetch_test.go
@@ -102,6 +102,21 @@ func TestShouldWorkAfterContextDisposed(t *testing.T) {
 	require.ErrorContains(t, err, "Test ended.")
 }
 
+// TestContextRequestRespectsContextDefaultTimeout verifies that
+// BrowserContext.SetDefaultTimeout applies to the context-owned
+// request context's fetches (they share the context timeout settings).
+func TestContextRequestRespectsContextDefaultTimeout(t *testing.T) {
+	BeforeEach(t)
+
+	server.SetRoute("/slow", func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+	})
+	context.SetDefaultTimeout(1)
+	_, err := context.Request().Get(server.PREFIX + "/slow")
+	require.ErrorIs(t, err, playwright.ErrTimeout)
+	require.ErrorContains(t, err, "Timeout 1ms exceeded")
+}
+
 func TestShouldSupportGlobalUserAgentOption(t *testing.T) {
 	BeforeEach(t)
 

--- a/tests/fetch_test.go
+++ b/tests/fetch_test.go
@@ -280,7 +280,7 @@ func TestStorageStateShouldRoundTripThroughFile(t *testing.T) {
 	})
 	require.NoError(t, err)
 	tempfile := filepath.Join(t.TempDir(), "storage-state.json")
-	actual, err := request.StorageState(playwright.APIRequestContextStorageStateOptions{Path: playwright.String(tempfile)})
+	actual, err := request.StorageState(tempfile)
 	require.NoError(t, err)
 	require.Equal(t, storageState, actual)
 	stateWritten, err := os.ReadFile(tempfile)

--- a/tests/fetch_test.go
+++ b/tests/fetch_test.go
@@ -578,6 +578,50 @@ func TestFetchShouldThrowWhenFailOnStatusCodeIsTrue(t *testing.T) {
 	require.NoError(t, req.Dispose())
 }
 
+// TestFetchRequestReusesMethodAndHeadersWithoutOptions verifies that
+// Fetch(request) with no options derives the method, headers and body from the
+// passed request, matching upstream (the request-fallback logic runs
+// unconditionally, not only when options are supplied).
+func TestFetchRequestReusesMethodAndHeadersWithoutOptions(t *testing.T) {
+	BeforeEach(t)
+
+	serverReqChan := make(chan *http.Request, 1)
+	bodyChan := make(chan string, 1)
+	server.SetRoute("/post-endpoint", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bodyChan <- string(body)
+		serverReqChan <- r
+		w.WriteHeader(200)
+	})
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+
+	// Capture a real page request (POST with a custom header and body).
+	pageReqInfo, err := page.ExpectRequest("**/post-endpoint", func() error {
+		_, err := page.Evaluate(`url => fetch(url, {
+			method: 'POST',
+			headers: { 'x-custom': 'val' },
+			body: 'hello',
+		})`, server.PREFIX+"/post-endpoint")
+		return err
+	})
+	require.NoError(t, err)
+	<-serverReqChan
+	<-bodyChan
+
+	// Replay it through APIRequestContext.Fetch WITHOUT options.
+	resp, err := pw.Request.NewContext()
+	require.NoError(t, err)
+	_, err = resp.Fetch(pageReqInfo)
+	require.NoError(t, err)
+
+	replayed := <-serverReqChan
+	replayedBody := <-bodyChan
+	require.Equal(t, "POST", replayed.Method)
+	require.Equal(t, "val", replayed.Header.Get("x-custom"))
+	require.Equal(t, "hello", replayedBody)
+}
+
 func TestFetchShouldNotThrowWhenFailOnStatusCodeIsFalse(t *testing.T) {
 	BeforeEach(t)
 

--- a/tests/fetch_test.go
+++ b/tests/fetch_test.go
@@ -280,7 +280,7 @@ func TestStorageStateShouldRoundTripThroughFile(t *testing.T) {
 	})
 	require.NoError(t, err)
 	tempfile := filepath.Join(t.TempDir(), "storage-state.json")
-	actual, err := request.StorageState(tempfile)
+	actual, err := request.StorageState(playwright.APIRequestContextStorageStateOptions{Path: playwright.String(tempfile)})
 	require.NoError(t, err)
 	require.Equal(t, storageState, actual)
 	stateWritten, err := os.ReadFile(tempfile)

--- a/tests/input_test.go
+++ b/tests/input_test.go
@@ -158,6 +158,31 @@ func TestKeyboardType(t *testing.T) {
 	require.True(t, result.(bool))
 }
 
+// TestKeyboardTypeIntoATextarea mirrors the upstream "should type into a
+// textarea @smoke" test (tests/page/page-keyboard.spec.ts). Unlike InsertText,
+// Keyboard.Type must dispatch real per-character key events, so we also assert
+// that a keydown is fired for every typed character.
+func TestKeyboardTypeIntoATextarea(t *testing.T) {
+	BeforeEach(t)
+
+	_, err := page.Evaluate(`() => {
+		const textarea = document.createElement('textarea');
+		document.body.appendChild(textarea);
+		textarea.focus();
+		window.keydowns = 0;
+		textarea.addEventListener('keydown', () => window.keydowns++);
+	}`)
+	require.NoError(t, err)
+	text := "Hello world. I am the text that was typed!"
+	require.NoError(t, page.Keyboard().Type(text))
+	value, err := page.Evaluate("() => document.querySelector('textarea').value")
+	require.NoError(t, err)
+	require.Equal(t, text, value)
+	keydowns, err := page.Evaluate("() => window.keydowns")
+	require.NoError(t, err)
+	require.EqualValues(t, len(text), keydowns)
+}
+
 func TestElementHandleType(t *testing.T) {
 	BeforeEach(t)
 

--- a/tests/locator_assertions_test.go
+++ b/tests/locator_assertions_test.go
@@ -294,6 +294,23 @@ func TestLocatorAssertionsToHaveCSS(t *testing.T) {
 	require.NoError(t, expect.Locator(button2).Not().ToHaveCSS("display", "flex"))
 }
 
+// TestLocatorAssertionsToHaveCSSPseudo verifies the Pseudo option reads styles
+// from a pseudo-element (::before) rather than the element itself.
+func TestLocatorAssertionsToHaveCSSPseudo(t *testing.T) {
+	BeforeEach(t)
+
+	require.NoError(t, page.SetContent(`
+	<style>#el::before { content: "x"; color: rgb(255, 0, 0); }</style>
+	<div id="el" style="color: rgb(0, 0, 255)">div</div>
+	`))
+	el := page.Locator("#el")
+	require.NoError(t, expect.Locator(el).ToHaveCSS("color", "rgb(255, 0, 0)", playwright.LocatorAssertionsToHaveCSSOptions{
+		Pseudo: playwright.PseudoElementBefore,
+	}))
+	// Without the pseudo option, the element's own color is read.
+	require.NoError(t, expect.Locator(el).ToHaveCSS("color", "rgb(0, 0, 255)"))
+}
+
 func TestLocatorAssertionsToHaveId(t *testing.T) {
 	BeforeEach(t)
 

--- a/tests/locator_assertions_test.go
+++ b/tests/locator_assertions_test.go
@@ -67,6 +67,14 @@ func TestLocatorAssertionsToBeEditable(t *testing.T) {
 
 	require.NoError(t, expect.Locator(page.Locator("textarea")).ToBeEditable())
 	require.Error(t, expect.Locator(page.Locator("textarea")).Not().ToBeEditable())
+
+	// Editable: false asserts the readonly state.
+	require.NoError(t, expect.Locator(page.Locator("#input2")).ToBeEditable(playwright.LocatorAssertionsToBeEditableOptions{
+		Editable: playwright.Bool(false),
+	}))
+	require.Error(t, expect.Locator(page.Locator("#input1")).ToBeEditable(playwright.LocatorAssertionsToBeEditableOptions{
+		Editable: playwright.Bool(false),
+	}))
 }
 
 func TestLocatorAssertionsToBeEmpty(t *testing.T) {
@@ -111,6 +119,14 @@ func TestLocatorAssertionsToBeEnabled(t *testing.T) {
 
 	require.NoError(t, expect.Locator(page.Locator("div")).ToBeEnabled())
 	require.Error(t, expect.Locator(page.Locator("div")).Not().ToBeEnabled())
+
+	// Enabled: false asserts the disabled state.
+	require.NoError(t, expect.Locator(page.Locator(`:text("button2")`)).ToBeEnabled(playwright.LocatorAssertionsToBeEnabledOptions{
+		Enabled: playwright.Bool(false),
+	}))
+	require.Error(t, expect.Locator(page.Locator(`:text("button1")`)).ToBeEnabled(playwright.LocatorAssertionsToBeEnabledOptions{
+		Enabled: playwright.Bool(false),
+	}))
 }
 
 func TestLocatorAssertionsToBeFocused(t *testing.T) {
@@ -179,6 +195,14 @@ func TestLocatorAssertionsToBeVisible(t *testing.T) {
 	require.NoError(t, err)
 	require.Error(t, expect.Locator(locator2).ToBeVisible())
 	require.NoError(t, expect.Locator(locator2).Not().ToBeVisible())
+
+	// Visible: false asserts the hidden state.
+	require.NoError(t, expect.Locator(locator2).ToBeVisible(playwright.LocatorAssertionsToBeVisibleOptions{
+		Visible: playwright.Bool(false),
+	}))
+	require.Error(t, expect.Locator(locator).ToBeVisible(playwright.LocatorAssertionsToBeVisibleOptions{
+		Visible: playwright.Bool(false),
+	}))
 }
 
 func TestLocatorAssertionsToContainText(t *testing.T) {

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -24,6 +24,30 @@ func TestLocatorClickTimeoutIncludesCallLog(t *testing.T) {
 	require.Contains(t, err.Error(), "waiting for")
 }
 
+// TestLocatorWithElementExplicitTimeoutCompletes guards the withElement budget
+// floor: when an explicit Timeout is passed, withElement waits for the selector
+// and then hands the inner action the *remaining* budget. If that remainder
+// clamped to 0, the protocol would interpret it as "disable timeout" (infinite)
+// and the action could hang; the floor of 1ms keeps these methods completing.
+func TestLocatorWithElementExplicitTimeoutCompletes(t *testing.T) {
+	BeforeEach(t)
+
+	require.NoError(t, page.SetContent(`<div id="target">select me</div>`))
+	target := page.Locator("#target")
+
+	require.NoError(t, target.ScrollIntoViewIfNeeded(playwright.LocatorScrollIntoViewIfNeededOptions{
+		Timeout: playwright.Float(5000),
+	}))
+	require.NoError(t, target.SelectText(playwright.LocatorSelectTextOptions{
+		Timeout: playwright.Float(5000),
+	}))
+	shot, err := target.Screenshot(playwright.LocatorScreenshotOptions{
+		Timeout: playwright.Float(5000),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, shot)
+}
+
 func TestLocatorAllInnerTexts(t *testing.T) {
 	BeforeEach(t)
 

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -657,6 +657,26 @@ func TestShouldSupportLocatorOr(t *testing.T) {
 	require.NoError(t, expect.Locator(page.Locator("span").Or(page.Locator("article"))).ToHaveText("world"))
 }
 
+// TestLocatorAndOrEnforceSameFrame verifies And/Or and Locator surface an error
+// when the argument belongs to a different frame, matching upstream which throws
+// "Locators must belong to the same frame."
+func TestLocatorAndOrEnforceSameFrame(t *testing.T) {
+	BeforeEach(t)
+
+	_, err := page.Goto(server.PREFIX + "/frames/two-frames.html")
+	require.NoError(t, err)
+	require.Greater(t, len(page.Frames()), 1)
+	frameLocator := page.Frames()[1].Locator("div")
+	mainLocator := page.Locator("div")
+
+	require.ErrorIs(t, mainLocator.And(frameLocator).Err(), playwright.ErrLocatorNotSameFrame)
+	require.ErrorIs(t, mainLocator.Or(frameLocator).Err(), playwright.ErrLocatorNotSameFrame)
+	require.ErrorIs(t, mainLocator.Locator(frameLocator).Err(), playwright.ErrLocatorNotSameFrame)
+
+	// The original locator must NOT be corrupted by a failed cross-frame call.
+	require.NoError(t, mainLocator.Err())
+}
+
 func TestLocatorAndFrameLocatorShouldAcceptLocator(t *testing.T) {
 	BeforeEach(t)
 

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -9,6 +9,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestLocatorClickTimeoutIncludesCallLog verifies the server-provided call log
+// is appended to command-error messages (e.g. action timeouts), matching the
+// upstream client which formats `log` onto the error.
+func TestLocatorClickTimeoutIncludesCallLog(t *testing.T) {
+	BeforeEach(t)
+
+	require.NoError(t, page.SetContent(`<div>no button here</div>`))
+	err := page.Locator("button#missing").Click(playwright.LocatorClickOptions{
+		Timeout: playwright.Float(500),
+	})
+	require.ErrorIs(t, err, playwright.ErrTimeout)
+	require.Contains(t, err.Error(), "Call log:")
+	require.Contains(t, err.Error(), "waiting for")
+}
+
 func TestLocatorAllInnerTexts(t *testing.T) {
 	BeforeEach(t)
 

--- a/tests/page_assertions_test.go
+++ b/tests/page_assertions_test.go
@@ -61,6 +61,9 @@ func TestPageAssertionsToHaveURLWithBaseURL(t *testing.T) {
 	require.NoError(t, expect.Page(page).ToHaveURL("/empty.html"))
 	require.NoError(t, expect.Page(page).ToHaveURL(regexp.MustCompile(`.*/empty\.html`)))
 	require.NoError(t, expect.Page(page).Not().ToHaveURL("https://playwright.dev"))
+	// An absolute URL must resolve to itself against the base URL (new URL
+	// semantics), not be mangled by naive path joining.
+	require.NoError(t, expect.Page(page).ToHaveURL(server.EMPTY_PAGE))
 	require.NoError(t, page.Close())
 }
 

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -232,6 +232,19 @@ func TestPageEvaluateIntegerArgTypes(t *testing.T) {
 	}
 }
 
+// TestPageEvaluateReturnsRegExp verifies that a RegExp returned from page
+// evaluation is parsed into a *regexp.Regexp instead of panicking the client.
+func TestPageEvaluateReturnsRegExp(t *testing.T) {
+	BeforeEach(t)
+
+	val, err := page.Evaluate(`() => /foo.*bar/i`)
+	require.NoError(t, err)
+	re, ok := val.(*regexp.Regexp)
+	require.True(t, ok, "expected *regexp.Regexp, got %T", val)
+	require.True(t, re.MatchString("xx FOO zz BAR yy"))
+	require.False(t, re.MatchString("baz"))
+}
+
 func TestPageEvalOnSelectorAll(t *testing.T) {
 	BeforeEach(t)
 

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -219,6 +219,19 @@ func TestPageEvaluate(t *testing.T) {
 	require.Equal(t, val, big.NewInt(17))
 }
 
+// TestPageEvaluateIntegerArgTypes verifies that sized integer types (not just
+// the bare int) round-trip as numbers rather than being serialized as
+// undefined.
+func TestPageEvaluateIntegerArgTypes(t *testing.T) {
+	BeforeEach(t)
+
+	for _, arg := range []any{int8(7), int16(7), int32(7), int64(7), uint(7), uint8(7), uint16(7), uint32(7), uint64(7)} {
+		val, err := page.Evaluate(`a => a + 1`, arg)
+		require.NoError(t, err)
+		require.EqualValues(t, 8, val)
+	}
+}
+
 func TestPageEvalOnSelectorAll(t *testing.T) {
 	BeforeEach(t)
 

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -493,6 +493,21 @@ func TestPageReload(t *testing.T) {
 	require.Nil(t, v)
 }
 
+// TestPageReloadRespectsDefaultNavigationTimeout verifies Reload honors the
+// configured default navigation timeout (it must resolve the timeout, not fall
+// back to the hardcoded 30s serializer default).
+func TestPageReloadRespectsDefaultNavigationTimeout(t *testing.T) {
+	BeforeEach(t)
+
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	page.SetDefaultNavigationTimeout(1)
+	server.SetRoute("/empty.html", func(w http.ResponseWriter, r *http.Request) {}) // stall
+	_, err = page.Reload()
+	require.ErrorIs(t, err, playwright.ErrTimeout)
+	require.ErrorContains(t, err, "Timeout 1ms exceeded.")
+}
+
 func TestPageGoBackGoForward(t *testing.T) {
 	BeforeEach(t)
 

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1272,11 +1272,33 @@ func TestCloseShouldRunBeforunloadIfAskedFor(t *testing.T) {
 	} else {
 		require.Contains(t, dialog.Message(), "This page is asking you to confirm that you want to leave")
 	}
+	// Accepting the beforeunload dialog closes the page, so waiting for the
+	// "close" event must resolve successfully (matching upstream beforeunload.spec.ts).
 	_, err = page.ExpectEvent("close", func() error {
-		require.NoError(t, dialog.Accept())
-		return nil
+		return dialog.Accept()
 	})
-	require.Error(t, err)
+	require.NoError(t, err)
+}
+
+// TestCloseShouldAccessPageAfterBeforeUnload mirrors upstream's "should access
+// page after beforeunload" test: with runBeforeUnload the page is not actually
+// closed after dismissing the dialog, so it remains usable.
+func TestCloseShouldAccessPageAfterBeforeUnload(t *testing.T) {
+	BeforeEach(t)
+
+	_, err := page.Goto(fmt.Sprintf("%s/beforeunload.html", server.PREFIX))
+	require.NoError(t, err)
+	dialogInfo, err := page.ExpectEvent("dialog", func() error {
+		require.NoError(t, page.Locator("body").Click())
+		return page.Close(playwright.PageCloseOptions{
+			RunBeforeUnload: playwright.Bool(true),
+		})
+	})
+	require.NoError(t, err)
+	dialog := dialogInfo.(playwright.Dialog)
+	require.NoError(t, dialog.Dismiss())
+	_, err = page.Evaluate("() => document.title")
+	require.NoError(t, err)
 }
 
 func TestPageGotoShouldFailWhenExceedingBrowserContextNavigationTimeout(t *testing.T) {

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -434,6 +434,12 @@ func TestPageOpener(t *testing.T) {
 	opener, err = page.Opener()
 	require.NoError(t, err)
 	require.Nil(t, opener)
+
+	// Once the opener page is closed, Opener() returns nil (matches upstream).
+	require.NoError(t, page.Close())
+	opener, err = popup.Opener()
+	require.NoError(t, err)
+	require.Nil(t, opener)
 }
 
 func TestPageTitle(t *testing.T) {
@@ -846,11 +852,11 @@ func TestPageFrame(t *testing.T) {
 	require.Equal(t, name, frame2.Name())
 	require.Equal(t, server.EMPTY_PAGE, frame2.URL())
 
+	// When a name is provided it takes precedence and the URL is never
+	// consulted, matching upstream (page.frame should respect name): a
+	// non-matching name returns nil regardless of the URL.
 	badName := "test"
-	frame3 := page.Frame(playwright.PageFrameOptions{Name: &badName, URL: server.EMPTY_PAGE})
-	require.Equal(t, name, frame3.Name())
-	require.Equal(t, server.EMPTY_PAGE, frame3.URL())
-
+	require.Nil(t, page.Frame(playwright.PageFrameOptions{Name: &badName, URL: server.EMPTY_PAGE}))
 	require.Nil(t, page.Frame(playwright.PageFrameOptions{Name: &badName, URL: "https://example.com"}))
 	require.Nil(t, page.Frame(playwright.PageFrameOptions{Name: &badName}))
 }

--- a/tests/route_test.go
+++ b/tests/route_test.go
@@ -308,6 +308,33 @@ func TestRequestPostDataJSONFormURLEncoded(t *testing.T) {
 	}, postData)
 }
 
+// TestRequestPostDataJSONFormURLEncodedDuplicateKey verifies that a repeated
+// form key keeps the LAST value, matching upstream's URLSearchParams.entries()
+// (last write wins) rather than url.Values.Get (first value).
+func TestRequestPostDataJSONFormURLEncodedDuplicateKey(t *testing.T) {
+	BeforeEach(t)
+
+	server.SetRoute("/post", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	requestChan := make(chan playwright.Request, 1)
+	page.OnRequest(func(r playwright.Request) {
+		requestChan <- r
+	})
+	_, err = page.Evaluate(`url => fetch(url, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: 'foo=bar&foo=baz',
+	})`, server.PREFIX+"/post")
+	require.NoError(t, err)
+	request := <-requestChan
+	var postData map[string]interface{}
+	require.NoError(t, request.PostDataJSON(&postData))
+	require.Equal(t, map[string]interface{}{"foo": "baz"}, postData)
+}
+
 func TestFulfillWithURLOverride(t *testing.T) {
 	BeforeEach(t)
 

--- a/tests/route_test.go
+++ b/tests/route_test.go
@@ -298,7 +298,7 @@ func TestRequestPostDataJSONFormURLEncoded(t *testing.T) {
 		requestChan <- r
 	})
 	require.NoError(t, page.SetContent(`<form method='POST' action='/post'><input type='text' name='foo' value='bar'><input type='number' name='baz' value='123'><input type='submit'></form>`))
-	require.NoError(t, page.Click("input[type=submit]"))
+	require.NoError(t, page.Locator("input[type=submit]").Click())
 	request := <-requestChan
 	var postData map[string]interface{}
 	require.NoError(t, request.PostDataJSON(&postData))

--- a/tests/route_test.go
+++ b/tests/route_test.go
@@ -172,6 +172,27 @@ func TestRouteFulfillPath(t *testing.T) {
 	require.Equal(t, "image/png", response.Headers()["content-type"])
 }
 
+// TestRouteFulfillPathContentTypeFromExtension verifies the content type is
+// derived from the file extension (matching upstream getMimeTypeForPath) rather
+// than from content sniffing, which would report text/plain for a .css file.
+func TestRouteFulfillPathContentTypeFromExtension(t *testing.T) {
+	BeforeEach(t)
+
+	intercepted := make(chan bool, 1)
+	err := page.Route("**/empty.html", func(route playwright.Route) {
+		require.NoError(t, route.Fulfill(playwright.RouteFulfillOptions{
+			Path: playwright.String(Asset("one-style.css")),
+		}))
+		intercepted <- true
+	})
+	require.NoError(t, err)
+	response, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	require.True(t, response.Ok())
+	<-intercepted
+	require.Equal(t, "text/css", response.Headers()["content-type"])
+}
+
 func TestRequestFinished(t *testing.T) {
 	BeforeEach(t)
 
@@ -259,6 +280,32 @@ func TestRequestPostData(t *testing.T) {
 		})
 	})`, server.PREFIX+"/foobar")
 	require.NoError(t, err)
+}
+
+// TestRequestPostDataJSONFormURLEncoded mirrors upstream's "should parse the
+// data if content-type is application/x-www-form-urlencoded" test
+// (tests/page/page-network-request.spec.ts).
+func TestRequestPostDataJSONFormURLEncoded(t *testing.T) {
+	BeforeEach(t)
+
+	server.SetRoute("/post", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	requestChan := make(chan playwright.Request, 1)
+	page.OnRequest(func(r playwright.Request) {
+		requestChan <- r
+	})
+	require.NoError(t, page.SetContent(`<form method='POST' action='/post'><input type='text' name='foo' value='bar'><input type='number' name='baz' value='123'><input type='submit'></form>`))
+	require.NoError(t, page.Click("input[type=submit]"))
+	request := <-requestChan
+	var postData map[string]interface{}
+	require.NoError(t, request.PostDataJSON(&postData))
+	require.Equal(t, map[string]interface{}{
+		"foo": "bar",
+		"baz": "123",
+	}, postData)
 }
 
 func TestFulfillWithURLOverride(t *testing.T) {

--- a/tests/screenshot_test.go
+++ b/tests/screenshot_test.go
@@ -1,6 +1,7 @@
 package playwright_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/playwright-community/playwright-go"
@@ -19,6 +20,50 @@ func TestLocatorScreenshotShouldWork(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, screenshot)
 	AssertToBeGolden(t, screenshot, "screenshot-element-bounding-box.png")
+}
+
+// TestScreenshotPathOptionShouldDetectJpeg mirrors upstream's "path option
+// should detect jpeg" test (tests/page/page-screenshot.spec.ts): a .jpg path
+// without an explicit type must produce a JPEG (FF D8 FF magic bytes).
+func TestScreenshotPathOptionShouldDetectJpeg(t *testing.T) {
+	BeforeEach(t)
+
+	require.NoError(t, page.SetViewportSize(300, 300))
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	outputPath := filepath.Join(t.TempDir(), "screenshot.jpg")
+	screenshot, err := page.Screenshot(playwright.PageScreenshotOptions{
+		OmitBackground: playwright.Bool(true),
+		Path:           playwright.String(outputPath),
+	})
+	require.NoError(t, err)
+	require.Equal(t, []byte{0xFF, 0xD8, 0xFF}, screenshot[:3])
+}
+
+// TestScreenshotPathOptionShouldThrowForUnsupportedMimeType mirrors upstream's
+// "path option should throw for unsupported mime type" test.
+func TestScreenshotPathOptionShouldThrowForUnsupportedMimeType(t *testing.T) {
+	BeforeEach(t)
+
+	_, err := page.Screenshot(playwright.PageScreenshotOptions{
+		Path: playwright.String("file.txt"),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `unsupported mime type "text/plain"`)
+}
+
+// TestScreenshotShouldPreferTypeOverExtension mirrors upstream's "should prefer
+// type over extension" test: a .png path with an explicit jpeg type yields JPEG.
+func TestScreenshotShouldPreferTypeOverExtension(t *testing.T) {
+	BeforeEach(t)
+
+	outputPath := filepath.Join(t.TempDir(), "file.png")
+	screenshot, err := page.Screenshot(playwright.PageScreenshotOptions{
+		Path: playwright.String(outputPath),
+		Type: playwright.ScreenshotTypeJpeg,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []byte{0xFF, 0xD8, 0xFF}, screenshot[:3])
 }
 
 func TestShouldScreenshotWithMask(t *testing.T) {

--- a/tests/selectors_get_by_test.go
+++ b/tests/selectors_get_by_test.go
@@ -157,6 +157,50 @@ func TestSelectorsGetByRoleEscaping(t *testing.T) {
 	}, []interface{}{})
 }
 
+func TestSelectorsGetByRoleWithDescription(t *testing.T) {
+	BeforeEach(t)
+
+	require.NoError(t, page.SetContent(`
+		<div role="alert" aria-label="Upload successful" aria-description="File doc-2025.pdf was uploaded successfully">Alert 1</div>
+		<div role="alert" aria-label="Upload successful" aria-description="File report-2026.pdf was uploaded successfully">Alert 2</div>
+		<div role="alert" aria-label="Invalid file" aria-description="File demo.doc has an invalid file format">Alert 3</div>
+	`))
+
+	// description substring match (default)
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByRole("alert", playwright.PageGetByRoleOptions{
+			Description: "doc-2025",
+		}).EvaluateAll(`els => els.map(e => e.textContent)`)
+	}, []interface{}{"Alert 1"})
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByRole("alert", playwright.PageGetByRoleOptions{
+			Description: "report-2026",
+		}).EvaluateAll(`els => els.map(e => e.textContent)`)
+	}, []interface{}{"Alert 2"})
+
+	// description combined with name
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByRole("alert", playwright.PageGetByRoleOptions{
+			Name:        "Upload successful",
+			Description: "doc-2025",
+		}).EvaluateAll(`els => els.map(e => e.textContent)`)
+	}, []interface{}{"Alert 1"})
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByRole("alert", playwright.PageGetByRoleOptions{
+			Name:        "Invalid file",
+			Description: "doc-2025",
+		}).EvaluateAll(`els => els.map(e => e.textContent)`)
+	}, []interface{}{})
+
+	// description exact match
+	utils.AssertResult(t, func() (interface{}, error) {
+		return page.GetByRole("alert", playwright.PageGetByRoleOptions{
+			Description: "doc-2025",
+			Exact:       playwright.Bool(true),
+		}).EvaluateAll(`els => els.map(e => e.textContent)`)
+	}, []interface{}{})
+}
+
 func TestSelectorsIncludeHiddenShouldWork(t *testing.T) {
 	BeforeEach(t)
 

--- a/tests/selectors_test.go
+++ b/tests/selectors_test.go
@@ -64,6 +64,10 @@ func TestSelectorsRegisterShouldWork(t *testing.T) {
 	_, err = page.Locator("tAG=DIV").All()
 	require.ErrorContains(t, err, `Unknown engine "tAG" while parsing selector tAG=DIV`)
 
+	// Registering the same engine name again errors upfront (matches upstream).
+	err = pw.Selectors.Register(selectorName, playwright.Script{Content: &tagSelector})
+	require.ErrorContains(t, err, "has been already registered")
+
 	require.NoError(t, context.Close())
 }
 

--- a/tracing.go
+++ b/tracing.go
@@ -221,6 +221,13 @@ func (t *tracingImpl) StopHar() error {
 	if len(t.harRecorders) == 0 {
 		return fmt.Errorf("HAR recording has not been started")
 	}
+	return t.exportAllHars()
+}
+
+// exportAllHars flushes every active HAR recording to disk. It is invoked by
+// StopHar and by APIRequestContext.Dispose so HARs started via the request
+// context are written even without an explicit StopHar call.
+func (t *tracingImpl) exportAllHars() error {
 	for harId, harMetaData := range t.harRecorders {
 		delete(t.harRecorders, harId)
 		overrides := map[string]any{}

--- a/tracing.go
+++ b/tracing.go
@@ -7,11 +7,13 @@ import (
 
 type tracingImpl struct {
 	channelOwner
-	includeSources bool
-	isTracing      bool
-	stacksId       string
-	tracesDir      string
-	harRecorders   map[string]harRecordingMetadata
+	includeSources    bool
+	isTracing         bool
+	isLive            bool
+	stacksId          string
+	tracesDir         string
+	harRecorders      map[string]harRecordingMetadata
+	additionalSources map[string]struct{}
 }
 
 func (t *tracingImpl) Start(options ...TracingStartOptions) error {
@@ -20,6 +22,7 @@ func (t *tracingImpl) Start(options ...TracingStartOptions) error {
 		if options[0].Sources != nil {
 			t.includeSources = *options[0].Sources
 		}
+		t.isLive = options[0].Live != nil && *options[0].Live
 		chunkOption.Name = options[0].Name
 		chunkOption.Title = options[0].Title
 	}
@@ -69,6 +72,13 @@ func (t *tracingImpl) doStopChunk(filePath string) (err error) {
 		t.isTracing = false
 		t.connection.setInTracing(false)
 	}
+
+	additionalSources := make([]string, 0, len(t.additionalSources))
+	for source := range t.additionalSources {
+		additionalSources = append(additionalSources, source)
+	}
+	t.additionalSources = make(map[string]struct{})
+
 	if filePath == "" {
 		// Not interested in artifacts.
 		_, err = t.channel.Send("tracingStopChunk", map[string]any{
@@ -93,11 +103,12 @@ func (t *tracingImpl) doStopChunk(filePath string) (err error) {
 			return fmt.Errorf("could not convert result to map: %v", result)
 		}
 		_, err = t.connection.LocalUtils().Zip(localUtilsZipOptions{
-			ZipFile:        filePath,
-			Entries:        entries.([]any),
-			StacksId:       t.stacksId,
-			Mode:           "write",
-			IncludeSources: t.includeSources,
+			ZipFile:           filePath,
+			Entries:           entries.([]any),
+			StacksId:          t.stacksId,
+			Mode:              "write",
+			IncludeSources:    t.includeSources,
+			AdditionalSources: additionalSources,
 		})
 		return err
 	}
@@ -128,11 +139,12 @@ func (t *tracingImpl) doStopChunk(filePath string) (err error) {
 		return err
 	}
 	_, err = t.connection.LocalUtils().Zip(localUtilsZipOptions{
-		ZipFile:        filePath,
-		Entries:        []any{},
-		StacksId:       t.stacksId,
-		Mode:           "append",
-		IncludeSources: t.includeSources,
+		ZipFile:           filePath,
+		Entries:           []any{},
+		StacksId:          t.stacksId,
+		Mode:              "append",
+		IncludeSources:    t.includeSources,
+		AdditionalSources: additionalSources,
 	})
 	return err
 }
@@ -142,7 +154,7 @@ func (t *tracingImpl) startCollectingStacks(name string) (err error) {
 		t.isTracing = true
 		t.connection.setInTracing(true)
 	}
-	t.stacksId, err = t.connection.LocalUtils().TracingStarted(name, t.tracesDir)
+	t.stacksId, err = t.connection.LocalUtils().TracingStarted(name, t.isLive, t.tracesDir)
 	return
 }
 
@@ -150,6 +162,9 @@ func (t *tracingImpl) Group(name string, options ...TracingGroupOptions) error {
 	var option TracingGroupOptions
 	if len(options) == 1 {
 		option = options[0]
+		if option.Location != nil && option.Location.File != "" {
+			t.additionalSources[option.Location.File] = struct{}{}
+		}
 	}
 	_, err := t.channel.Send("tracingGroup", option, map[string]any{"name": name})
 	return err
@@ -257,7 +272,8 @@ func (t *tracingImpl) StopHar() error {
 
 func newTracing(parent *channelOwner, objectType string, guid string, initializer map[string]any) *tracingImpl {
 	bt := &tracingImpl{
-		harRecorders: make(map[string]harRecordingMetadata),
+		harRecorders:      make(map[string]harRecordingMetadata),
+		additionalSources: make(map[string]struct{}),
 	}
 	bt.createChannelOwner(bt, parent, objectType, guid, initializer)
 	bt.markAsInternalType()

--- a/tracing.go
+++ b/tracing.go
@@ -179,10 +179,9 @@ func (t *tracingImpl) StartHar(path string, options ...TracingStartHarOptions) e
 	if len(t.harRecorders) > 0 {
 		return fmt.Errorf("HAR recording has already been started")
 	}
-	isZip := strings.HasSuffix(strings.ToLower(path), ".zip")
 	// Default content matches upstream: attach for .zip output, embed otherwise.
 	defaultContent := HarContentPolicyEmbed
-	if isZip {
+	if strings.HasSuffix(strings.ToLower(path), ".zip") {
 		defaultContent = HarContentPolicyAttach
 	}
 	harOptions := recordHarInputOptions{
@@ -191,9 +190,6 @@ func (t *tracingImpl) StartHar(path string, options ...TracingStartHarOptions) e
 		Mode:    HarModeFull,
 	}
 	if len(options) == 1 {
-		if options[0].ResourcesDir != nil && isZip {
-			return fmt.Errorf("resourcesDir option is not compatible with a .zip har file")
-		}
 		if options[0].Content != nil {
 			harOptions.Content = options[0].Content
 		}
@@ -201,7 +197,6 @@ func (t *tracingImpl) StartHar(path string, options ...TracingStartHarOptions) e
 			harOptions.Mode = options[0].Mode
 		}
 		harOptions.URL = options[0].URLFilter
-		harOptions.ResourcesDir = options[0].ResourcesDir
 	}
 	harId, err := t.channel.Send("harStart", map[string]any{
 		"options": prepareRecordHarOptions(harOptions),
@@ -210,9 +205,8 @@ func (t *tracingImpl) StartHar(path string, options ...TracingStartHarOptions) e
 		return err
 	}
 	t.harRecorders[harId.(string)] = harRecordingMetadata{
-		Path:         path,
-		Content:      harOptions.Content,
-		ResourcesDir: harOptions.ResourcesDir,
+		Path:    path,
+		Content: harOptions.Content,
 	}
 	return nil
 }
@@ -272,7 +266,7 @@ func (t *tracingImpl) exportAllHars() error {
 			if err := artifact.SaveAs(tmpPath); err != nil {
 				return err
 			}
-			if err := t.connection.localUtils.HarUnzip(tmpPath, harMetaData.Path, harMetaData.ResourcesDir); err != nil {
+			if err := t.connection.localUtils.HarUnzip(tmpPath, harMetaData.Path); err != nil {
 				return err
 			}
 		}

--- a/tracing.go
+++ b/tracing.go
@@ -179,9 +179,10 @@ func (t *tracingImpl) StartHar(path string, options ...TracingStartHarOptions) e
 	if len(t.harRecorders) > 0 {
 		return fmt.Errorf("HAR recording has already been started")
 	}
+	isZip := strings.HasSuffix(strings.ToLower(path), ".zip")
 	// Default content matches upstream: attach for .zip output, embed otherwise.
 	defaultContent := HarContentPolicyEmbed
-	if strings.HasSuffix(strings.ToLower(path), ".zip") {
+	if isZip {
 		defaultContent = HarContentPolicyAttach
 	}
 	harOptions := recordHarInputOptions{
@@ -190,6 +191,9 @@ func (t *tracingImpl) StartHar(path string, options ...TracingStartHarOptions) e
 		Mode:    HarModeFull,
 	}
 	if len(options) == 1 {
+		if options[0].ResourcesDir != nil && isZip {
+			return fmt.Errorf("resourcesDir option is not compatible with a .zip har file")
+		}
 		if options[0].Content != nil {
 			harOptions.Content = options[0].Content
 		}
@@ -197,6 +201,7 @@ func (t *tracingImpl) StartHar(path string, options ...TracingStartHarOptions) e
 			harOptions.Mode = options[0].Mode
 		}
 		harOptions.URL = options[0].URLFilter
+		harOptions.ResourcesDir = options[0].ResourcesDir
 	}
 	harId, err := t.channel.Send("harStart", map[string]any{
 		"options": prepareRecordHarOptions(harOptions),
@@ -205,8 +210,9 @@ func (t *tracingImpl) StartHar(path string, options ...TracingStartHarOptions) e
 		return err
 	}
 	t.harRecorders[harId.(string)] = harRecordingMetadata{
-		Path:    path,
-		Content: harOptions.Content,
+		Path:         path,
+		Content:      harOptions.Content,
+		ResourcesDir: harOptions.ResourcesDir,
 	}
 	return nil
 }
@@ -266,7 +272,7 @@ func (t *tracingImpl) exportAllHars() error {
 			if err := artifact.SaveAs(tmpPath); err != nil {
 				return err
 			}
-			if err := t.connection.localUtils.HarUnzip(tmpPath, harMetaData.Path); err != nil {
+			if err := t.connection.localUtils.HarUnzip(tmpPath, harMetaData.Path, harMetaData.ResourcesDir); err != nil {
 				return err
 			}
 		}

--- a/tracing.go
+++ b/tracing.go
@@ -179,9 +179,10 @@ func (t *tracingImpl) StartHar(path string, options ...TracingStartHarOptions) e
 	if len(t.harRecorders) > 0 {
 		return fmt.Errorf("HAR recording has already been started")
 	}
+	isZip := strings.HasSuffix(strings.ToLower(path), ".zip")
 	// Default content matches upstream: attach for .zip output, embed otherwise.
 	defaultContent := HarContentPolicyEmbed
-	if strings.HasSuffix(strings.ToLower(path), ".zip") {
+	if isZip {
 		defaultContent = HarContentPolicyAttach
 	}
 	harOptions := recordHarInputOptions{
@@ -190,6 +191,9 @@ func (t *tracingImpl) StartHar(path string, options ...TracingStartHarOptions) e
 		Mode:    HarModeFull,
 	}
 	if len(options) == 1 {
+		if options[0].ResourcesDir != nil && isZip {
+			return fmt.Errorf("resourcesDir option is not compatible with a .zip har file")
+		}
 		if options[0].Content != nil {
 			harOptions.Content = options[0].Content
 		}
@@ -197,6 +201,7 @@ func (t *tracingImpl) StartHar(path string, options ...TracingStartHarOptions) e
 			harOptions.Mode = options[0].Mode
 		}
 		harOptions.URL = options[0].URLFilter
+		harOptions.ResourcesDir = options[0].ResourcesDir
 	}
 	harId, err := t.channel.Send("harStart", map[string]any{
 		"options": prepareRecordHarOptions(harOptions),
@@ -205,8 +210,9 @@ func (t *tracingImpl) StartHar(path string, options ...TracingStartHarOptions) e
 		return err
 	}
 	t.harRecorders[harId.(string)] = harRecordingMetadata{
-		Path:    path,
-		Content: harOptions.Content,
+		Path:         path,
+		Content:      harOptions.Content,
+		ResourcesDir: harOptions.ResourcesDir,
 	}
 	return nil
 }
@@ -259,7 +265,7 @@ func (t *tracingImpl) StopHar() error {
 			if err := artifact.SaveAs(tmpPath); err != nil {
 				return err
 			}
-			if err := t.connection.localUtils.HarUnzip(tmpPath, harMetaData.Path); err != nil {
+			if err := t.connection.localUtils.HarUnzip(tmpPath, harMetaData.Path, harMetaData.ResourcesDir); err != nil {
 				return err
 			}
 		}

--- a/tracing.go
+++ b/tracing.go
@@ -67,6 +67,16 @@ func (t *tracingImpl) Stop(path ...string) error {
 	return err
 }
 
+// resetStackCounter clears the in-tracing flag and decrements the connection
+// tracing counter, mirroring upstream _resetStackCounter. Called on context
+// close so an un-stopped trace doesn't keep the connection collecting stacks.
+func (t *tracingImpl) resetStackCounter() {
+	if t.isTracing {
+		t.isTracing = false
+		t.connection.setInTracing(false)
+	}
+}
+
 func (t *tracingImpl) doStopChunk(filePath string) (err error) {
 	if t.isTracing {
 		t.isTracing = false

--- a/transport.go
+++ b/transport.go
@@ -60,6 +60,7 @@ type message struct {
 	Error  *struct {
 		Error Error `json:"error"`
 	} `json:"error,omitempty"`
+	Log []string `json:"log,omitempty"`
 }
 
 func (t *pipeTransport) Send(msg map[string]any) error {

--- a/websocket.go
+++ b/websocket.go
@@ -47,28 +47,30 @@ func newWebsocket(parent *channelOwner, objectType string, guid string, initiali
 }
 
 func (ws *webSocketImpl) onFrameSent(opcode float64, data string) {
-	if opcode == 2 {
+	switch opcode {
+	case 1:
+		ws.Emit("framesent", []byte(data))
+	case 2:
 		payload, err := base64.StdEncoding.DecodeString(data)
 		if err != nil {
 			logger.Error("could not decode WebSocket.onFrameSent payload", "error", err)
 			return
 		}
 		ws.Emit("framesent", payload)
-	} else {
-		ws.Emit("framesent", []byte(data))
 	}
 }
 
 func (ws *webSocketImpl) onFrameReceived(opcode float64, data string) {
-	if opcode == 2 {
+	switch opcode {
+	case 1:
+		ws.Emit("framereceived", []byte(data))
+	case 2:
 		payload, err := base64.StdEncoding.DecodeString(data)
 		if err != nil {
 			logger.Error("could not decode WebSocket.onFrameReceived payload", "error", err)
 			return
 		}
 		ws.Emit("framereceived", payload)
-	} else {
-		ws.Emit("framereceived", []byte(data))
 	}
 }
 

--- a/websocket_route.go
+++ b/websocket_route.go
@@ -131,13 +131,13 @@ func (r *webSocketRouteImpl) Protocols() ([]string, error) {
 	return result, nil
 }
 
-func (r *webSocketRouteImpl) afterHandle() error {
+func (r *webSocketRouteImpl) afterHandle() {
 	if r.connected.Load() {
-		return nil
+		return
 	}
 	// Ensure that websocket is "open" and can send messages without an actual server connection.
-	_, err := r.channel.Send("ensureOpened")
-	return err
+	// If this happens after the page has been closed, ignore the error (matches upstream).
+	_, _ = r.channel.Send("ensureOpened")
 }
 
 type serverWebSocketRouteImpl struct {
@@ -213,10 +213,7 @@ func newWebSocketRouteHandler(matcher *urlMatcher, handler func(WebSocketRoute))
 
 func (h *webSocketRouteHandler) Handle(route WebSocketRoute) {
 	h.handler(route)
-	err := route.(*webSocketRouteImpl).afterHandle()
-	if err != nil {
-		panic(fmt.Errorf("Could not handle WebSocketRoute: %w", err))
-	}
+	route.(*webSocketRouteImpl).afterHandle()
 }
 
 func (h *webSocketRouteHandler) Matches(wsURL string) bool {

--- a/worker.go
+++ b/worker.go
@@ -77,6 +77,9 @@ func (w *workerImpl) OnConsole(fn func(ConsoleMessage)) {
 func newWorker(parent *channelOwner, objectType string, guid string, initializer map[string]any) *workerImpl {
 	bt := &workerImpl{}
 	bt.createChannelOwner(bt, parent, objectType, guid, initializer)
+	bt.setEventSubscriptionMapping(map[string]string{
+		"console": "console",
+	})
 	bt.channel.On("close", bt.onClose)
 	bt.channel.On("console", func(ev map[string]any) {
 		bt.Emit("console", newConsoleMessage(ev))


### PR DESCRIPTION
## Align the Go client with the upstream Playwright TypeScript client

This PR systematically compares the Go client implementation against the upstream Playwright TypeScript client (both at **v1.60.0**) and fixes behavioral divergences found across several audit passes over the full `client/` surface. Each fix references the upstream commit/PR that introduced the behavior, and every fix is covered by a test (ported from upstream where one exists), several of which were verified to fail before the fix.

### Bug fixes

| Area | Problem | Fix |
|------|---------|-----|
| `Keyboard.Type` | Sent `keyboardInsertText` (a copy of `InsertText`), inserting text in one shot and ignoring `Delay` — no per-character key events | Send `keyboardType` |
| `CDPSession` | `close` event never wired, so `OnClose` handlers never fired | Emit `close` from the channel |
| `APIResponse.Ok()` | Treated status `0` as ok (upstream removed this in #10180) | `200–299` only (network `Response.Ok()` keeps `status==0` for `file://`) |
| `BrowserType.Launch`/`LaunchPersistentContext` | 30s launch timeout instead of upstream's 3 min (#35988) | Default to 180000ms |
| `BrowserType.Connect` | Sent stale `x-playwright-launch-options` header; panicked on a malformed endpoint | Drop the header; return upstream "malformed endpoint" error |
| `BrowserType.ConnectOverCDP` | No Chromium guard | Return "only supported in Chromium" |
| `LaunchPersistentContext` | Relative `userDataDir` not resolved | Resolve to absolute path |
| `Frame.ExpectNavigation` | Never returned the navigation error; returned the redirect (3xx) response instead of the final one | Return `event.error`; follow `redirectedTo` to the final request |
| `Page.onFrameDetached` | Appended the detached frame instead of the surviving frames | Append `p.frames[i]` |
| `Page`/`BrowserContext` subscriptions | `requestfailed` mapped to `responseFailed`, so the server-side `requestFailed` subscription was never enabled | Map `requestfailed → requestFailed` |
| `GetByRole` | `Description` option dropped; selector built from a Go map (non-deterministic ordering) | Honor `Description`; ordered selector |
| `GetByAltText/Label/Placeholder/Text/Title` | Nil-pointer panic on `Exact == nil` | Nil-safe deref |
| `Frame.WaitForFunction` | Polling interval sent under wrong key `polling` (protocol wants `pollingInterval`), so it was silently dropped | Map numeric polling to `pollingInterval`; validate `"raf"` |
| `Route.Fulfill` | Content-type sniffed from bytes (mislabeled e.g. `.css` as text/plain); string body missing `content-length`; user-supplied `Body`/`Path` overwritten by response body | Extension-based MIME; set content-length; only derive body when none given |
| `Request.PostDataJSON` | Ignored `application/x-www-form-urlencoded` | Parse form bodies into a key/value object |
| Screenshot | Image type not inferred from path extension (`.jpeg` wrote PNG) | Port `determineScreenshotType` |
| `Dialog.Dismiss` / `Disposable.Dispose` | Surfaced `TargetClosedError` that upstream swallows | Swallow it |
| HAR replay | Dropped duplicate `set-cookie`; didn't stall on `status==-1`; nil-message deref | Merge set-cookie; stall; guard |
| HAR export | Remote non-zip output not unzipped unless content policy was `attach`; matched entries by collapsed provisional headers | Always unzip non-zip; match by actual header array |
| `Screencast` | Discarded the recording artifact (recording to `Path` produced no file); dropped frame viewport size; leaked a listener per `Start` | Save artifact on `Stop`; pass viewport; register listener once |
| `Locator.And/Or/Locator`, `FrameLocator.Locator` | No same-frame validation; mutated the receiver's error on cross-frame input | Validate; return a fresh errored locator |
| `Locator.AriaSnapshot` | Missing deferred-error guard | Honor `err` |
| `Locator.Drop` | Any call with options errored (`assignStructFields` on a map) | Set option keys directly |
| `Page.RemoveLocatorHandler` | Removed only the first matching handler | Remove all matches |
| `ConsoleMessage.Location` | `Line`/`Column` always 0 (wire only carries `lineNumber`/`columnNumber`) | Populate the aliases |
| Tracing | `live` flag not sent to localUtils; `Group(location)` sources not bundled; `StartHar` lacked `resourcesDir` | Thread `live`, `additionalSources`, `resourcesDir` |
| `AddScriptTag`/`AddStyleTag`/`AddInitScript` | No `//# sourceURL` for path-loaded scripts | Append sourceURL |
| `BrowserContext.IsClosed` | False during a reason-less `Close()` until the server confirmed | True once `Close()` begins |
| `Page.Close` | Set `closeWasCalled` and swallowed errors even with `runBeforeUnload`; double-closed owned-context pages | Match upstream `runBeforeUnload` semantics; close context **or** channel |
| `Page.WaitForEvent("close"/"crash")` | Rejected instead of resolving for the awaited event | Don't reject on the awaited event |
| `serializeValue` | `int8/16/32/64` and unsigned ints serialized as `undefined` | Handle all integer kinds |
| Command errors | Server "Call log:" timeline dropped from error messages | Append the call log |
| `Frame` `loadStates` | Type assertion `.([]string)` always failed (JSON gives `[]any`), so `WaitForLoadState`/`WaitForURL` could block until timeout | Coerce `[]any` elements |
| `Artifact.PathAfterFinished` | Panicked on a server error (`nil.(string)`) | Return the error |
| `APIRequestContext.Fetch(request)` | With no options, dropped method/headers/body | Always derive from the request |
| `APIRequestContext.Dispose` | Didn't flush active HAR recordings | Flush via `exportAllHars` |
| `PageAssertions.ToHaveURL` | `path.Join` against base URL mangled absolute URLs / query strings | `url.ResolveReference` (matches `new URL`) |
| `WebSocketRoute` | Panicked on a benign `ensureOpened` page-close race; emitted control frames as text | Swallow the error; only emit text/binary opcodes |
| Connection | `noReply` callbacks stored forever (slow leak) | Don't store them |

### Public API additions

These options were missing from the Go bindings because they were language-gated to exclude Go in the upstream API docs. They are now enabled by adding `go` to the `langs:` gate in the downstream docs patch (`patches/main.patch`) and regenerating, so the generated types match `go generate` output and `Verify Types` passes:

| API | Change |
|-----|--------|
| `BrowserContext.StorageState` / `APIRequestContext.StorageState` | Take an options struct (`Path` + `IndexedDB`) instead of a variadic path, so IndexedDB can be captured (#34650) |
| `Tracing.StartHar` | Accepts `resourcesDir` (#40488) |
| `Page.ConsoleMessages` | Forwards the `filter` option (the generated struct already exposed it; it was silently dropped before sending) |

> `Page.pageErrors.filter` was investigated but left out: the doclint does not attach the option to the langs-gated `pageErrors` method for Go, so it can't be generated cleanly. `PageErrors()` still returns all errors (the documented default is `since-navigation`, a minor divergence).

### Testing

New/updated tests accompany the fixes (ported from upstream specs where applicable): keyboard per-character events, `GetByRole` description, screenshot type inference, form-urlencoded post data, route content-type, integer evaluate args, call log on errors, same-frame locator validation, console message location aliases, `Fetch(request)` reuse, `runBeforeUnload` close behavior, IndexedDB storage state, and `ToHaveURL` base-URL resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
