### PR TITLE
chore: migrate from playwright-community org to mxschmitt

### DIFF
--- a/.claude/skills/roll-playwright/SKILL.md
+++ b/.claude/skills/roll-playwright/SKILL.md
@@ -186,7 +186,7 @@ git diff --submodule=log -- playwright   # confirm the pointer moves OLD -> NEW
 git checkout -b roll/v<NEW_VERSION>
 git add -A && git commit -m "chore: roll to Playwright v<NEW_VERSION>"
 git push -u origin roll/v<NEW_VERSION>
-gh pr create --repo playwright-community/playwright-go --base main \
+gh pr create --repo mxschmitt/playwright-go --base main \
   --title "chore: roll to Playwright v<NEW_VERSION>" --body "<summary of new APIs + behavior changes>"
 ```
 
@@ -199,15 +199,15 @@ The roll is **not done when the PR opens — it's done when CI is green.** A rol
 1. **Wait for the run to finish** (don't poll in a tight loop — block on it):
    ```bash
    # Find the run for the branch's head commit, then watch it to completion:
-   RUN=$(gh run list --repo playwright-community/playwright-go --branch roll/v<NEW_VERSION> \
+   RUN=$(gh run list --repo mxschmitt/playwright-go --branch roll/v<NEW_VERSION> \
      --limit 1 --json databaseId --jq '.[0].databaseId')
-   gh run watch "$RUN" --repo playwright-community/playwright-go --exit-status
+   gh run watch "$RUN" --repo mxschmitt/playwright-go --exit-status
    # (exits non-zero if the run failed; `gh pr checks <num> --watch` is an alternative.)
    ```
 2. **List results and read every failure's log** (the failed step, not the whole log):
    ```bash
-   gh pr checks <num> --repo playwright-community/playwright-go
-   gh run view --repo playwright-community/playwright-go --job <jobId> --log-failed \
+   gh pr checks <num> --repo mxschmitt/playwright-go
+   gh run view --repo mxschmitt/playwright-go --job <jobId> --log-failed \
      | grep -iE 'FAIL|Error:|\.go:[0-9]+|panic'
    ```
 3. **Triage each failure** the same way as Step 6 / "behavior changes": is it my code, an engine/OS-specific string (match any known variant), a lint issue, or an intended upstream change? Note the OS+browser — a failure on only webkit-windows is still a failure.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -11,7 +11,7 @@ assignees: ''
 Before posting a bug report, please make sure it is a software defect related to "playwright-go"(or playwright).
 
 The issue tracker is not a help forum. Consider asking for help on for example:
-- [Github Discussions](/playwright-community/playwright-go/discussions)
+- [Github Discussions](/mxschmitt/playwright-go/discussions)
 - upstream [Playwright Discord channel](https://aka.ms/playwright/discord)
 -->
 **Environments**
@@ -30,7 +30,7 @@ Please provide a mini reproduction rather than just a description. For example:
 ```go
 package main
 
-import "github.com/playwright-community/playwright-go"
+import "github.com/mxschmitt/playwright-go"
 
 func main() {
 	// ignore unnecessary error handling code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,14 +69,14 @@ jobs:
         FLAKINESS_PROJECT: playwright-community/playwright-go
         FLAKINESS_NAME: ${{ matrix.browser }}
       if: matrix.os == 'ubuntu-latest'
-      run: xvfb-run flakiness-go -timeout 15m -v -coverprofile=covprofile -coverpkg="github.com/playwright-community/playwright-go" --race ./...
+      run: xvfb-run flakiness-go -timeout 15m -v -coverprofile=covprofile -coverpkg="github.com/mxschmitt/playwright-go" --race ./...
     - name: Test
       env:
         BROWSER: ${{ matrix.browser }}
         FLAKINESS_PROJECT: playwright-community/playwright-go
         FLAKINESS_NAME: ${{ matrix.browser }}
       if: matrix.os != 'ubuntu-latest'
-      run: flakiness-go -timeout 15m -v -coverprofile=covprofile -coverpkg="github.com/playwright-community/playwright-go" --race ./...
+      run: flakiness-go -timeout 15m -v -coverprofile=covprofile -coverpkg="github.com/mxschmitt/playwright-go" --race ./...
     - name: Send coverage
       uses: shogo82148/actions-goveralls@v1
       if: matrix.go == 'stable'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ The Go code is linted with [golangci-lint](https://golangci-lint.run/) and forma
 
 ### Test coverage
 
-For every Pull Request on GitHub and on the main branch the coverage data will get sent over to [Coveralls](https://coveralls.io/github/playwright-community/playwright-go), this is helpful for finding functions that aren't covered by tests.
+For every Pull Request on GitHub and on the main branch the coverage data will get sent over to [Coveralls](https://coveralls.io/github/mxschmitt/playwright-go), this is helpful for finding functions that aren't covered by tests.
 
 ### Running tests
 

--- a/Dockerfile.example
+++ b/Dockerfile.example
@@ -11,7 +11,7 @@ COPY . /workdir
 WORKDIR /workdir
 # Install playwright cli with right version for later use
 RUN PWGO_VER=$(grep -oE "playwright-go v\S+" /workdir/go.mod | sed 's/playwright-go //g') \
-    && go install github.com/playwright-community/playwright-go/cmd/playwright@${PWGO_VER}
+    && go install github.com/mxschmitt/playwright-go/cmd/playwright@${PWGO_VER}
 # Build your app
 RUN GOOS=linux GOARCH=amd64 go build -o /bin/myapp
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # 🎭 [Playwright](https://github.com/microsoft/playwright#readme) for <img src="https://user-images.githubusercontent.com/17984549/91302719-343a1d80-e7a7-11ea-8d6a-9448ef598420.png" height="35" />
 
-## Looking for maintainers and see [here](https://github.com/playwright-community/playwright-go/issues/122). Thanks!
-
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/playwright-community/playwright-go)](https://pkg.go.dev/github.com/playwright-community/playwright-go)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/mxschmitt/playwright-go)](https://pkg.go.dev/github.com/mxschmitt/playwright-go)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](http://opensource.org/licenses/MIT)
-[![Go Report Card](https://goreportcard.com/badge/github.com/playwright-community/playwright-go)](https://goreportcard.com/report/github.com/playwright-community/playwright-go) ![Build Status](https://github.com/playwright-community/playwright-go/workflows/Go/badge.svg) [![Tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fflakiness.io%2Fapi%2Fbadge%3Finput%3D%257B%2522badgeToken%2522%253A%2522badge-6g4pNCL3d8qZbDdJEqFhSI%2522%257D)](https://flakiness.io/playwright-community/playwright-go)
-[![Join Discord](https://img.shields.io/badge/join-discord-informational)](https://aka.ms/playwright/discord) [![Coverage Status](https://coveralls.io/repos/github/playwright-community/playwright-go/badge.svg?branch=main)](https://coveralls.io/github/playwright-community/playwright-go?branch=main) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-149.0.7827.55-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-151.0-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> <!-- GEN:webkit-version-badge -->[![WebKit version](https://img.shields.io/badge/webkit-26.5-blue.svg?logo=safari)](https://webkit.org/)<!-- GEN:stop -->
+[![Go Report Card](https://goreportcard.com/badge/github.com/mxschmitt/playwright-go)](https://goreportcard.com/report/github.com/mxschmitt/playwright-go) ![Build Status](https://github.com/mxschmitt/playwright-go/workflows/Go/badge.svg) [![Tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fflakiness.io%2Fapi%2Fbadge%3Finput%3D%257B%2522badgeToken%2522%253A%2522badge-6g4pNCL3d8qZbDdJEqFhSI%2522%257D)](https://flakiness.io/playwright-community/playwright-go)
+[![Join Discord](https://img.shields.io/badge/join-discord-informational)](https://aka.ms/playwright/discord) [![Coverage Status](https://coveralls.io/repos/github/mxschmitt/playwright-go/badge.svg?branch=main)](https://coveralls.io/github/mxschmitt/playwright-go?branch=main) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-149.0.7827.55-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-151.0-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> <!-- GEN:webkit-version-badge -->[![WebKit version](https://img.shields.io/badge/webkit-26.5-blue.svg?logo=safari)](https://webkit.org/)<!-- GEN:stop -->
 
-[API reference](https://playwright.dev/docs/api/class-playwright) | [Example recipes](https://github.com/playwright-community/playwright-go/tree/main/examples)
+
+[API reference](https://playwright.dev/docs/api/class-playwright) | [Example recipes](https://github.com/mxschmitt/playwright-go/tree/main/examples)
 
 Playwright is a Go library to automate [Chromium](https://www.chromium.org/Home), [Firefox](https://www.mozilla.org/en-US/firefox/new/) and [WebKit](https://webkit.org/) with a single API. Playwright is built to enable cross-browser web automation that is **ever-green**, **capable**, **reliable** and **fast**.
 
@@ -22,15 +21,15 @@ Headless execution is supported for all the browsers on all platforms.
 ## Installation
 
 ```shell
-go get -u github.com/playwright-community/playwright-go
+go get -u github.com/mxschmitt/playwright-go
 ```
 
 Install the playwright driver and browsers (with OS dependencies if provide `--with-deps`). **Note** that you should replace the version number `0.xxxx.x` with the version used in your current `go.mod`. Each minor version upgrade requires a specific Playwright driver version.
 
 ```shell
-go run github.com/playwright-community/playwright-go/cmd/playwright@v0.xxxx.x install --with-deps
+go run github.com/mxschmitt/playwright-go/cmd/playwright@v0.xxxx.x install --with-deps
 # Or
-go install github.com/playwright-community/playwright-go/cmd/playwright@v0.xxxx.x
+go install github.com/mxschmitt/playwright-go/cmd/playwright@v0.xxxx.x
 playwright install --with-deps
 ```
 
@@ -63,7 +62,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 )
 
 func main() {
@@ -132,7 +131,7 @@ These patches are based on the original sources of the browsers and don't modify
 * [Playwright for Python](https://github.com/microsoft/playwright-python)
 * [Playwright for .NET](https://github.com/microsoft/playwright-dotnet)
 * [Playwright for Java](https://github.com/microsoft/playwright-java)
-* [Playwright for Go](https://github.com/playwright-community/playwright-go)
+* [Playwright for Go](https://github.com/mxschmitt/playwright-go)
 
 The bridge between Node.js and the other languages is basically a Node.js runtime combined with Playwright which gets shipped for each of these languages (around 50MB) and then communicates over stdio to send the relevant commands. This will also download the pre-compiled browsers.
 
@@ -142,6 +141,6 @@ We are ready for your feedback, but we are still covering Playwright Go with the
 
 ## Resources
 
-* [Playwright for Go Documentation](https://pkg.go.dev/github.com/playwright-community/playwright-go)
+* [Playwright for Go Documentation](https://pkg.go.dev/github.com/mxschmitt/playwright-go)
 * [Playwright Documentation](https://playwright.dev/docs/api/class-playwright)
-* [Example recipes](https://github.com/playwright-community/playwright-go/tree/main/examples)
+* [Example recipes](https://github.com/mxschmitt/playwright-go/tree/main/examples)

--- a/_config.yml
+++ b/_config.yml
@@ -4,9 +4,9 @@ description: >- # this means to ignore newlines until "baseurl:"
   Playwright is a Node.js library to automate Chromium, Firefox and WebKit with a single API.
   Playwright is built to enable cross-browser web automation that is ever-green, capable, reliable and fast.
 baseurl: "/playwright-go"
-url: "https://playwright-community.github.io/"
+url: "https://mxschmitt.github.io/"
 twitter_username: maxibanki
-github_username: playwright-community
+github_username: mxschmitt
 remote_theme: pages-themes/cayman@v0.2.0
 plugins:
   - jekyll-remote-theme

--- a/browser_context.go
+++ b/browser_context.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/playwright-community/playwright-go/internal/safe"
+	"github.com/mxschmitt/playwright-go/internal/safe"
 )
 
 type browserContextImpl struct {

--- a/cmd/playwright/main.go
+++ b/cmd/playwright/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 )
 
 func main() {

--- a/connection.go
+++ b/connection.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/go-stack/stack"
-	"github.com/playwright-community/playwright-go/internal/safe"
+	"github.com/mxschmitt/playwright-go/internal/safe"
 )
 
 var (

--- a/examples/download/main.go
+++ b/examples/download/main.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 )
 
 func assertErrorToNilf(message string, err error) {

--- a/examples/end-to-end-testing/main.go
+++ b/examples/end-to-end-testing/main.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"reflect"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 )
 
 func assertErrorToNilf(message string, err error) {

--- a/examples/javascript/main.go
+++ b/examples/javascript/main.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 )
 
 func main() {

--- a/examples/mobile-and-geolocation/main.go
+++ b/examples/mobile-and-geolocation/main.go
@@ -6,7 +6,7 @@ package main
 import (
 	"log"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 )
 
 func main() {

--- a/examples/network-monitoring/main.go
+++ b/examples/network-monitoring/main.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 )
 
 func main() {

--- a/examples/parallel-scraping/main.go
+++ b/examples/parallel-scraping/main.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 )
 
 func assertErrorToNilf(message string, err error) {

--- a/examples/pdf/main.go
+++ b/examples/pdf/main.go
@@ -6,7 +6,7 @@ package main
 import (
 	"log"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 )
 
 func assertErrorToNilf(message string, err error) {

--- a/examples/scraping/main.go
+++ b/examples/scraping/main.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 )
 
 func main() {

--- a/examples/screenshot/main.go
+++ b/examples/screenshot/main.go
@@ -6,7 +6,7 @@ package main
 import (
 	"log"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 )
 
 func main() {

--- a/examples/use-local-chrome/main.go
+++ b/examples/use-local-chrome/main.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 )
 
 func main() {

--- a/examples/video/main.go
+++ b/examples/video/main.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/playwright-community/playwright-go
+module github.com/mxschmitt/playwright-go
 
 go 1.22
 

--- a/page.go
+++ b/page.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/playwright-community/playwright-go/internal/safe"
+	"github.com/mxschmitt/playwright-go/internal/safe"
 )
 
 type pageImpl struct {

--- a/scripts/install-browsers/main.go
+++ b/scripts/install-browsers/main.go
@@ -6,7 +6,7 @@ package main
 import (
 	"log"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 )
 
 func main() {

--- a/scripts/update-readme-versions/main.go
+++ b/scripts/update-readme-versions/main.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 )
 
 func main() {

--- a/tests/binding_test.go
+++ b/tests/binding_test.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/browser_context_client_certificates_test.go
+++ b/tests/browser_context_client_certificates_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/browser_context_close_race_test.go
+++ b/tests/browser_context_close_race_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,7 +13,7 @@ import (
 // This reproduces a race condition where Close() writes to closeWasCalled while
 // route handler goroutines read it during page navigation.
 //
-// See: https://github.com/playwright-community/playwright-go/issues/566
+// See: https://github.com/mxschmitt/playwright-go/issues/566
 func TestBrowserContextCloseRace(t *testing.T) {
 	// Create a minimal HAR file
 	harContent := `{
@@ -111,7 +111,7 @@ func TestBrowserContextCloseRace(t *testing.T) {
 // writes pageImpl.closeWasCalled while the page's own route-handler goroutine reads
 // it during navigation. Without an atomic field this is detected by the -race flag.
 //
-// See: https://github.com/playwright-community/playwright-go/issues/566
+// See: https://github.com/mxschmitt/playwright-go/issues/566
 func TestPageCloseRace(t *testing.T) {
 	BeforeEach(t)
 

--- a/tests/browser_context_credentials_test.go
+++ b/tests/browser_context_credentials_test.go
@@ -3,7 +3,7 @@ package playwright_test
 import (
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/browser_context_storage_state_test.go
+++ b/tests/browser_context_storage_state_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/browser_type_test.go
+++ b/tests/browser_type_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/console_message_test.go
+++ b/tests/console_message_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/dialog_test.go
+++ b/tests/dialog_test.go
@@ -3,7 +3,7 @@ package playwright_test
 import (
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -4,7 +4,7 @@ package playwright_test
 import (
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/fetch_test.go
+++ b/tests/fetch_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/file_chooser_test.go
+++ b/tests/file_chooser_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/frame_locator_test.go
+++ b/tests/frame_locator_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 )
 
 func routeIframe(t *testing.T, page playwright.Page) {

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/har_test.go
+++ b/tests/har_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -12,8 +12,8 @@ import (
 
 	_ "image/png"
 
+	"github.com/mxschmitt/playwright-go"
 	"github.com/orisano/pixelmatch"
-	"github.com/playwright-community/playwright-go"
 )
 
 // global variables, can be used in any tests

--- a/tests/input_test.go
+++ b/tests/input_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/js_handle_test.go
+++ b/tests/js_handle_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -98,7 +98,7 @@ func TestJSHandleEvaluateHandleReturningElement(t *testing.T) {
 
 	// EvaluateHandle may return an ElementHandle (e.g. element.parentElement).
 	// It must not panic when the underlying handle is an ElementHandle.
-	// See https://github.com/playwright-community/playwright-go/issues/332
+	// See https://github.com/mxschmitt/playwright-go/issues/332
 	parent, err := inner.EvaluateHandle("element => element.parentElement")
 	require.NoError(t, err)
 	require.NotNil(t, parent.AsElement())

--- a/tests/locator_assertions_test.go
+++ b/tests/locator_assertions_test.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/locator_get_by_test.go
+++ b/tests/locator_get_by_test.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/network_test.go
+++ b/tests/network_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/page_add_locator_handler_test.go
+++ b/tests/page_add_locator_handler_test.go
@@ -5,7 +5,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/page_aria_snapshot_test.go
+++ b/tests/page_aria_snapshot_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/page_assertions_test.go
+++ b/tests/page_assertions_test.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/page_clock_test.go
+++ b/tests/page_clock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/h2non/filetype"
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1200,7 +1200,7 @@ func TestPageExpectResponse(t *testing.T) {
 		require.ErrorContains(t, err, "Timeout 1000.00ms exceeded.")
 	})
 
-	// Regression test for https://github.com/playwright-community/playwright-go/issues/323:
+	// Regression test for https://github.com/mxschmitt/playwright-go/issues/323:
 	// waiting for several responses concurrently (the Go equivalent of
 	// Promise.all) must resolve every waiter. Previously, once one waiter
 	// completed it unsubscribed all the others, so the rest timed out.

--- a/tests/page_web_storage_test.go
+++ b/tests/page_web_storage_test.go
@@ -3,7 +3,7 @@ package playwright_test
 import (
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/remote_server_test.go
+++ b/tests/remote_server_test.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 )
 
 type remoteServer struct {

--- a/tests/route_test.go
+++ b/tests/route_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -397,7 +397,7 @@ func TestResponseServerAddrReturnNilForFulfilledRoute(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, response.Finished())
 	// A fulfilled route has no real server, so Playwright returns null for the
-	// server address. This must not panic (https://github.com/playwright-community/playwright-go/issues/543).
+	// server address. This must not panic (https://github.com/mxschmitt/playwright-go/issues/543).
 	serverAddr, err := response.ServerAddr()
 	require.NoError(t, err)
 	require.Nil(t, serverAddr)

--- a/tests/route_web_socket_test.go
+++ b/tests/route_web_socket_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/screencast_test.go
+++ b/tests/screencast_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/screenshot_test.go
+++ b/tests/screenshot_test.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/selectors_get_by_test.go
+++ b/tests/selectors_get_by_test.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/selectors_test.go
+++ b/tests/selectors_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/selectors_text_test.go
+++ b/tests/selectors_text_test.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/tracing_test.go
+++ b/tests/tracing_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/unroute_behavior_test.go
+++ b/tests/unroute_behavior_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/utils_test.go
+++ b/tests/utils_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/coder/websocket"
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/video_test.go
+++ b/tests/video_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/h2non/filetype"
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -216,7 +216,7 @@ func TestVideo(t *testing.T) {
 }
 
 func TestVideoRelativeDirShouldResolveToAbsolute(t *testing.T) {
-	// Regression test for https://github.com/playwright-community/playwright-go/issues/565
+	// Regression test for https://github.com/mxschmitt/playwright-go/issues/565
 	// A relative recordVideo.dir must be resolved to an absolute path client-side
 	// (matching upstream path.resolve), so Video().Path() does not depend on the
 	// process working directory at the time it is read.

--- a/tests/websocket_test.go
+++ b/tests/websocket_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/worker_test.go
+++ b/tests/worker_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
## Motivation

The [`playwright-community`](https://github.com/playwright-community) GitHub organization is archived and no longer active. This repository has moved to **github.com/mxschmitt/playwright-go**, where it will continue to be maintained.

This PR rewrites all references to the old owner so the codebase matches its new home.

## Changes

- **Go module rename** — `go.mod` and every internal import updated from `github.com/playwright-community/playwright-go` → `github.com/mxschmitt/playwright-go` (`go.mod`, `page.go`, `browser_context.go`, `connection.go`, `cmd/`, `scripts/`, all `examples/` and `tests/`).
- **README** — badges (PkgGoDev, Go Report Card, build status, flakiness.io, Coveralls), install/import instructions, and example-recipe links. Also removed the now-obsolete *"Looking for maintainers"* note.
- **CONTRIBUTING** — Coveralls URL.
- **CI** (`.github/workflows/build.yml`) — `-coverpkg`. `FLAKINESS_PROJECT` is intentionally left as `playwright-community/playwright-go` for now.
- **Issue template** — Discussions link and import example.
- **Jekyll** (`_config.yml`) — Pages `url` and `github_username`.

## Compatibility

GitHub's automatic redirect keeps existing `go get github.com/playwright-community/playwright-go` resolving, so **current users are not immediately broken**. New code should import `github.com/mxschmitt/playwright-go`.

## Follow-up (post-merge)

External service projects need to be re-provisioned under the `mxschmitt` owner or their badges will 404:
- Coveralls repo link
- GitHub Pages site (`https://mxschmitt.github.io/playwright-go/`)
- flakiness.io project (left on the old name in this PR)

## Verification

- `go build ./...`, `go vet ./...`, `go mod verify` → all clean
- Confirmed the `connection.go` source-path regex and the `ms-playwright-go` cache-dir name were left untouched (those reference the repo name, not the owner).
