### PR TITLE
ci: re-run flaky tests via gotestsum while surfacing them on flakiness.io

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,21 +62,63 @@ jobs:
     - run: |
         go install ./...
         go install github.com/mxschmitt/flakiness-go/cmd/flakiness-go@latest
+        go install gotest.tools/gotestsum@latest
         playwright install --with-deps ${{ matrix.browser }}
+    # We run the suite through gotestsum so that flaky tests (browser-side
+    # timing races that upstream microsoft/playwright absorbs with `retries: 3`)
+    # are re-run instead of failing the whole job. gotestsum re-runs ONLY the
+    # failed tests, exits 0 if each passes within the attempt budget, and
+    # writes every attempt to --jsonfile. We then pipe that json into
+    # `flakiness-go --stdin`, which records each attempt as a distinct
+    # RunAttempt — so a fail-then-pass is uploaded to flakiness.io as *flaky*
+    # (visible), not hidden. A test that fails every attempt still fails the
+    # job (gotestsum exits non-zero), and --rerun-fails-max-failures aborts the
+    # rerun if a broad breakage produces too many failures to be "flaky".
+    #
+    # Exit handling: `flakiness-go --stdin` always exits 0 (it is a reporter),
+    # so the pass/fail gate is gotestsum's exit code, captured below. We always
+    # run the reporter — even on a hard failure — so the failure is uploaded.
+    #
+    # Coverage caveat: when a rerun happens, `go test` overwrites covprofile
+    # with only the re-run test's coverage. Reruns are rare (only on a flake)
+    # and coverage upload is best-effort (continue-on-error, stable only), so we
+    # accept the occasional degraded number rather than running the suite twice.
     - name: Test
+      shell: bash
       env:
         BROWSER: ${{ matrix.browser }}
         FLAKINESS_PROJECT: playwright-community/playwright-go
         FLAKINESS_NAME: ${{ matrix.browser }}
       if: matrix.os == 'ubuntu-latest'
-      run: xvfb-run flakiness-go -timeout 15m -v -coverprofile=covprofile -coverpkg="github.com/mxschmitt/playwright-go" --race ./...
+      run: |
+        ec=0
+        xvfb-run gotestsum \
+          --format standard-verbose \
+          --rerun-fails=2 \
+          --rerun-fails-max-failures=15 \
+          --packages=./... \
+          --jsonfile=gotest-report.json \
+          -- -timeout=15m -coverprofile=covprofile -coverpkg="github.com/mxschmitt/playwright-go" --race || ec=$?
+        flakiness-go --stdin < gotest-report.json || true
+        exit $ec
     - name: Test
+      shell: bash
       env:
         BROWSER: ${{ matrix.browser }}
         FLAKINESS_PROJECT: playwright-community/playwright-go
         FLAKINESS_NAME: ${{ matrix.browser }}
       if: matrix.os != 'ubuntu-latest'
-      run: flakiness-go -timeout 15m -v -coverprofile=covprofile -coverpkg="github.com/mxschmitt/playwright-go" --race ./...
+      run: |
+        ec=0
+        gotestsum \
+          --format standard-verbose \
+          --rerun-fails=2 \
+          --rerun-fails-max-failures=15 \
+          --packages=./... \
+          --jsonfile=gotest-report.json \
+          -- -timeout=15m -coverprofile=covprofile -coverpkg="github.com/mxschmitt/playwright-go" --race || ec=$?
+        flakiness-go --stdin < gotest-report.json || true
+        exit $ec
     - name: Send coverage
       uses: shogo82148/actions-goveralls@v1
       if: matrix.go == 'stable'


### PR DESCRIPTION
## Problem

Our CI runs each (browser × OS × go) matrix cell once with no retry. Browser-side timing flakes — e.g. `TestPageSetViewport` on firefox/macOS (default 1280×720 transiently reports `innerHeight=683` due to first-paint/window-chrome timing) and `TestBrowserContextClearCookies/should remove cookies by name and domain` on webkit/linux (cross-process `document.cookie` view lags the cleared cookie) — fail an entire job even though the tests are correct.

These are faithful 1:1 ports of upstream specs. Upstream microsoft/playwright keeps them green via [`retries: process.env.CI ? 3 : 0`](https://github.com/microsoft/playwright/blob/main/tests/library/playwright.config.ts) and a reporter that records each attempt, so a fail-then-pass shows up as **flaky** (visible), not hidden. We had neither retry nor that surfacing.

## What this does

Runs the suite through [`gotestsum --rerun-fails`](https://github.com/gotestyourself/gotestsum) instead of invoking `flakiness-go` directly:

```bash
gotestsum --rerun-fails=2 --rerun-fails-max-failures=15 \
  --packages=./... --jsonfile=gotest-report.json \
  -- -timeout=15m -coverprofile=covprofile -coverpkg=… --race
flakiness-go --stdin < gotest-report.json
```

- gotestsum re-runs **only the failed tests** (up to 2 attempts), exits `0` if each passes within budget, and writes **every attempt** to `--jsonfile`.
- `flakiness-go --stdin` consumes that stream and records each attempt as a distinct `RunAttempt`, so **fail-then-pass is uploaded to flakiness.io as _flaky_** — the opposite of an in-process retry helper, which would emit a single passing attempt and hide the flake.
- A test that fails **every** attempt still fails the job. `--rerun-fails-max-failures=15` aborts the rerun on a broad breakage that isn't "flaky".

## Why not just wrap tests in a retry helper?

An in-process retry (rerun inside the test body) makes `go test -json` emit a single `pass`, so flakiness.io only ever sees one attempt and the "≥2 mixed attempts" flaky criterion is never met — the flake goes permanently invisible. This approach keeps CI green on transients **and** keeps the flake visible, matching upstream's semantics. The existing `withRetry` helper stays reserved for genuinely-slow-but-correct tests (its sole use, `TestShouldUploadAFolderRemote`).

## Verification (done locally, end-to-end)

gotestsum v1.13.0 + flakiness-go `main`, against a fixture that fails once then passes:

| Check | Result |
|---|---|
| gotestsum reruns only the failed test | ✅ |
| Both attempts in one `--jsonfile` stream | ✅ `run,output,fail,run,output,pass` |
| gotestsum exit, fail-then-pass | ✅ **0** (CI green) |
| gotestsum exit, fails-every-attempt | ✅ **1** (real regression fails) |
| flakiness-go `--stdin` → flaky classification | ✅ 2 attempts `[failed, passed]` |

## Implementation notes / caveats

- **Exit gate:** `flakiness-go --stdin` always exits `0` (it's a reporter), so the pass/fail gate is gotestsum's exit code, captured as `ec` and re-raised after the reporter runs (the reporter runs even on hard failure, so failures still upload).
- **Coverage on rerun:** when a rerun happens, `go test -coverprofile` is overwritten with only the reran test's coverage. Reruns are rare (only on a flake) and coverage upload is already best-effort (`continue-on-error`, stable-only), so we accept the occasional degraded number rather than doubling suite time. Documented inline.

## Related

Investigation + the `flakiness-go`-side discussion (incl. why a native `--rerun-failed` is now optional): mxschmitt/flakiness-go#2.

## Follow-up (not in this PR)

Optional targeted hardening of the two specific tests (bounded poll in `VerifyViewport`; poll-until-expected in `expectPageCookies`) so they're deterministic even without a rerun. Left out to keep this PR focused on the CI mechanism; happy to add if preferred.