### PR TITLE
ci: only cancel in-progress runs for pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     branches: [ main, roll/* ]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/verify_type_generation.yml
+++ b/.github/workflows/verify_type_generation.yml
@@ -6,7 +6,7 @@ on:
     branches: [ main ]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Disable concurrency cancellation on the `main` branch while keeping it for pull requests.

Previously `build.yml` and `verify_type_generation.yml` had `cancel-in-progress: true`, which cancelled in-progress runs on `main` whenever a new push landed. Now cancellation is gated on the event type:

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- **Pull requests:** newer pushes still cancel stale runs (saves CI minutes).
- **`main` / `roll/*` pushes:** runs always complete, so post-merge CI status isn't lost to cancellation.

`docs.yml` needed no change — it only triggers on push to `main` and already has `cancel-in-progress: false`.