### PR TITLE
fix: guard pageImpl.frames to prevent data race

### DIFF
--- a/page.go
+++ b/page.go
@@ -209,7 +209,11 @@ func (p *pageImpl) Frame(options ...PageFrameOptions) Frame {
 		matcher = newURLMatcher(option.URL, p.browserContext.options.BaseURL)
 	}
 
-	for _, f := range p.frames {
+	p.RLock()
+	framesSnapshot := make([]Frame, len(p.frames))
+	copy(framesSnapshot, p.frames)
+	p.RUnlock()
+	for _, f := range framesSnapshot {
 		// When a name is specified, match strictly by name and never consult the
 		// URL, matching upstream.
 		if option.Name != nil {
@@ -227,7 +231,11 @@ func (p *pageImpl) Frame(options ...PageFrameOptions) Frame {
 }
 
 func (p *pageImpl) Frames() []Frame {
-	return p.frames
+	p.RLock()
+	defer p.RUnlock()
+	frames := make([]Frame, len(p.frames))
+	copy(frames, p.frames)
+	return frames
 }
 
 func (p *pageImpl) SetDefaultNavigationTimeout(timeout float64) {
@@ -1044,13 +1052,16 @@ func (p *pageImpl) onBinding(binding *bindingCallImpl) {
 
 func (p *pageImpl) onFrameAttached(frame *frameImpl) {
 	frame.page = p
+	p.Lock()
 	p.frames = append(p.frames, frame)
+	p.Unlock()
 	p.Emit("frameattached", frame)
 	p.browserContext.Emit("frameattached", frame)
 }
 
 func (p *pageImpl) onFrameDetached(frame *frameImpl) {
 	frame.detached = true
+	p.Lock()
 	frames := make([]Frame, 0)
 	for i := 0; i < len(p.frames); i++ {
 		if p.frames[i] != frame {
@@ -1060,6 +1071,7 @@ func (p *pageImpl) onFrameDetached(frame *frameImpl) {
 	if len(frames) != len(p.frames) {
 		p.frames = frames
 	}
+	p.Unlock()
 	// Remove the frame from its parent's childFrames so ChildFrames() doesn't
 	// keep returning a detached ghost frame (matches upstream).
 	if frame.parentFrame != nil {

--- a/tests/page_frames_race_test.go
+++ b/tests/page_frames_race_test.go
@@ -1,0 +1,48 @@
+package playwright_test
+
+import (
+	"testing"
+)
+
+// TestPageFramesRace reproduces a data race between Page.Frames()/Page.Frame()
+// (called from a user goroutine) and onFrameAttached/onFrameDetached (called
+// from the connection dispatch goroutine as iframes are added/removed).
+//
+// Before the fix this fails under `go test -race` with multiple
+// "WARNING: DATA RACE" reports on pageImpl.frames; there are no assertions
+// here beyond that because the race detector itself is the check.
+func TestPageFramesRace(t *testing.T) {
+	BeforeEach(t)
+
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				for _, f := range page.Frames() {
+					_ = f.URL()
+				}
+				_ = page.Frame()
+			}
+		}
+	}()
+
+	for i := 0; i < 200; i++ {
+		_, err := page.Evaluate(`() => {
+			const f = document.createElement('iframe');
+			f.src = 'about:blank';
+			document.body.appendChild(f);
+			f.remove();
+		}`)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	close(done)
+	<-stopped
+}


### PR DESCRIPTION
 ## What changed

  This fixes a data race involving `pageImpl.frames`.

  The frames slice is updated by the connection event handler when iframes are attached or detached, while user code can read it through `Page.Frames()` and `Page.Frame()` at the same time.

  This PR:

  - protects `pageImpl.frames` with the existing `channelOwner` RWMutex;
  - returns a copy of the frames slice from `Page.Frames()`;
  - makes `Page.Frame()` iterate over a protected snapshot;
  - keeps event emission outside the lock to avoid deadlocks when event handlers call Page methods.

  ## Testing

  - Added `tests/page_frames_race_test.go`
  - `go build ./...`
  - `gofumpt -w page.go tests/page_frames_race_test.go`
  - `golangci-lint run`
  - `BROWSER=chromium HEADLESS=1 go test -v --race ./...`

 All checks passed locally, including the full test suite with the race detector.