### PR TITLE
feat: allow PLAYWRIGHT_CLI_PATH to point directly at cli.js

### DIFF
--- a/run.go
+++ b/run.go
@@ -355,6 +355,10 @@ type RunOptions struct {
 	//  - PLAYWRIGHT_NODEJS_PATH: use a preinstalled Node.js and skip downloading
 	//    one. Required on platforms without a prebuilt Node.js binary (e.g.
 	//    linux/arm).
+	//  - PLAYWRIGHT_CLI_PATH: use a preinstalled cli.js directly, bypassing the
+	//    assumed <DriverDirectory>/package/cli.js layout. Useful for
+	//    distro-packaged drivers (e.g. the official NixOS playwright-driver,
+	//    which keeps cli.js at the package root).
 	//  - PLAYWRIGHT_GO_NPM_REGISTRY: npm registry mirror for playwright-core
 	//    (default https://registry.npmjs.org).
 	//  - NODE_MIRROR: Node.js distribution mirror (default https://nodejs.org/dist).
@@ -468,6 +472,13 @@ func getNodeExecutable(driverDirectory string) string {
 }
 
 func getDriverCliJs(driverDirectory string) string {
+	// Allow pointing directly at cli.js, e.g. for distro-packaged drivers whose
+	// layout differs from the assembled bundle (the official NixOS
+	// playwright-driver keeps cli.js at the package root, not under package/).
+	// This mirrors PLAYWRIGHT_NODEJS_PATH for the Node.js binary.
+	if envPath := os.Getenv("PLAYWRIGHT_CLI_PATH"); envPath != "" {
+		return envPath
+	}
 	return filepath.Join(driverDirectory, "package", "cli.js")
 }
 

--- a/run_test.go
+++ b/run_test.go
@@ -209,6 +209,18 @@ func TestGetNodeExecutable(t *testing.T) {
 	assert.Contains(t, executable, "testDirectory")
 }
 
+func TestGetDriverCliJs(t *testing.T) {
+	// When PLAYWRIGHT_CLI_PATH is set, use that path directly.
+	t.Setenv("PLAYWRIGHT_CLI_PATH", "/custom/cli.js")
+	assert.Equal(t, "/custom/cli.js", getDriverCliJs("testDirectory"))
+
+	// Otherwise fall back to the assumed <DriverDirectory>/package/cli.js layout.
+	require.NoError(t, os.Unsetenv("PLAYWRIGHT_CLI_PATH"))
+	cliJs := getDriverCliJs("testDirectory")
+	assert.Contains(t, cliJs, "testDirectory")
+	assert.Contains(t, cliJs, "cli.js")
+}
+
 func killProcessByPid(pid int) error {
 	process, err := os.FindProcess(pid)
 	if err != nil {


### PR DESCRIPTION
## Problem

Closes #575.

On NixOS, the official `playwright-driver` package keeps `cli.js` at the **package root**, whereas playwright-go's `getDriverCliJs` hardcodes `<DriverDirectory>/package/cli.js`. As a result, even when users point `PLAYWRIGHT_DRIVER_PATH` at the Nix store path, resolution fails — forcing symlink workarounds in their flakes (see the issue thread).

## Fix

Add a `PLAYWRIGHT_CLI_PATH` env var that points directly at `cli.js`, bypassing the assumed `package/` layout. This deliberately mirrors the existing `PLAYWRIGHT_NODEJS_PATH` escape hatch (which already lets users point directly at the Node.js binary), so both halves of the driver are now symmetric.

With this, the reporter's flake reduces to:

```nix
export PLAYWRIGHT_CLI_PATH="${pkgs.playwright-driver}/cli.js"
export PLAYWRIGHT_NODEJS_PATH="${pkgs.nodejs}/bin/node"
```

## Changes

- `getDriverCliJs` honors `PLAYWRIGHT_CLI_PATH` before falling back to the default layout.
- Documented the new var in the `RunOptions.DriverDirectory` doc comment.
- Added `TestGetDriverCliJs`, mirroring `TestGetNodeExecutable`.

`go build ./...` and the targeted tests pass.