### PR TITLE
[codex] fix page frames data race

### DIFF
--- a/page.go
+++ b/page.go
@@ -23,6 +23,7 @@ type pageImpl struct {
 	touchscreen     *touchscreenImpl
 	timeoutSettings *timeoutSettings
 	browserContext  *browserContextImpl
+	framesMu        sync.RWMutex
 	frames          []Frame
 	workers         []Worker
 	mainFrame       Frame
@@ -209,7 +210,7 @@ func (p *pageImpl) Frame(options ...PageFrameOptions) Frame {
 		matcher = newURLMatcher(option.URL, p.browserContext.options.BaseURL)
 	}
 
-	for _, f := range p.frames {
+	for _, f := range p.Frames() {
 		// When a name is specified, match strictly by name and never consult the
 		// URL, matching upstream.
 		if option.Name != nil {
@@ -227,7 +228,9 @@ func (p *pageImpl) Frame(options ...PageFrameOptions) Frame {
 }
 
 func (p *pageImpl) Frames() []Frame {
-	return p.frames
+	p.framesMu.RLock()
+	defer p.framesMu.RUnlock()
+	return slices.Clone(p.frames)
 }
 
 func (p *pageImpl) SetDefaultNavigationTimeout(timeout float64) {
@@ -1044,13 +1047,16 @@ func (p *pageImpl) onBinding(binding *bindingCallImpl) {
 
 func (p *pageImpl) onFrameAttached(frame *frameImpl) {
 	frame.page = p
+	p.framesMu.Lock()
 	p.frames = append(p.frames, frame)
+	p.framesMu.Unlock()
 	p.Emit("frameattached", frame)
 	p.browserContext.Emit("frameattached", frame)
 }
 
 func (p *pageImpl) onFrameDetached(frame *frameImpl) {
 	frame.detached = true
+	p.framesMu.Lock()
 	frames := make([]Frame, 0)
 	for i := 0; i < len(p.frames); i++ {
 		if p.frames[i] != frame {
@@ -1060,6 +1066,7 @@ func (p *pageImpl) onFrameDetached(frame *frameImpl) {
 	if len(frames) != len(p.frames) {
 		p.frames = frames
 	}
+	p.framesMu.Unlock()
 	// Remove the frame from its parent's childFrames so ChildFrames() doesn't
 	// keep returning a detached ghost frame (matches upstream).
 	if frame.parentFrame != nil {

--- a/tests/page_frames_race_test.go
+++ b/tests/page_frames_race_test.go
@@ -1,0 +1,42 @@
+package playwright_test
+
+import "testing"
+
+// TestPageFramesRace reproduces a data race between Page.Frames()/Page.Frame()
+// and frame attach/detach events. The race detector is the assertion.
+func TestPageFramesRace(t *testing.T) {
+	BeforeEach(t)
+
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				for _, frame := range page.Frames() {
+					_ = frame.URL()
+				}
+				_ = page.Frame()
+			}
+		}
+	}()
+	defer func() {
+		close(done)
+		<-stopped
+	}()
+
+	for i := 0; i < 200; i++ {
+		_, err := page.Evaluate(`() => {
+			const frame = document.createElement('iframe');
+			frame.src = 'about:blank';
+			document.body.appendChild(frame);
+			frame.remove();
+		}`)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## What changed

- protect `pageImpl.frames` with a dedicated `framesMu`
- return a cloned frame snapshot from `Page.Frames()`
- make `Page.Frame()` search the same protected snapshot
- keep frame event emission outside the lock
- add a race-detector regression test that attaches and removes iframes while reading the page frame list

## Why

Frame attach and detach events mutate `pageImpl.frames` on the connection dispatch goroutine while user goroutines can call `Page.Frames()` and `Page.Frame()`. This causes concurrent slice reads and writes.

A dedicated mutex is used instead of the embedded `channelOwner` mutex. The latter also protects routing state and can be held across protocol calls; making frame event dispatch acquire it could block the sole protocol dispatcher while another goroutine waits for a reply.

## Impact

Concurrent frame-list reads no longer race with frame lifecycle events. Returning a clone also prevents callers from retaining the internal slice backing array.

## Validation

- reproduced multiple race reports on the unpatched base
- `go test -race ./tests -run '^TestPageFramesRace$' -count=10 -v`
- full Chromium browser integration package passed
- `gofumpt -w page.go tests/page_frames_race_test.go`
- `git diff --check`

closes https://github.com/mxschmitt/playwright-go/pull/625
