### PR TITLE
test: add reusable withRetry helper for flaky WebKit folder upload

### DIFF
--- a/tests/browser_type_test.go
+++ b/tests/browser_type_test.go
@@ -385,10 +385,13 @@ func TestShouldUploadAFolderRemote(t *testing.T) {
 	page, err := browser_context.NewPage()
 	require.NoError(t, err)
 	// WebKit folder upload over a remote connection (file streaming + browser
-	// ingestion) can exceed the default 30s action timeout on loaded CI runners.
-	// flakiness-go does not retry (unlike upstream's CI retries: 3), so raise the
-	// default action timeout to give the slow WebKit step room.
-	page.SetDefaultTimeout(90 * 1000)
+	// ingestion) is genuinely slow on loaded CI runners: the flakiness dashboard
+	// shows this test bumping into ~90s on webkit/ubuntu. Upstream marks the
+	// equivalent test test.slow() (a 90s test budget) AND retries it up to 3
+	// times on CI; flakiness-go does not retry, so a single 90s action timeout
+	// fails outright when one slow run exceeds it. Use a generous single timeout
+	// (3 min, well under the 15m suite budget) as the no-retry equivalent.
+	page.SetDefaultTimeout(180 * 1000)
 
 	_, err = page.Goto(fmt.Sprintf("%s%s", server.PREFIX, "/input/folderupload.html"))
 	require.NoError(t, err)

--- a/tests/browser_type_test.go
+++ b/tests/browser_type_test.go
@@ -369,73 +369,73 @@ func TestSetInputFilesShouldPreserveLastModifiedTimestamp(t *testing.T) {
 }
 
 func TestShouldUploadAFolderRemote(t *testing.T) {
-	BeforeEach(t)
-
-	remoteServer, err := newRemoteServer()
-	require.NoError(t, err)
-	defer remoteServer.Close()
-
-	browser1, err := browserType.Connect(remoteServer.url)
-	require.NoError(t, err)
-	require.NotNil(t, browser1)
-	defer browser1.Close() //nolint:errcheck
-
-	browser_context, err := browser1.NewContext()
-	require.NoError(t, err)
-	page, err := browser_context.NewPage()
-	require.NoError(t, err)
 	// WebKit folder upload over a remote connection (file streaming + browser
-	// ingestion) is genuinely slow on loaded CI runners: the flakiness dashboard
-	// shows this test bumping into ~90s on webkit/ubuntu. Upstream marks the
-	// equivalent test test.slow() (a 90s test budget) AND retries it up to 3
-	// times on CI; flakiness-go does not retry, so a single 90s action timeout
-	// fails outright when one slow run exceeds it. Use a generous single timeout
-	// (3 min, well under the 15m suite budget) as the no-retry equivalent.
-	page.SetDefaultTimeout(180 * 1000)
+	// ingestion) is genuinely slow on loaded CI runners and is flaky upstream
+	// too: microsoft/playwright marks the equivalent test test.slow() (a 90s
+	// budget) and still has to lean on its CI retries: 3 to stay green (we have
+	// observed it reported as "1 flaky" on their webkit job). Our CI does not
+	// retry, so mirror upstream by retrying the whole test a few times; each
+	// attempt also gets a generous 180s action timeout for headroom.
+	withRetry(t, 3, func(t testing.TB) {
+		remoteServer, err := newRemoteServer()
+		require.NoError(t, err)
+		defer remoteServer.Close()
 
-	_, err = page.Goto(fmt.Sprintf("%s%s", server.PREFIX, "/input/folderupload.html"))
-	require.NoError(t, err)
+		browser1, err := browserType.Connect(remoteServer.url)
+		require.NoError(t, err)
+		require.NotNil(t, browser1)
+		defer browser1.Close() //nolint:errcheck
 
-	//nolint:staticcheck
-	input, err := page.QuerySelector("input")
-	require.NoError(t, err)
+		browser_context, err := browser1.NewContext()
+		require.NoError(t, err)
+		page, err := browser_context.NewPage()
+		require.NoError(t, err)
+		page.SetDefaultTimeout(180 * 1000)
 
-	dir := filepath.Join(t.TempDir(), "file-upload-test")
-	require.NoError(t, os.MkdirAll(dir, 0o700))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "file1.txt"), []byte("file1 content"), 0o600))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "file2"), []byte("file2 content"), 0o600))
-	require.Nil(t, os.Mkdir(filepath.Join(dir, "sub-dir"), 0o700))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "sub-dir", "really.txt"), []byte("sub-dir file content"), 0o600))
-	//nolint:staticcheck
-	require.NoError(t, input.SetInputFiles(dir))
+		_, err = page.Goto(fmt.Sprintf("%s%s", server.PREFIX, "/input/folderupload.html"))
+		require.NoError(t, err)
 
-	ret, err := input.Evaluate(`e => [...e.files].map(f => f.webkitRelativePath)`)
-	require.NoError(t, err)
+		//nolint:staticcheck
+		input, err := page.QuerySelector("input")
+		require.NoError(t, err)
 
-	expectResult := []interface{}{"file-upload-test/file1.txt", "file-upload-test/file2"}
-	// https://issues.chromium.org/issues/345393164
-	if !isChromium || !headless || !chromiumVersionLessThan(browser.Version(), "127.0.6533.0") {
-		expectResult = append(expectResult, "file-upload-test/sub-dir/really.txt")
-	}
-	slices.SortFunc(ret.([]interface{}), func(i, j interface{}) int {
-		return strings.Compare(i.(string), j.(string))
-	})
-	require.Equal(t, expectResult, ret.([]interface{}))
+		dir := filepath.Join(t.TempDir(), "file-upload-test")
+		require.NoError(t, os.MkdirAll(dir, 0o700))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "file1.txt"), []byte("file1 content"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "file2"), []byte("file2 content"), 0o600))
+		require.Nil(t, os.Mkdir(filepath.Join(dir, "sub-dir"), 0o700))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "sub-dir", "really.txt"), []byte("sub-dir file content"), 0o600))
+		//nolint:staticcheck
+		require.NoError(t, input.SetInputFiles(dir))
 
-	webkitRelativePaths, err := input.Evaluate(`e => [...e.files].map(f => f.webkitRelativePath)`)
-	require.NoError(t, err)
-	for i, path := range webkitRelativePaths.([]interface{}) {
-		content, err := input.Evaluate(`(e, i) => {
+		ret, err := input.Evaluate(`e => [...e.files].map(f => f.webkitRelativePath)`)
+		require.NoError(t, err)
+
+		expectResult := []interface{}{"file-upload-test/file1.txt", "file-upload-test/file2"}
+		// https://issues.chromium.org/issues/345393164
+		if !isChromium || !headless || !chromiumVersionLessThan(browser.Version(), "127.0.6533.0") {
+			expectResult = append(expectResult, "file-upload-test/sub-dir/really.txt")
+		}
+		slices.SortFunc(ret.([]interface{}), func(i, j interface{}) int {
+			return strings.Compare(i.(string), j.(string))
+		})
+		require.Equal(t, expectResult, ret.([]interface{}))
+
+		webkitRelativePaths, err := input.Evaluate(`e => [...e.files].map(f => f.webkitRelativePath)`)
+		require.NoError(t, err)
+		for i, path := range webkitRelativePaths.([]interface{}) {
+			content, err := input.Evaluate(`(e, i) => {
 			const reader = new FileReader();
 			const promise = new Promise(fulfill => reader.onload = fulfill);
 			reader.readAsText(e.files[i]);
 			return promise.then(() => reader.result);
     }`, i)
-		require.NoError(t, err)
-		b, err := os.ReadFile(filepath.Join(dir, "..", path.(string)))
-		require.NoError(t, err)
-		require.Equal(t, string(b), content.(string))
-	}
+			require.NoError(t, err)
+			b, err := os.ReadFile(filepath.Join(dir, "..", path.(string)))
+			require.NoError(t, err)
+			require.Equal(t, string(b), content.(string))
+		}
+	})
 }
 
 func TestBrowserBind(t *testing.T) {

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -54,6 +54,56 @@ func skipWebKitMacOSPopup(t *testing.T) {
 	}
 }
 
+// attemptT wraps *testing.T but captures assertion failures locally instead of
+// propagating them to the real test. It satisfies testify's require.TestingT
+// and the parts of testing.TB our tests use, so an existing test body can run
+// against it unchanged.
+type attemptT struct {
+	*testing.T
+	failed bool
+}
+
+func (a *attemptT) Errorf(format string, args ...interface{}) {
+	a.failed = true
+	a.Logf("[retry] "+format, args...)
+}
+
+func (a *attemptT) FailNow() {
+	a.failed = true
+	runtime.Goexit()
+}
+
+// withRetry runs body up to attempts times and passes as soon as one attempt
+// succeeds, failing the test only if every attempt fails. Each attempt runs in
+// its own goroutine so a require.* failure (which calls runtime.Goexit) ends
+// only that attempt, and gets a fresh browser context/page via BeforeEach so a
+// botched attempt never leaks state into the next one.
+//
+// Use this only for tests that are genuinely correct but occasionally too slow
+// on loaded CI runners (where upstream relies on its CI retries: 3) — not to
+// paper over real bugs. The body receives a testing.TB; pass it to require.*
+// and use it wherever the test would otherwise use t.
+func withRetry(t *testing.T, attempts int, body func(t testing.TB)) {
+	t.Helper()
+	for i := 0; i < attempts; i++ {
+		a := &attemptT{T: t}
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			BeforeEach(a.T)
+			body(a)
+		}()
+		<-done
+		if !a.failed {
+			return
+		}
+		if i < attempts-1 {
+			t.Logf("attempt %d/%d failed, retrying", i+1, attempts)
+		}
+	}
+	t.Fatalf("still failing after %d attempts", attempts)
+}
+
 // BeforeAll prepares the environment, including
 //   - start Playwright driver
 //   - launch browser depends on BROWSER env


### PR DESCRIPTION
## Problem

`TestShouldUploadAFolderRemote` (WebKit) failed in CI with `Timeout 90000ms exceeded` at `input.SetInputFiles(dir)` ([failing run](https://github.com/playwright-community/playwright-go/actions/runs/28211314178/job/83573051685#step:6:400)).

This is **not** a playwright-go bug:

- It reproduces locally in ~2s — the failure only happens on loaded CI runners.
- The flakiness.io dashboard shows this test running at **~1 min 31 sec** on `webkit / ubuntu 24.04`, hugging the previously-set 90s wall.
- It is **flaky upstream too**: `microsoft/playwright` marks the equivalent `should upload a folder` test [`test.slow()`](https://github.com/microsoft/playwright/blob/main/tests/library/browsertype-connect.spec.ts) (a 90s budget) and still relies on its CI `retries: 3` to stay green. In their webkit job `83561144096` this exact test was reported as `1 flaky` with the same `Test timeout of 90000ms exceeded`.

The root asymmetry: upstream survives the slow WebKit folder-upload via **retries**, but Go's `testing` package has **no built-in retry**, so a single slow attempt fails our whole job.

## Fix

Add a small, **reusable** retry helper and use it here:

```go
func withRetry(t *testing.T, attempts int, body func(t testing.TB))
```

- Re-runs `body` until one attempt passes; fails only if every attempt fails.
- Each attempt runs in its own goroutine (so a `require.*` `runtime.Goexit` ends only that attempt; deferred cleanups still run) and gets a fresh context/page via `BeforeEach`.
- Assertion failures are **captured**, not propagated to the parent test, via an `attemptT` wrapper.
- Body takes `testing.TB`, so existing test bodies work unchanged and other flaky tests can adopt it.

`TestShouldUploadAFolderRemote` is wrapped in `withRetry(t, 3, ...)` (mirroring upstream's `retries: 3`) and keeps a generous 180s per-action timeout for headroom.

## Verification

- `go vet` clean; `golangci-lint run ./tests/` → 0 issues.
- Retry-recovers path (fail, fail, pass) → parent test PASS.
- All-attempts-fail path → parent test FAIL with `still failing after N attempts`.
- `BROWSER=webkit go test -run TestShouldUploadAFolderRemote` → PASS.
